### PR TITLE
Notes: compact list cards + deep-linkable detail modal (#394)

### DIFF
--- a/frontend/src/pages/BookPage/Notes/NoteCard.tsx
+++ b/frontend/src/pages/BookPage/Notes/NoteCard.tsx
@@ -1,5 +1,7 @@
 import type { NoteWithLinks } from '@/api/generated/model';
-import { Box, Chip, Stack, styled, Typography } from '@mui/material';
+import { markdownStyles } from '@/theme/theme';
+import { Box, Chip, Stack, styled, Typography, useTheme } from '@mui/material';
+import ReactMarkdown from 'react-markdown';
 
 import { NOTE_KIND_LABELS, type NoteKindValue } from './noteKinds';
 
@@ -25,9 +27,7 @@ const NoteStyled = styled(Box)(({ theme }) => ({
 }));
 
 export const NoteCard = ({ note, onClick }: NoteCardProps) => {
-  const chapters = note.chapters ?? [];
-  const highlightTags = note.highlight_tags ?? [];
-  const highlights = note.highlights ?? [];
+  const theme = useTheme();
 
   return (
     <NoteStyled
@@ -46,35 +46,17 @@ export const NoteCard = ({ note, onClick }: NoteCardProps) => {
         {note.kind && <Chip size="small" label={NOTE_KIND_LABELS[note.kind as NoteKindValue]} />}
       </Stack>
       {note.body && (
-        <Typography
-          variant="body2"
-          color="text.secondary"
+        <Box
           sx={{
+            ...markdownStyles(theme),
             display: '-webkit-box',
             WebkitLineClamp: 3,
             WebkitBoxOrient: 'vertical',
             overflow: 'hidden',
           }}
         >
-          {note.body}
-        </Typography>
-      )}
-      {(chapters.length > 0 || highlightTags.length > 0 || highlights.length > 0) && (
-        <Stack direction="row" spacing={1} sx={{ mt: 1, flexWrap: 'wrap', gap: 0.5 }}>
-          {chapters.map((chapter) => (
-            <Chip key={`ch-${chapter.id}`} size="small" variant="outlined" label={chapter.name} />
-          ))}
-          {highlightTags.map((tag) => (
-            <Chip key={`tag-${tag.id}`} size="small" variant="outlined" label={`#${tag.name}`} />
-          ))}
-          {highlights.length > 0 && (
-            <Chip
-              size="small"
-              variant="outlined"
-              label={`${highlights.length} highlight${highlights.length === 1 ? '' : 's'}`}
-            />
-          )}
-        </Stack>
+          <ReactMarkdown>{note.body}</ReactMarkdown>
+        </Box>
       )}
     </NoteStyled>
   );

--- a/frontend/src/pages/BookPage/Notes/NoteCard.tsx
+++ b/frontend/src/pages/BookPage/Notes/NoteCard.tsx
@@ -1,95 +1,81 @@
 import type { NoteWithLinks } from '@/api/generated/model';
-import { IconButtonWithTooltip } from '@/components/buttons/IconButtonWithTooltip.tsx';
-import { DeleteIcon, EditIcon } from '@/theme/Icons.tsx';
-import { markdownStyles } from '@/theme/theme';
-import { Box, Chip, Stack, styled, Typography, useTheme } from '@mui/material';
-import ReactMarkdown from 'react-markdown';
+import { Box, Chip, Stack, styled, Typography } from '@mui/material';
 
 import { NOTE_KIND_LABELS, type NoteKindValue } from './noteKinds';
 
 interface NoteCardProps {
   note: NoteWithLinks;
-  onEdit: () => void;
-  onDelete: () => void;
+  onClick: () => void;
 }
 
 const NoteStyled = styled(Box)(({ theme }) => ({
-  position: 'relative',
   borderLeft: `3px solid ${theme.palette.primary.main}`,
   paddingLeft: theme.spacing(2),
   paddingTop: theme.spacing(2),
   paddingBottom: theme.spacing(2),
+  cursor: 'pointer',
   transition: 'background-color 0.15s ease',
   '&:hover': {
     backgroundColor: theme.palette.action.hover,
   },
-}));
-
-const ActionButtonsStyled = styled(Box)(({ theme }) => ({
-  position: 'absolute',
-  top: theme.spacing(2),
-  right: 0,
-  display: 'flex',
-  gap: 0.5,
-  zIndex: 1,
-  opacity: 0.7,
-  transition: 'opacity 0.2s ease',
-  '&:hover': {
-    opacity: 1,
+  '&:focus-visible': {
+    outline: `2px solid ${theme.palette.primary.main}`,
+    outlineOffset: 2,
   },
 }));
 
-export const NoteCard = ({ note, onEdit, onDelete }: NoteCardProps) => {
-  const theme = useTheme();
-
+export const NoteCard = ({ note, onClick }: NoteCardProps) => {
   const chapters = note.chapters ?? [];
   const highlightTags = note.highlight_tags ?? [];
   const highlights = note.highlights ?? [];
 
   return (
-    <NoteStyled>
-      <Box sx={{ pr: 8 }}>
-        <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 0.5 }}>
-          <Typography variant="h3">{note.title}</Typography>
-          {note.kind && <Chip size="small" label={NOTE_KIND_LABELS[note.kind as NoteKindValue]} />}
+    <NoteStyled
+      role="button"
+      tabIndex={0}
+      onClick={onClick}
+      onKeyDown={(event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          onClick();
+        }
+      }}
+    >
+      <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 0.5 }}>
+        <Typography variant="h3">{note.title}</Typography>
+        {note.kind && <Chip size="small" label={NOTE_KIND_LABELS[note.kind as NoteKindValue]} />}
+      </Stack>
+      {note.body && (
+        <Typography
+          variant="body2"
+          color="text.secondary"
+          sx={{
+            display: '-webkit-box',
+            WebkitLineClamp: 3,
+            WebkitBoxOrient: 'vertical',
+            overflow: 'hidden',
+          }}
+        >
+          {note.body}
+        </Typography>
+      )}
+      {(chapters.length > 0 || highlightTags.length > 0 || highlights.length > 0) && (
+        <Stack direction="row" spacing={1} sx={{ mt: 1, flexWrap: 'wrap', gap: 0.5 }}>
+          {chapters.map((chapter) => (
+            <Chip key={`ch-${chapter.id}`} size="small" variant="outlined" label={chapter.name} />
+          ))}
+          {highlightTags.map((tag) => (
+            <Chip key={`tag-${tag.id}`} size="small" variant="outlined" label={`#${tag.name}`} />
+          ))}
+          {highlights.length > 0 && (
+            <Chip
+              size="small"
+              variant="outlined"
+              label={`${highlights.length} highlight${highlights.length === 1 ? '' : 's'}`}
+            />
+          )}
         </Stack>
-        {note.body && (
-          <Box sx={markdownStyles(theme)}>
-            <ReactMarkdown>{note.body}</ReactMarkdown>
-          </Box>
-        )}
-        {(chapters.length > 0 || highlightTags.length > 0 || highlights.length > 0) && (
-          <Stack direction="row" spacing={1} sx={{ mt: 1, flexWrap: 'wrap', gap: 0.5 }}>
-            {chapters.map((chapter) => (
-              <Chip key={`ch-${chapter.id}`} size="small" variant="outlined" label={chapter.name} />
-            ))}
-            {highlightTags.map((tag) => (
-              <Chip key={`tag-${tag.id}`} size="small" variant="outlined" label={`#${tag.name}`} />
-            ))}
-            {highlights.length > 0 && (
-              <Chip
-                size="small"
-                variant="outlined"
-                label={`${highlights.length} highlight${highlights.length === 1 ? '' : 's'}`}
-              />
-            )}
-          </Stack>
-        )}
-      </Box>
-      <ActionButtonsStyled>
-        <IconButtonWithTooltip
-          title="Edit note"
-          ariaLabel="Edit note"
-          onClick={onEdit}
-          icon={<EditIcon />}
-        />
-        <IconButtonWithTooltip
-          title="Delete note"
-          ariaLabel="Delete note"
-          onClick={onDelete}
-          icon={<DeleteIcon />}
-        />
-      </ActionButtonsStyled>
+      )}
     </NoteStyled>
   );
 };

--- a/frontend/src/pages/BookPage/Notes/NoteEditorDialog.tsx
+++ b/frontend/src/pages/BookPage/Notes/NoteEditorDialog.tsx
@@ -1,20 +1,9 @@
-import type { HighlightTagInBook, NoteWithLinks } from '@/api/generated/model';
-import {
-  getGetNotesForBookApiV1BooksBookIdNotesGetQueryKey,
-  useCreateNoteApiV1NotesPost,
-  useUpdateNoteApiV1NotesNoteIdPut,
-} from '@/api/generated/notes/notes.ts';
+import type { NoteWithLinks } from '@/api/generated/model';
 import { CommonDialog } from '@/components/dialogs/CommonDialog.tsx';
-import { useSnackbar } from '@/context/SnackbarContext.tsx';
-import { useBookPage } from '@/pages/BookPage/BookPageContext';
-import { HighlightTagInput } from '@/pages/BookPage/Highlights/HighlightViewModal/components/HighlightTagInput.tsx';
-import { Autocomplete, Box, Button, MenuItem, TextField } from '@mui/material';
-import { useQueryClient } from '@tanstack/react-query';
-import { useEffect } from 'react';
-import { Controller, useForm } from 'react-hook-form';
+import { Box, Button } from '@mui/material';
+import { useRef, useState } from 'react';
 
-import { useNoteTagField } from './hooks/useNoteTagField';
-import { NOTE_KIND_LABELS, NOTE_KINDS, type NoteKindValue } from './noteKinds';
+import { NoteEditorForm, type NoteEditorFormHandle } from './NoteEditorForm';
 
 interface NoteEditorDialogProps {
   open: boolean;
@@ -26,21 +15,6 @@ interface NoteEditorDialogProps {
   initialBody?: string;
 }
 
-interface ChapterOption {
-  id: number;
-  name: string;
-}
-
-interface NoteFormValues {
-  title: string;
-  body: string;
-  kind: NoteKindValue | '';
-  chapters: ChapterOption[];
-  tags: HighlightTagInBook[];
-}
-
-const EMPTY_FORM: NoteFormValues = { title: '', body: '', kind: '', chapters: [], tags: [] };
-
 export const NoteEditorDialog = ({
   open,
   onClose,
@@ -49,90 +23,8 @@ export const NoteEditorDialog = ({
   initialHighlightIds,
   initialBody,
 }: NoteEditorDialogProps) => {
-  const { book } = useBookPage();
-  const { showSnackbar } = useSnackbar();
-  const queryClient = useQueryClient();
-
-  const chapterOptions: ChapterOption[] = book.chapters.map((chapter) => ({
-    id: chapter.id,
-    name: chapter.name,
-  }));
-
-  const { control, handleSubmit, reset, watch } = useForm<NoteFormValues>({
-    defaultValues: EMPTY_FORM,
-  });
-
-  useEffect(() => {
-    if (!open) return;
-    if (note) {
-      reset({
-        title: note.title,
-        body: note.body,
-        kind: (note.kind as NoteKindValue | null) ?? '',
-        chapters: chapterOptions.filter((option) => note.chapter_ids.includes(option.id)),
-        tags: book.highlight_tags.filter((tag) => note.highlight_tag_ids.includes(tag.id)),
-      });
-    } else {
-      reset({
-        ...EMPTY_FORM,
-        body: initialBody ?? '',
-        chapters: chapterOptions.filter((option) => (initialChapterIds ?? []).includes(option.id)),
-      });
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open, note]);
-
-  const invalidateNotes = () => {
-    void queryClient.invalidateQueries({
-      queryKey: getGetNotesForBookApiV1BooksBookIdNotesGetQueryKey(book.id),
-    });
-  };
-
-  const { resolveTags, isCreating: isCreatingTag } = useNoteTagField(book.id);
-
-  const createMutation = useCreateNoteApiV1NotesPost({
-    mutation: {
-      onSuccess: () => {
-        invalidateNotes();
-        onClose();
-      },
-      onError: (error) => {
-        console.error('Failed to create note:', error);
-        showSnackbar('Failed to create note. Please try again.', 'error');
-      },
-    },
-  });
-  const updateMutation = useUpdateNoteApiV1NotesNoteIdPut({
-    mutation: {
-      onSuccess: () => {
-        invalidateNotes();
-        onClose();
-      },
-      onError: (error) => {
-        console.error('Failed to update note:', error);
-        showSnackbar('Failed to update note. Please try again.', 'error');
-      },
-    },
-  });
-
-  const isSaving = createMutation.isPending || updateMutation.isPending;
-  const canSave = watch('title').trim().length > 0 && !isSaving;
-
-  const onSubmit = async (values: NoteFormValues) => {
-    const payload = {
-      title: values.title.trim(),
-      body: values.body,
-      kind: values.kind === '' ? null : values.kind,
-      chapter_ids: values.chapters.map((option) => option.id),
-      highlight_ids: note?.highlight_ids ?? initialHighlightIds ?? [],
-      highlight_tag_ids: values.tags.map((tag) => tag.id),
-    };
-    if (note) {
-      await updateMutation.mutateAsync({ noteId: note.id, data: payload });
-    } else {
-      await createMutation.mutateAsync({ data: { ...payload, book_id: book.id } });
-    }
-  };
+  const formRef = useRef<NoteEditorFormHandle>(null);
+  const [status, setStatus] = useState({ isSaving: false, canSave: false });
 
   return (
     <CommonDialog
@@ -140,75 +32,32 @@ export const NoteEditorDialog = ({
       onClose={onClose}
       title={note ? 'Edit Note' : 'New Note'}
       maxWidth="md"
-      isLoading={isSaving}
+      isLoading={status.isSaving}
       footerActions={
         <Box sx={{ display: 'flex', gap: 1, width: '100%', justifyContent: 'flex-end' }}>
-          <Button onClick={onClose} disabled={isSaving}>
+          <Button onClick={onClose} disabled={status.isSaving}>
             Cancel
           </Button>
-          <Button variant="contained" onClick={handleSubmit(onSubmit)} disabled={!canSave}>
-            {isSaving ? 'Saving...' : 'Save'}
+          <Button
+            variant="contained"
+            onClick={() => formRef.current?.submit()}
+            disabled={!status.canSave}
+          >
+            {status.isSaving ? 'Saving...' : 'Save'}
           </Button>
         </Box>
       }
     >
-      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, pt: 1 }}>
-        <Controller
-          name="title"
-          control={control}
-          render={({ field }) => <TextField {...field} label="Title" fullWidth autoFocus />}
-        />
-        <Controller
-          name="kind"
-          control={control}
-          render={({ field }) => (
-            <TextField {...field} select label="Kind" fullWidth>
-              <MenuItem value="">None</MenuItem>
-              {NOTE_KINDS.map((value) => (
-                <MenuItem key={value} value={value}>
-                  {NOTE_KIND_LABELS[value]}
-                </MenuItem>
-              ))}
-            </TextField>
-          )}
-        />
-        <Controller
-          name="body"
-          control={control}
-          render={({ field }) => (
-            <TextField {...field} label="Note (markdown)" fullWidth multiline minRows={5} />
-          )}
-        />
-        <Controller
-          name="chapters"
-          control={control}
-          render={({ field }) => (
-            <Autocomplete
-              multiple
-              options={chapterOptions}
-              getOptionLabel={(option) => option.name}
-              isOptionEqualToValue={(option, value) => option.id === value.id}
-              value={field.value}
-              onChange={(_, value) => field.onChange(value)}
-              renderInput={(params) => <TextField {...params} label="Chapters" />}
-            />
-          )}
-        />
-        <Controller
-          name="tags"
-          control={control}
-          render={({ field }) => (
-            <HighlightTagInput
-              value={field.value}
-              onChange={(newValue) =>
-                resolveTags(newValue, book.highlight_tags).then(field.onChange)
-              }
-              availableTags={book.highlight_tags}
-              isProcessing={isCreatingTag}
-            />
-          )}
-        />
-      </Box>
+      <NoteEditorForm
+        ref={formRef}
+        open={open}
+        note={note}
+        initialChapterIds={initialChapterIds}
+        initialHighlightIds={initialHighlightIds}
+        initialBody={initialBody}
+        onSaved={onClose}
+        onStatusChange={setStatus}
+      />
     </CommonDialog>
   );
 };

--- a/frontend/src/pages/BookPage/Notes/NoteEditorForm.tsx
+++ b/frontend/src/pages/BookPage/Notes/NoteEditorForm.tsx
@@ -1,0 +1,217 @@
+import type { HighlightTagInBook, NoteWithLinks } from '@/api/generated/model';
+import {
+  getGetNotesForBookApiV1BooksBookIdNotesGetQueryKey,
+  useCreateNoteApiV1NotesPost,
+  useUpdateNoteApiV1NotesNoteIdPut,
+} from '@/api/generated/notes/notes.ts';
+import { useSnackbar } from '@/context/SnackbarContext.tsx';
+import { useBookPage } from '@/pages/BookPage/BookPageContext';
+import { HighlightTagInput } from '@/pages/BookPage/Highlights/HighlightViewModal/components/HighlightTagInput.tsx';
+import { Autocomplete, Box, MenuItem, TextField } from '@mui/material';
+import { useQueryClient } from '@tanstack/react-query';
+import { forwardRef, useEffect, useImperativeHandle } from 'react';
+import { Controller, useForm } from 'react-hook-form';
+
+import { useNoteTagField } from './hooks/useNoteTagField';
+import { NOTE_KIND_LABELS, NOTE_KINDS, type NoteKindValue } from './noteKinds';
+
+export interface NoteEditorFormHandle {
+  submit: () => void;
+}
+
+interface NoteEditorFormProps {
+  /** Drives the reset effect: form values are (re)initialised when this flips true. */
+  open: boolean;
+  /** Edit mode when set; create mode otherwise */
+  note?: NoteWithLinks | null;
+  initialChapterIds?: number[];
+  initialHighlightIds?: number[];
+  initialBody?: string;
+  /** Called after a successful create/update. */
+  onSaved: () => void;
+  /** Reports save-ability so the hosting dialog can render its footer buttons. */
+  onStatusChange?: (status: { isSaving: boolean; canSave: boolean }) => void;
+}
+
+interface ChapterOption {
+  id: number;
+  name: string;
+}
+
+interface NoteFormValues {
+  title: string;
+  body: string;
+  kind: NoteKindValue | '';
+  chapters: ChapterOption[];
+  tags: HighlightTagInBook[];
+}
+
+const EMPTY_FORM: NoteFormValues = { title: '', body: '', kind: '', chapters: [], tags: [] };
+
+/**
+ * The note create/edit form fields plus mutations, without a dialog shell.
+ * Shared by `NoteEditorDialog` (create + standalone edit) and `NoteViewModal`'s
+ * in-place edit mode. The host renders the footer buttons and triggers save via
+ * the imperative `submit` handle.
+ */
+export const NoteEditorForm = forwardRef<NoteEditorFormHandle, NoteEditorFormProps>(
+  function NoteEditorForm(
+    { open, note, initialChapterIds, initialHighlightIds, initialBody, onSaved, onStatusChange },
+    ref
+  ) {
+    const { book } = useBookPage();
+    const { showSnackbar } = useSnackbar();
+    const queryClient = useQueryClient();
+
+    const chapterOptions: ChapterOption[] = book.chapters.map((chapter) => ({
+      id: chapter.id,
+      name: chapter.name,
+    }));
+
+    const { control, handleSubmit, reset, watch } = useForm<NoteFormValues>({
+      defaultValues: EMPTY_FORM,
+    });
+
+    useEffect(() => {
+      if (!open) return;
+      if (note) {
+        reset({
+          title: note.title,
+          body: note.body,
+          kind: (note.kind as NoteKindValue | null) ?? '',
+          chapters: chapterOptions.filter((option) => note.chapter_ids.includes(option.id)),
+          tags: book.highlight_tags.filter((tag) => note.highlight_tag_ids.includes(tag.id)),
+        });
+      } else {
+        reset({
+          ...EMPTY_FORM,
+          body: initialBody ?? '',
+          chapters: chapterOptions.filter((option) =>
+            (initialChapterIds ?? []).includes(option.id)
+          ),
+        });
+      }
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [open, note]);
+
+    const invalidateNotes = () => {
+      void queryClient.invalidateQueries({
+        queryKey: getGetNotesForBookApiV1BooksBookIdNotesGetQueryKey(book.id),
+      });
+    };
+
+    const { resolveTags, isCreating: isCreatingTag } = useNoteTagField(book.id);
+
+    const createMutation = useCreateNoteApiV1NotesPost({
+      mutation: {
+        onSuccess: () => {
+          invalidateNotes();
+          onSaved();
+        },
+        onError: (error) => {
+          console.error('Failed to create note:', error);
+          showSnackbar('Failed to create note. Please try again.', 'error');
+        },
+      },
+    });
+    const updateMutation = useUpdateNoteApiV1NotesNoteIdPut({
+      mutation: {
+        onSuccess: () => {
+          invalidateNotes();
+          onSaved();
+        },
+        onError: (error) => {
+          console.error('Failed to update note:', error);
+          showSnackbar('Failed to update note. Please try again.', 'error');
+        },
+      },
+    });
+
+    const isSaving = createMutation.isPending || updateMutation.isPending;
+    const canSave = watch('title').trim().length > 0 && !isSaving;
+
+    useEffect(() => {
+      onStatusChange?.({ isSaving, canSave });
+    }, [isSaving, canSave, onStatusChange]);
+
+    const onSubmit = async (values: NoteFormValues) => {
+      const payload = {
+        title: values.title.trim(),
+        body: values.body,
+        kind: values.kind === '' ? null : values.kind,
+        chapter_ids: values.chapters.map((option) => option.id),
+        highlight_ids: note?.highlight_ids ?? initialHighlightIds ?? [],
+        highlight_tag_ids: values.tags.map((tag) => tag.id),
+      };
+      if (note) {
+        await updateMutation.mutateAsync({ noteId: note.id, data: payload });
+      } else {
+        await createMutation.mutateAsync({ data: { ...payload, book_id: book.id } });
+      }
+    };
+
+    useImperativeHandle(ref, () => ({
+      submit: () => void handleSubmit(onSubmit)(),
+    }));
+
+    return (
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, pt: 1 }}>
+        <Controller
+          name="title"
+          control={control}
+          render={({ field }) => <TextField {...field} label="Title" fullWidth autoFocus />}
+        />
+        <Controller
+          name="kind"
+          control={control}
+          render={({ field }) => (
+            <TextField {...field} select label="Kind" fullWidth>
+              <MenuItem value="">None</MenuItem>
+              {NOTE_KINDS.map((value) => (
+                <MenuItem key={value} value={value}>
+                  {NOTE_KIND_LABELS[value]}
+                </MenuItem>
+              ))}
+            </TextField>
+          )}
+        />
+        <Controller
+          name="body"
+          control={control}
+          render={({ field }) => (
+            <TextField {...field} label="Note (markdown)" fullWidth multiline minRows={5} />
+          )}
+        />
+        <Controller
+          name="chapters"
+          control={control}
+          render={({ field }) => (
+            <Autocomplete
+              multiple
+              options={chapterOptions}
+              getOptionLabel={(option) => option.name}
+              isOptionEqualToValue={(option, value) => option.id === value.id}
+              value={field.value}
+              onChange={(_, value) => field.onChange(value)}
+              renderInput={(params) => <TextField {...params} label="Chapters" />}
+            />
+          )}
+        />
+        <Controller
+          name="tags"
+          control={control}
+          render={({ field }) => (
+            <HighlightTagInput
+              value={field.value}
+              onChange={(newValue) =>
+                resolveTags(newValue, book.highlight_tags).then(field.onChange)
+              }
+              availableTags={book.highlight_tags}
+              isProcessing={isCreatingTag}
+            />
+          )}
+        />
+      </Box>
+    );
+  }
+);

--- a/frontend/src/pages/BookPage/Notes/NoteModals.tsx
+++ b/frontend/src/pages/BookPage/Notes/NoteModals.tsx
@@ -1,6 +1,5 @@
-import { ConfirmationDialog } from '@/components/dialogs/ConfirmationDialog.tsx';
-
 import { NoteEditorDialog } from './NoteEditorDialog';
+import { NoteViewModal } from './NoteViewModal';
 import type { NoteModalsController } from './hooks/useNoteModals';
 
 interface NoteModalsProps {
@@ -10,25 +9,24 @@ interface NoteModalsProps {
 }
 
 /**
- * Renders the note editor and delete-confirmation dialogs for a
- * `useNoteModals` controller, so each surface (notes tab, chapter section, ...)
- * only wires up the triggers, not the dialogs and delete handlers.
+ * Renders the note create editor and the note detail modal for a `useNoteModals`
+ * controller, so each surface (notes tab, chapter section, ...) only wires up the
+ * triggers, not the dialogs. Editing/deleting an existing note lives inside
+ * `NoteViewModal`.
  */
 export const NoteModals = ({ controller, initialChapterIds }: NoteModalsProps) => (
   <>
     <NoteEditorDialog
       open={controller.editorOpen}
       onClose={controller.closeEditor}
-      note={controller.editingNote}
       initialChapterIds={initialChapterIds}
     />
-    <ConfirmationDialog
-      open={controller.deletingNote !== null}
-      title="Delete note"
-      message={`Delete note "${controller.deletingNote?.title ?? ''}"? This cannot be undone.`}
-      onConfirm={controller.confirmDelete}
-      onClose={controller.cancelDelete}
-      isLoading={controller.isDeleting}
-    />
+    {controller.viewingNote && (
+      <NoteViewModal
+        key={controller.viewingNote.id}
+        note={controller.viewingNote}
+        onClose={controller.closeView}
+      />
+    )}
   </>
 );

--- a/frontend/src/pages/BookPage/Notes/NoteModals.tsx
+++ b/frontend/src/pages/BookPage/Notes/NoteModals.tsx
@@ -21,10 +21,10 @@ export const NoteModals = ({ controller, initialChapterIds }: NoteModalsProps) =
       onClose={controller.closeEditor}
       initialChapterIds={initialChapterIds}
     />
-    {controller.viewingNote && (
+    {controller.viewingNoteId !== null && (
       <NoteViewModal
-        key={controller.viewingNote.id}
-        note={controller.viewingNote}
+        key={controller.viewingNoteId}
+        noteId={controller.viewingNoteId}
         onClose={controller.closeView}
       />
     )}

--- a/frontend/src/pages/BookPage/Notes/NoteViewModal.tsx
+++ b/frontend/src/pages/BookPage/Notes/NoteViewModal.tsx
@@ -112,7 +112,7 @@ export const NoteViewModal = ({ noteId, onClose }: NoteViewModalProps) => {
           {activeNote?.kind && (
             <Chip
               size="small"
-              label={NOTE_KIND_LABELS[activeNote?.kind as NoteKindValue]}
+              label={NOTE_KIND_LABELS[activeNote.kind as NoteKindValue]}
               sx={{ mb: 0.5, ml: 1 }}
             />
           )}

--- a/frontend/src/pages/BookPage/Notes/NoteViewModal.tsx
+++ b/frontend/src/pages/BookPage/Notes/NoteViewModal.tsx
@@ -1,16 +1,16 @@
-import type { NoteWithLinks } from '@/api/generated/model';
 import {
   getGetNotesForBookApiV1BooksBookIdNotesGetQueryKey,
   useDeleteNoteApiV1NotesNoteIdDelete,
   useGetNoteApiV1NotesNoteIdGet,
 } from '@/api/generated/notes/notes.ts';
+import { Spinner } from '@/components/animations/Spinner.tsx';
 import { CommonDialog } from '@/components/dialogs/CommonDialog.tsx';
 import { CommonDialogTitle } from '@/components/dialogs/CommonDialogTitle.tsx';
 import { ConfirmationDialog } from '@/components/dialogs/ConfirmationDialog.tsx';
 import { useSnackbar } from '@/context/SnackbarContext.tsx';
 import { useBookPage } from '@/pages/BookPage/BookPageContext';
 import { markdownStyles } from '@/theme/theme';
-import { Box, Button, Chip, Stack, useTheme } from '@mui/material';
+import { Box, Button, Chip, Stack, Typography, useTheme } from '@mui/material';
 import { useQueryClient } from '@tanstack/react-query';
 import { useRef, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
@@ -20,8 +20,8 @@ import { NoteToolbar } from './components/NoteToolbar';
 import { NOTE_KIND_LABELS, type NoteKindValue } from './noteKinds';
 
 interface NoteViewModalProps {
-  /** The list item to display; the detail fetch refreshes its linked summaries. */
-  note: NoteWithLinks;
+  /** Note to display; its full detail (with linked summaries) is fetched by id. */
+  noteId: number;
   onClose: () => void;
 }
 
@@ -30,10 +30,11 @@ interface NoteViewModalProps {
  * shows the full note (content first) with an action toolbar underneath;
  * clicking Edit swaps the same dialog to the note editor form.
  *
- * Mounted only while a note is open (keyed by note id), mirroring the highlight
- * modal — so transient state resets naturally between notes.
+ * Opened by note id (deep-linkable via the `noteId` URL param). Mounted only
+ * while a note is open (keyed by id), mirroring the highlight modal — so
+ * transient state resets naturally between notes.
  */
-export const NoteViewModal = ({ note, onClose }: NoteViewModalProps) => {
+export const NoteViewModal = ({ noteId, onClose }: NoteViewModalProps) => {
   const theme = useTheme();
   const { book } = useBookPage();
   const { showSnackbar } = useSnackbar();
@@ -44,8 +45,7 @@ export const NoteViewModal = ({ note, onClose }: NoteViewModalProps) => {
   const formRef = useRef<NoteEditorFormHandle>(null);
   const [formStatus, setFormStatus] = useState({ isSaving: false, canSave: false });
 
-  const { data: detail } = useGetNoteApiV1NotesNoteIdGet(note.id);
-  const activeNote = detail ?? note;
+  const { data: activeNote, isLoading, isError } = useGetNoteApiV1NotesNoteIdGet(noteId);
 
   const deleteMutation = useDeleteNoteApiV1NotesNoteIdDelete({
     mutation: {
@@ -64,19 +64,20 @@ export const NoteViewModal = ({ note, onClose }: NoteViewModalProps) => {
   });
 
   const handleCopy = async () => {
+    if (!activeNote) return;
     await navigator.clipboard.writeText(activeNote.body);
     showSnackbar('Note copied to clipboard.', 'success');
   };
 
   const handleConfirmDelete = () => {
-    void deleteMutation.mutateAsync({ noteId: activeNote.id });
+    void deleteMutation.mutateAsync({ noteId });
   };
 
-  const isLoading = deleteMutation.isPending;
+  const isDeleting = deleteMutation.isPending;
 
-  const chapters = activeNote.chapters ?? [];
-  const highlightTags = activeNote.highlight_tags ?? [];
-  const highlights = activeNote.highlights ?? [];
+  const chapters = activeNote?.chapters ?? [];
+  const highlightTags = activeNote?.highlight_tags ?? [];
+  const highlights = activeNote?.highlights ?? [];
 
   const footerActions = isEditing ? (
     <Box sx={{ display: 'flex', gap: 1, width: '100%', justifyContent: 'flex-end' }}>
@@ -93,7 +94,7 @@ export const NoteViewModal = ({ note, onClose }: NoteViewModalProps) => {
     </Box>
   ) : (
     <Box sx={{ display: 'flex', justifyContent: 'flex-end', width: '100%' }}>
-      <Button onClick={onClose} disabled={isLoading}>
+      <Button onClick={onClose} disabled={isDeleting}>
         Close
       </Button>
     </Box>
@@ -104,12 +105,16 @@ export const NoteViewModal = ({ note, onClose }: NoteViewModalProps) => {
       open
       onClose={onClose}
       maxWidth="md"
-      isLoading={isEditing ? formStatus.isSaving : isLoading}
-      title={<CommonDialogTitle>{isEditing ? 'Edit note' : activeNote.title}</CommonDialogTitle>}
+      isLoading={isEditing ? formStatus.isSaving : isDeleting}
+      title={
+        <CommonDialogTitle>
+          {isEditing ? 'Edit note' : (activeNote?.title ?? 'Note')}
+        </CommonDialogTitle>
+      }
       footerActions={footerActions}
     >
       <Box mt={2} mb={2}>
-        {isEditing ? (
+        {isEditing && activeNote ? (
           <NoteEditorForm
             ref={formRef}
             open={isEditing}
@@ -117,7 +122,7 @@ export const NoteViewModal = ({ note, onClose }: NoteViewModalProps) => {
             onSaved={() => setIsEditing(false)}
             onStatusChange={setFormStatus}
           />
-        ) : (
+        ) : activeNote ? (
           <Stack gap={2}>
             <Box>
               {activeNote.kind && (
@@ -164,21 +169,27 @@ export const NoteViewModal = ({ note, onClose }: NoteViewModalProps) => {
               onEdit={() => setIsEditing(true)}
               onCopy={() => void handleCopy()}
               onDelete={() => setDeleteConfirmOpen(true)}
-              disabled={isLoading}
+              disabled={isDeleting}
             />
           </Stack>
+        ) : isError ? (
+          <Typography color="text.secondary">
+            This note could not be found. It may have been deleted.
+          </Typography>
+        ) : (
+          isLoading && <Spinner />
         )}
       </Box>
 
       <ConfirmationDialog
         open={deleteConfirmOpen}
         title="Delete note"
-        message={`Delete note "${activeNote.title}"? This cannot be undone.`}
+        message={`Delete note "${activeNote?.title ?? ''}"? This cannot be undone.`}
         confirmText="Delete"
         confirmColor="error"
         onConfirm={handleConfirmDelete}
         onClose={() => setDeleteConfirmOpen(false)}
-        isLoading={isLoading}
+        isLoading={isDeleting}
       />
     </CommonDialog>
   );

--- a/frontend/src/pages/BookPage/Notes/NoteViewModal.tsx
+++ b/frontend/src/pages/BookPage/Notes/NoteViewModal.tsx
@@ -1,0 +1,185 @@
+import type { NoteWithLinks } from '@/api/generated/model';
+import {
+  getGetNotesForBookApiV1BooksBookIdNotesGetQueryKey,
+  useDeleteNoteApiV1NotesNoteIdDelete,
+  useGetNoteApiV1NotesNoteIdGet,
+} from '@/api/generated/notes/notes.ts';
+import { CommonDialog } from '@/components/dialogs/CommonDialog.tsx';
+import { CommonDialogTitle } from '@/components/dialogs/CommonDialogTitle.tsx';
+import { ConfirmationDialog } from '@/components/dialogs/ConfirmationDialog.tsx';
+import { useSnackbar } from '@/context/SnackbarContext.tsx';
+import { useBookPage } from '@/pages/BookPage/BookPageContext';
+import { markdownStyles } from '@/theme/theme';
+import { Box, Button, Chip, Stack, useTheme } from '@mui/material';
+import { useQueryClient } from '@tanstack/react-query';
+import { useRef, useState } from 'react';
+import ReactMarkdown from 'react-markdown';
+
+import { NoteEditorForm, type NoteEditorFormHandle } from './NoteEditorForm';
+import { NoteToolbar } from './components/NoteToolbar';
+import { NOTE_KIND_LABELS, type NoteKindValue } from './noteKinds';
+
+interface NoteViewModalProps {
+  /** The list item to display; the detail fetch refreshes its linked summaries. */
+  note: NoteWithLinks;
+  onClose: () => void;
+}
+
+/**
+ * Read-only note detail dialog that toggles into an in-place editor. Read mode
+ * shows the full note (content first) with an action toolbar underneath;
+ * clicking Edit swaps the same dialog to the note editor form.
+ *
+ * Mounted only while a note is open (keyed by note id), mirroring the highlight
+ * modal — so transient state resets naturally between notes.
+ */
+export const NoteViewModal = ({ note, onClose }: NoteViewModalProps) => {
+  const theme = useTheme();
+  const { book } = useBookPage();
+  const { showSnackbar } = useSnackbar();
+  const queryClient = useQueryClient();
+
+  const [isEditing, setIsEditing] = useState(false);
+  const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
+  const formRef = useRef<NoteEditorFormHandle>(null);
+  const [formStatus, setFormStatus] = useState({ isSaving: false, canSave: false });
+
+  const { data: detail } = useGetNoteApiV1NotesNoteIdGet(note.id);
+  const activeNote = detail ?? note;
+
+  const deleteMutation = useDeleteNoteApiV1NotesNoteIdDelete({
+    mutation: {
+      onSuccess: () => {
+        void queryClient.invalidateQueries({
+          queryKey: getGetNotesForBookApiV1BooksBookIdNotesGetQueryKey(book.id),
+        });
+        setDeleteConfirmOpen(false);
+        onClose();
+      },
+      onError: (error) => {
+        console.error('Failed to delete note:', error);
+        showSnackbar('Failed to delete note. Please try again.', 'error');
+      },
+    },
+  });
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(activeNote.body);
+    showSnackbar('Note copied to clipboard.', 'success');
+  };
+
+  const handleConfirmDelete = () => {
+    void deleteMutation.mutateAsync({ noteId: activeNote.id });
+  };
+
+  const isLoading = deleteMutation.isPending;
+
+  const chapters = activeNote.chapters ?? [];
+  const highlightTags = activeNote.highlight_tags ?? [];
+  const highlights = activeNote.highlights ?? [];
+
+  const footerActions = isEditing ? (
+    <Box sx={{ display: 'flex', gap: 1, width: '100%', justifyContent: 'flex-end' }}>
+      <Button onClick={() => setIsEditing(false)} disabled={formStatus.isSaving}>
+        Cancel
+      </Button>
+      <Button
+        variant="contained"
+        onClick={() => formRef.current?.submit()}
+        disabled={!formStatus.canSave}
+      >
+        {formStatus.isSaving ? 'Saving...' : 'Save'}
+      </Button>
+    </Box>
+  ) : (
+    <Box sx={{ display: 'flex', justifyContent: 'flex-end', width: '100%' }}>
+      <Button onClick={onClose} disabled={isLoading}>
+        Close
+      </Button>
+    </Box>
+  );
+
+  return (
+    <CommonDialog
+      open
+      onClose={onClose}
+      maxWidth="md"
+      isLoading={isEditing ? formStatus.isSaving : isLoading}
+      title={<CommonDialogTitle>{isEditing ? 'Edit note' : activeNote.title}</CommonDialogTitle>}
+      footerActions={footerActions}
+    >
+      <Box mt={2} mb={2}>
+        {isEditing ? (
+          <NoteEditorForm
+            ref={formRef}
+            open={isEditing}
+            note={activeNote}
+            onSaved={() => setIsEditing(false)}
+            onStatusChange={setFormStatus}
+          />
+        ) : (
+          <Stack gap={2}>
+            <Box>
+              {activeNote.kind && (
+                <Chip
+                  size="small"
+                  label={NOTE_KIND_LABELS[activeNote.kind as NoteKindValue]}
+                  sx={{ mb: 1 }}
+                />
+              )}
+              {activeNote.body && (
+                <Box sx={markdownStyles(theme)}>
+                  <ReactMarkdown>{activeNote.body}</ReactMarkdown>
+                </Box>
+              )}
+              {(chapters.length > 0 || highlightTags.length > 0 || highlights.length > 0) && (
+                <Stack direction="row" spacing={1} sx={{ mt: 2, flexWrap: 'wrap', gap: 0.5 }}>
+                  {chapters.map((chapter) => (
+                    <Chip
+                      key={`ch-${chapter.id}`}
+                      size="small"
+                      variant="outlined"
+                      label={chapter.name}
+                    />
+                  ))}
+                  {highlightTags.map((tag) => (
+                    <Chip
+                      key={`tag-${tag.id}`}
+                      size="small"
+                      variant="outlined"
+                      label={`#${tag.name}`}
+                    />
+                  ))}
+                  {highlights.length > 0 && (
+                    <Chip
+                      size="small"
+                      variant="outlined"
+                      label={`${highlights.length} highlight${highlights.length === 1 ? '' : 's'}`}
+                    />
+                  )}
+                </Stack>
+              )}
+            </Box>
+            <NoteToolbar
+              onEdit={() => setIsEditing(true)}
+              onCopy={() => void handleCopy()}
+              onDelete={() => setDeleteConfirmOpen(true)}
+              disabled={isLoading}
+            />
+          </Stack>
+        )}
+      </Box>
+
+      <ConfirmationDialog
+        open={deleteConfirmOpen}
+        title="Delete note"
+        message={`Delete note "${activeNote.title}"? This cannot be undone.`}
+        confirmText="Delete"
+        confirmColor="error"
+        onConfirm={handleConfirmDelete}
+        onClose={() => setDeleteConfirmOpen(false)}
+        isLoading={isLoading}
+      />
+    </CommonDialog>
+  );
+};

--- a/frontend/src/pages/BookPage/Notes/NoteViewModal.tsx
+++ b/frontend/src/pages/BookPage/Notes/NoteViewModal.tsx
@@ -109,6 +109,13 @@ export const NoteViewModal = ({ noteId, onClose }: NoteViewModalProps) => {
       title={
         <CommonDialogTitle>
           {isEditing ? 'Edit note' : (activeNote?.title ?? 'Note')}
+          {activeNote?.kind && (
+            <Chip
+              size="small"
+              label={NOTE_KIND_LABELS[activeNote?.kind as NoteKindValue]}
+              sx={{ mb: 0.5, ml: 1 }}
+            />
+          )}
         </CommonDialogTitle>
       }
       footerActions={footerActions}
@@ -125,13 +132,6 @@ export const NoteViewModal = ({ noteId, onClose }: NoteViewModalProps) => {
         ) : activeNote ? (
           <Stack gap={2}>
             <Box>
-              {activeNote.kind && (
-                <Chip
-                  size="small"
-                  label={NOTE_KIND_LABELS[activeNote.kind as NoteKindValue]}
-                  sx={{ mb: 1 }}
-                />
-              )}
               {activeNote.body && (
                 <Box sx={markdownStyles(theme)}>
                   <ReactMarkdown>{activeNote.body}</ReactMarkdown>

--- a/frontend/src/pages/BookPage/Notes/NotesPage.tsx
+++ b/frontend/src/pages/BookPage/Notes/NotesPage.tsx
@@ -42,7 +42,7 @@ export const NotesPage = () => {
     highlight_tag_id: tagId,
   };
   const { data, isLoading, isError } = useGetNotesForBookApiV1BooksBookIdNotesGet(book.id, params);
-  const noteModals = useNoteModals(book.id);
+  const noteModals = useNoteModals();
 
   const handleKindFilter = (value: NoteKindValue | null) => {
     void navigate({ search: (prev) => ({ ...prev, kind: value ?? undefined }) });
@@ -76,11 +76,7 @@ export const NotesPage = () => {
       <Stack component="ul" sx={{ gap: 2, listStyle: 'none', p: 0, m: 0 }}>
         {notes.map((note) => (
           <li key={note.id}>
-            <NoteCard
-              note={note}
-              onEdit={() => noteModals.openEdit(note)}
-              onDelete={() => noteModals.requestDelete(note)}
-            />
+            <NoteCard note={note} onClick={() => noteModals.openView(note)} />
           </li>
         ))}
       </Stack>

--- a/frontend/src/pages/BookPage/Notes/components/NoteToolbar.tsx
+++ b/frontend/src/pages/BookPage/Notes/components/NoteToolbar.tsx
@@ -1,0 +1,40 @@
+import { IconButtonWithTooltip } from '@/components/buttons/IconButtonWithTooltip.tsx';
+import { CopyIcon, DeleteIcon, EditIcon } from '@/theme/Icons.tsx';
+import { Box } from '@mui/material';
+
+interface NoteToolbarProps {
+  onEdit: () => void;
+  onCopy: () => void;
+  onDelete: () => void;
+  disabled?: boolean;
+}
+
+/**
+ * Action toolbar for the note detail modal. Sits below the note content,
+ * mirroring the highlight modal's `Toolbar` (content first, actions underneath).
+ */
+export const NoteToolbar = ({ onEdit, onCopy, onDelete, disabled = false }: NoteToolbarProps) => (
+  <Box sx={{ display: 'flex', justifyContent: 'flex-end', gap: 1 }}>
+    <IconButtonWithTooltip
+      title="Edit note"
+      ariaLabel="Edit note"
+      onClick={onEdit}
+      disabled={disabled}
+      icon={<EditIcon />}
+    />
+    <IconButtonWithTooltip
+      title="Copy note content"
+      ariaLabel="Copy note content"
+      onClick={onCopy}
+      disabled={disabled}
+      icon={<CopyIcon />}
+    />
+    <IconButtonWithTooltip
+      title="Delete note"
+      ariaLabel="Delete note"
+      onClick={onDelete}
+      disabled={disabled}
+      icon={<DeleteIcon />}
+    />
+  </Box>
+);

--- a/frontend/src/pages/BookPage/Notes/components/NoteToolbar.tsx
+++ b/frontend/src/pages/BookPage/Notes/components/NoteToolbar.tsx
@@ -9,10 +9,6 @@ interface NoteToolbarProps {
   disabled?: boolean;
 }
 
-/**
- * Action toolbar for the note detail modal. Sits below the note content,
- * mirroring the highlight modal's `Toolbar` (content first, actions underneath).
- */
 export const NoteToolbar = ({ onEdit, onCopy, onDelete, disabled = false }: NoteToolbarProps) => (
   <Box sx={{ display: 'flex', justifyContent: 'flex-end', gap: 1 }}>
     <IconButtonWithTooltip

--- a/frontend/src/pages/BookPage/Notes/hooks/useNoteModals.ts
+++ b/frontend/src/pages/BookPage/Notes/hooks/useNoteModals.ts
@@ -1,5 +1,18 @@
 import type { NoteWithLinks } from '@/api/generated/model';
-import { useState } from 'react';
+import { getGetNoteApiV1NotesNoteIdGetQueryKey } from '@/api/generated/notes/notes.ts';
+import { useQueryClient } from '@tanstack/react-query';
+import { useNavigate, useSearch } from '@tanstack/react-router';
+import { useCallback, useRef, useState } from 'react';
+
+interface UseNoteModalsOptions {
+  /**
+   * Sync the open note to the `noteId` URL search param so the detail modal is
+   * shareable/deep-linkable (like `?highlightId=`). Defaults to true. Nested
+   * surfaces that already own the URL (e.g. the chapter dialog) pass false to
+   * keep the open note in local state instead.
+   */
+  syncToUrl?: boolean;
+}
 
 /**
  * Owns the open state for the note editor (create) and the note detail modal.
@@ -19,20 +32,71 @@ export interface NoteModalsController {
   // Consumed by NoteModals:
   editorOpen: boolean;
   closeEditor: () => void;
-  viewingNote: NoteWithLinks | null;
+  viewingNoteId: number | null;
   closeView: () => void;
 }
 
-export const useNoteModals = (): NoteModalsController => {
+export const useNoteModals = (options: UseNoteModalsOptions = {}): NoteModalsController => {
+  const { syncToUrl = true } = options;
+  const queryClient = useQueryClient();
+
   const [editorOpen, setEditorOpen] = useState(false);
-  const [viewingNote, setViewingNote] = useState<NoteWithLinks | null>(null);
+
+  // strict: false so this hook works from any child route under /book/$bookId
+  const search = useSearch({ strict: false }) as { noteId?: number };
+  const navigate = useNavigate() as (opts: {
+    search: (prev: Record<string, unknown>) => Record<string, unknown>;
+    replace?: boolean;
+  }) => Promise<void>;
+
+  // Local state used when syncToUrl is false (e.g. inside the chapter dialog).
+  const [localNoteId, setLocalNoteId] = useState<number | null>(null);
+  // Tracks whether the modal was opened via user click (push) vs a direct URL.
+  const wasOpenedByPush = useRef(false);
+
+  const viewingNoteId = syncToUrl ? (search.noteId ?? null) : localNoteId;
+
+  const setNoteId = useCallback(
+    (noteId: number | undefined, replace: boolean) => {
+      if (syncToUrl) {
+        void navigate({
+          search: (prev) => ({ ...prev, noteId }),
+          replace,
+        });
+      } else {
+        setLocalNoteId(noteId ?? null);
+      }
+    },
+    [navigate, syncToUrl]
+  );
+
+  const openView = useCallback(
+    (note: NoteWithLinks) => {
+      // Seed the detail query so the modal renders instantly instead of
+      // flashing a spinner while the GET resolves.
+      queryClient.setQueryData(getGetNoteApiV1NotesNoteIdGetQueryKey(note.id), note);
+      wasOpenedByPush.current = true;
+      // Push a history entry so the back button closes the modal.
+      setNoteId(note.id, false);
+    },
+    [queryClient, setNoteId]
+  );
+
+  const closeView = useCallback(() => {
+    if (wasOpenedByPush.current && syncToUrl) {
+      wasOpenedByPush.current = false;
+      window.history.back();
+    } else {
+      setNoteId(undefined, true);
+    }
+  }, [setNoteId, syncToUrl]);
 
   return {
     openCreate: () => setEditorOpen(true),
-    openView: (note) => setViewingNote(note),
+    openView,
     editorOpen,
     closeEditor: () => setEditorOpen(false),
-    viewingNote,
-    closeView: () => setViewingNote(null),
+    viewingNoteId,
+    closeView,
   };
 };

--- a/frontend/src/pages/BookPage/Notes/hooks/useNoteModals.ts
+++ b/frontend/src/pages/BookPage/Notes/hooks/useNoteModals.ts
@@ -1,79 +1,38 @@
 import type { NoteWithLinks } from '@/api/generated/model';
-import {
-  getGetNotesForBookApiV1BooksBookIdNotesGetQueryKey,
-  useDeleteNoteApiV1NotesNoteIdDelete,
-} from '@/api/generated/notes/notes.ts';
-import { useSnackbar } from '@/context/SnackbarContext.tsx';
-import { useQueryClient } from '@tanstack/react-query';
 import { useState } from 'react';
 
 /**
- * Owns the open/edit/delete state for the note editor and delete-confirmation
- * dialogs, plus the delete mutation. Shared by every surface that lets a user
- * create/edit/delete notes (notes tab, chapter section, ...) so they don't each
- * re-declare the same state and handlers. Render the dialogs with `NoteModals`.
+ * Owns the open state for the note editor (create) and the note detail modal.
+ * Shared by every surface that lists notes (notes tab, chapter section, ...) so
+ * they don't each re-declare the same state. Render the dialogs with `NoteModals`.
+ *
+ * Editing and deleting an existing note happen inside `NoteViewModal` itself
+ * (read-only view that toggles to editable), so the controller only tracks which
+ * note is open and whether the create editor is open.
  */
 export interface NoteModalsController {
   /** Open the editor to create a new note. */
   openCreate: () => void;
-  /** Open the editor to edit an existing note. */
-  openEdit: (note: NoteWithLinks) => void;
-  /** Ask to delete a note (opens the confirmation dialog). */
-  requestDelete: (note: NoteWithLinks) => void;
+  /** Open the detail modal for an existing note. */
+  openView: (note: NoteWithLinks) => void;
 
   // Consumed by NoteModals:
   editorOpen: boolean;
-  editingNote: NoteWithLinks | null;
   closeEditor: () => void;
-  deletingNote: NoteWithLinks | null;
-  cancelDelete: () => void;
-  confirmDelete: () => void;
-  isDeleting: boolean;
+  viewingNote: NoteWithLinks | null;
+  closeView: () => void;
 }
 
-export const useNoteModals = (bookId: number): NoteModalsController => {
-  const queryClient = useQueryClient();
-  const { showSnackbar } = useSnackbar();
-
+export const useNoteModals = (): NoteModalsController => {
   const [editorOpen, setEditorOpen] = useState(false);
-  const [editingNote, setEditingNote] = useState<NoteWithLinks | null>(null);
-  const [deletingNote, setDeletingNote] = useState<NoteWithLinks | null>(null);
-
-  const deleteMutation = useDeleteNoteApiV1NotesNoteIdDelete({
-    mutation: {
-      onSuccess: () => {
-        void queryClient.invalidateQueries({
-          queryKey: getGetNotesForBookApiV1BooksBookIdNotesGetQueryKey(bookId),
-        });
-        setDeletingNote(null);
-      },
-      onError: (error) => {
-        console.error('Failed to delete note:', error);
-        showSnackbar('Failed to delete note. Please try again.', 'error');
-      },
-    },
-  });
+  const [viewingNote, setViewingNote] = useState<NoteWithLinks | null>(null);
 
   return {
-    openCreate: () => {
-      setEditingNote(null);
-      setEditorOpen(true);
-    },
-    openEdit: (note) => {
-      setEditingNote(note);
-      setEditorOpen(true);
-    },
-    requestDelete: (note) => setDeletingNote(note),
+    openCreate: () => setEditorOpen(true),
+    openView: (note) => setViewingNote(note),
     editorOpen,
-    editingNote,
     closeEditor: () => setEditorOpen(false),
-    deletingNote,
-    cancelDelete: () => setDeletingNote(null),
-    confirmDelete: () => {
-      if (deletingNote) {
-        void deleteMutation.mutateAsync({ noteId: deletingNote.id });
-      }
-    },
-    isDeleting: deleteMutation.isPending,
+    viewingNote,
+    closeView: () => setViewingNote(null),
   };
 };

--- a/frontend/src/pages/BookPage/Notes/hooks/useNoteModals.ts
+++ b/frontend/src/pages/BookPage/Notes/hooks/useNoteModals.ts
@@ -5,31 +5,12 @@ import { useNavigate, useSearch } from '@tanstack/react-router';
 import { useCallback, useRef, useState } from 'react';
 
 interface UseNoteModalsOptions {
-  /**
-   * Sync the open note to the `noteId` URL search param so the detail modal is
-   * shareable/deep-linkable (like `?highlightId=`). Defaults to true. Nested
-   * surfaces that already own the URL (e.g. the chapter dialog) pass false to
-   * keep the open note in local state instead.
-   */
   syncToUrl?: boolean;
 }
 
-/**
- * Owns the open state for the note editor (create) and the note detail modal.
- * Shared by every surface that lists notes (notes tab, chapter section, ...) so
- * they don't each re-declare the same state. Render the dialogs with `NoteModals`.
- *
- * Editing and deleting an existing note happen inside `NoteViewModal` itself
- * (read-only view that toggles to editable), so the controller only tracks which
- * note is open and whether the create editor is open.
- */
 export interface NoteModalsController {
-  /** Open the editor to create a new note. */
   openCreate: () => void;
-  /** Open the detail modal for an existing note. */
   openView: (note: NoteWithLinks) => void;
-
-  // Consumed by NoteModals:
   editorOpen: boolean;
   closeEditor: () => void;
   viewingNoteId: number | null;
@@ -42,16 +23,13 @@ export const useNoteModals = (options: UseNoteModalsOptions = {}): NoteModalsCon
 
   const [editorOpen, setEditorOpen] = useState(false);
 
-  // strict: false so this hook works from any child route under /book/$bookId
   const search = useSearch({ strict: false }) as { noteId?: number };
   const navigate = useNavigate() as (opts: {
     search: (prev: Record<string, unknown>) => Record<string, unknown>;
     replace?: boolean;
   }) => Promise<void>;
 
-  // Local state used when syncToUrl is false (e.g. inside the chapter dialog).
   const [localNoteId, setLocalNoteId] = useState<number | null>(null);
-  // Tracks whether the modal was opened via user click (push) vs a direct URL.
   const wasOpenedByPush = useRef(false);
 
   const viewingNoteId = syncToUrl ? (search.noteId ?? null) : localNoteId;
@@ -72,11 +50,8 @@ export const useNoteModals = (options: UseNoteModalsOptions = {}): NoteModalsCon
 
   const openView = useCallback(
     (note: NoteWithLinks) => {
-      // Seed the detail query so the modal renders instantly instead of
-      // flashing a spinner while the GET resolves.
       queryClient.setQueryData(getGetNoteApiV1NotesNoteIdGetQueryKey(note.id), note);
       wasOpenedByPush.current = true;
-      // Push a history entry so the back button closes the modal.
       setNoteId(note.id, false);
     },
     [queryClient, setNoteId]

--- a/frontend/src/pages/BookPage/Structure/ChapterDetailDialog/NotesSection.tsx
+++ b/frontend/src/pages/BookPage/Structure/ChapterDetailDialog/NotesSection.tsx
@@ -16,7 +16,7 @@ export const NotesSection = ({ chapter, bookId }: NotesSectionProps) => {
   const { data, isLoading } = useGetNotesForBookApiV1BooksBookIdNotesGet(bookId, {
     chapter_id: chapter.id,
   });
-  const noteModals = useNoteModals();
+  const noteModals = useNoteModals({ syncToUrl: false });
 
   // NOTE: the orval axios mutator unwraps the response (`.then(({ data }) => data)`),
   // so the generated GET hook's `data` is the payload itself, not an AxiosResponse.

--- a/frontend/src/pages/BookPage/Structure/ChapterDetailDialog/NotesSection.tsx
+++ b/frontend/src/pages/BookPage/Structure/ChapterDetailDialog/NotesSection.tsx
@@ -16,7 +16,7 @@ export const NotesSection = ({ chapter, bookId }: NotesSectionProps) => {
   const { data, isLoading } = useGetNotesForBookApiV1BooksBookIdNotesGet(bookId, {
     chapter_id: chapter.id,
   });
-  const noteModals = useNoteModals(bookId);
+  const noteModals = useNoteModals();
 
   // NOTE: the orval axios mutator unwraps the response (`.then(({ data }) => data)`),
   // so the generated GET hook's `data` is the payload itself, not an AxiosResponse.
@@ -41,11 +41,7 @@ export const NotesSection = ({ chapter, bookId }: NotesSectionProps) => {
       <Stack component="ul" sx={{ gap: 2, listStyle: 'none', p: 0, m: 0 }}>
         {notes.map((note) => (
           <li key={note.id}>
-            <NoteCard
-              note={note}
-              onEdit={() => noteModals.openEdit(note)}
-              onDelete={() => noteModals.requestDelete(note)}
-            />
+            <NoteCard note={note} onClick={() => noteModals.openView(note)} />
           </li>
         ))}
       </Stack>

--- a/frontend/src/routes/book.$bookId/notes.tsx
+++ b/frontend/src/routes/book.$bookId/notes.tsx
@@ -5,6 +5,7 @@ type NotesSearch = {
   kind?: string;
   chapterId?: number;
   tagId?: number;
+  noteId?: number;
 };
 
 export const Route = createFileRoute('/book/$bookId/notes')({
@@ -13,5 +14,6 @@ export const Route = createFileRoute('/book/$bookId/notes')({
     kind: (search.kind as string | undefined) || undefined,
     chapterId: (search.chapterId as number | undefined) || undefined,
     tagId: (search.tagId as number | undefined) || undefined,
+    noteId: (search.noteId as number | undefined) || undefined,
   }),
 });


### PR DESCRIPTION
Closes #394.

## What

On the Notes tab, each note used to render its full markdown body inline. Notes are now compact cards that open a **read-only detail modal** which toggles into an in-place editor, following the `HighlightViewModal` pattern (content first, action toolbar underneath). The modal is also deep-linkable by note id.

## Changes

- **Compact cards** (`NoteCard`) — title, kind chip, body clamped to 3 lines, linked chips. The whole card is clickable (keyboard-accessible); inline edit/delete icons removed.
- **`NoteViewModal`** — read-only detail view with a toolbar (Edit / Copy / Delete) below the content, mirroring `HighlightViewModal` + its `Toolbar`. Edit toggles the same dialog into the note editor in place (Save/Cancel returns to read mode).
- **`NoteEditorForm`** — extracted from `NoteEditorDialog` so the create dialog and the modal's edit mode share one form implementation.
- **Deep-linking** — opening a note sets `?noteId=<id>` (mirrors `?highlightId=` on the highlights tab); loading such a URL opens the modal directly, and the browser back button closes it. `useNoteModals` gains a `syncToUrl` option; the chapter dialog's notes section keeps local state (`syncToUrl: false`), matching `HighlightsSection`. The modal opens by id and fetches its own detail (`GET /api/v1/notes/{id}`) with loading + not-found states; the list item seeds the query cache so card clicks render instantly.

## Verification

- `npm run type-check` ✅
- `npm run lint` ✅ (strict React Compiler rules)
- Manual UI testing per the checklist in the issue thread (list clamp, open/edit/copy/delete, create flow, highlight + chapter-dialog regressions, URL open/back/deep-link/not-found).

🤖 Generated with [Claude Code](https://claude.com/claude-code)