### PR TITLE
Notes: linked-entity tabs (highlights, chapters) with clickable links in note detail modal

### DIFF
--- a/frontend/src/pages/BookPage/Notes/NoteViewModal.tsx
+++ b/frontend/src/pages/BookPage/Notes/NoteViewModal.tsx
@@ -12,10 +12,12 @@ import { useBookPage } from '@/pages/BookPage/BookPageContext';
 import { markdownStyles } from '@/theme/theme';
 import { Box, Button, Chip, Stack, Typography, useTheme } from '@mui/material';
 import { useQueryClient } from '@tanstack/react-query';
+import { useNavigate } from '@tanstack/react-router';
 import { useRef, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 
 import { NoteEditorForm, type NoteEditorFormHandle } from './NoteEditorForm';
+import { NoteLinkTabs } from './components/NoteLinkTabs';
 import { NoteToolbar } from './components/NoteToolbar';
 import { NOTE_KIND_LABELS, type NoteKindValue } from './noteKinds';
 
@@ -39,6 +41,25 @@ export const NoteViewModal = ({ noteId, onClose }: NoteViewModalProps) => {
   const { book } = useBookPage();
   const { showSnackbar } = useSnackbar();
   const queryClient = useQueryClient();
+  const navigate = useNavigate();
+
+  // Navigating to another route drops the `noteId` param, so the note modal
+  // closes naturally as the target entity's deep link opens its modal there.
+  const handleOpenHighlight = (highlightId: number) => {
+    void navigate({
+      to: '/book/$bookId/highlights',
+      params: { bookId: String(book.id) },
+      search: { highlightId },
+    });
+  };
+
+  const handleOpenChapter = (chapterId: number) => {
+    void navigate({
+      to: '/book/$bookId/structure',
+      params: { bookId: String(book.id) },
+      search: { chapterId },
+    });
+  };
 
   const [isEditing, setIsEditing] = useState(false);
   const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
@@ -137,16 +158,8 @@ export const NoteViewModal = ({ noteId, onClose }: NoteViewModalProps) => {
                   <ReactMarkdown>{activeNote.body}</ReactMarkdown>
                 </Box>
               )}
-              {(chapters.length > 0 || highlightTags.length > 0 || highlights.length > 0) && (
+              {highlightTags.length > 0 && (
                 <Stack direction="row" spacing={1} sx={{ mt: 2, flexWrap: 'wrap', gap: 0.5 }}>
-                  {chapters.map((chapter) => (
-                    <Chip
-                      key={`ch-${chapter.id}`}
-                      size="small"
-                      variant="outlined"
-                      label={chapter.name}
-                    />
-                  ))}
                   {highlightTags.map((tag) => (
                     <Chip
                       key={`tag-${tag.id}`}
@@ -155,13 +168,6 @@ export const NoteViewModal = ({ noteId, onClose }: NoteViewModalProps) => {
                       label={`#${tag.name}`}
                     />
                   ))}
-                  {highlights.length > 0 && (
-                    <Chip
-                      size="small"
-                      variant="outlined"
-                      label={`${highlights.length} highlight${highlights.length === 1 ? '' : 's'}`}
-                    />
-                  )}
                 </Stack>
               )}
             </Box>
@@ -171,6 +177,14 @@ export const NoteViewModal = ({ noteId, onClose }: NoteViewModalProps) => {
               onDelete={() => setDeleteConfirmOpen(true)}
               disabled={isDeleting}
             />
+            {(highlights.length > 0 || chapters.length > 0) && (
+              <NoteLinkTabs
+                highlights={highlights}
+                chapters={chapters}
+                onOpenHighlight={handleOpenHighlight}
+                onOpenChapter={handleOpenChapter}
+              />
+            )}
           </Stack>
         ) : isError ? (
           <Typography color="text.secondary">

--- a/frontend/src/pages/BookPage/Notes/components/NoteLinkTabs.tsx
+++ b/frontend/src/pages/BookPage/Notes/components/NoteLinkTabs.tsx
@@ -1,0 +1,104 @@
+import type { NoteLinkedChapter, NoteLinkedHighlight } from '@/api/generated/model';
+import { QuoteIcon } from '@/theme/Icons.tsx';
+import { Box, List, ListItemButton, ListItemText, Tab, Tabs } from '@mui/material';
+import { type ReactElement, useState } from 'react';
+
+interface NoteLinkTabsProps {
+  highlights: NoteLinkedHighlight[];
+  chapters: NoteLinkedChapter[];
+  onOpenHighlight: (highlightId: number) => void;
+  onOpenChapter: (chapterId: number) => void;
+}
+
+const formatTabLabel = (label: string, count: number) =>
+  count > 0 ? `${label} (${count})` : label;
+
+const PREVIEW_WORD_COUNT = 30;
+
+/**
+ * Preview a highlight's text like `HighlightCard`: prepend `...` when it starts
+ * mid-sentence (lowercase) and append `...` when truncated to the preview length.
+ */
+const formatHighlightPreview = (text: string) => {
+  const startsWithLowercase =
+    text.length > 0 && text[0] === text[0].toLowerCase() && text[0] !== text[0].toUpperCase();
+  const withLeadingEllipsis = startsWithLowercase ? `...${text}` : text;
+
+  const words = withLeadingEllipsis.split(/\s+/);
+  return words.length > PREVIEW_WORD_COUNT
+    ? words.slice(0, PREVIEW_WORD_COUNT).join(' ') + '...'
+    : withLeadingEllipsis;
+};
+
+/**
+ * Tabs listing a note's linked entities (highlights, chapters) as clickable
+ * rows. Each row navigates to the target entity via its deep link. Only tabs
+ * whose entity type has items are rendered, mirroring `ChapterDetailDialog`'s
+ * tabbed composition.
+ */
+export const NoteLinkTabs = ({
+  highlights,
+  chapters,
+  onOpenHighlight,
+  onOpenChapter,
+}: NoteLinkTabsProps) => {
+  const tabs = [
+    highlights.length > 0 && {
+      key: 'highlights',
+      label: formatTabLabel('Highlights', highlights.length),
+      content: (
+        <List disablePadding>
+          {highlights.map((highlight) => (
+            <ListItemButton
+              key={highlight.id}
+              onClick={() => onOpenHighlight(highlight.id)}
+              sx={{ alignItems: 'start', gap: 1.5 }}
+            >
+              <QuoteIcon
+                sx={{ fontSize: 20, color: 'primary.main', flexShrink: 0, mt: 0.3, opacity: 0.7 }}
+              />
+              <ListItemText primary={formatHighlightPreview(highlight.text)} />
+            </ListItemButton>
+          ))}
+        </List>
+      ),
+    },
+    chapters.length > 0 && {
+      key: 'chapters',
+      label: formatTabLabel('Chapters', chapters.length),
+      content: (
+        <List disablePadding>
+          {chapters.map((chapter) => (
+            <ListItemButton key={chapter.id} onClick={() => onOpenChapter(chapter.id)}>
+              <ListItemText primary={chapter.name} />
+            </ListItemButton>
+          ))}
+        </List>
+      ),
+    },
+  ].filter((tab): tab is { key: string; label: string; content: ReactElement } => tab !== false);
+
+  const [activeTab, setActiveTab] = useState(0);
+
+  if (tabs.length === 0) return null;
+
+  // Guard against the active index pointing past the available tabs.
+  const safeActiveTab = Math.min(activeTab, tabs.length - 1);
+
+  return (
+    <Box>
+      <Tabs
+        value={safeActiveTab}
+        onChange={(_, newValue: number) => setActiveTab(newValue)}
+        variant="scrollable"
+        scrollButtons="auto"
+        sx={{ borderBottom: 1, borderColor: 'divider' }}
+      >
+        {tabs.map((tab) => (
+          <Tab key={tab.key} label={tab.label} />
+        ))}
+      </Tabs>
+      <Box sx={{ pt: 1 }}>{tabs[safeActiveTab]?.content}</Box>
+    </Box>
+  );
+};


### PR DESCRIPTION
Closes #395.

## What
Adds **Highlights** and **Chapters** tabs to the note detail modal (`NoteViewModal`), mirroring `ChapterDetailDialog`'s tabbed composition. Each row is a clickable link to the target entity.

## Behavior
- One tab per linked-entity type; a tab only renders when that type has items.
- Clicking a row cross-navigates to the entity's existing deep link — `/highlights?highlightId=X` or `/structure?chapterId=X` — which auto-opens that entity's modal on its own page. Navigating away drops the `noteId` param, so the note modal closes naturally.
- Highlight rows lead with a quote icon and preview the text like `HighlightCard` (leading `...` when starting mid-sentence, trailing `...` when truncated).
- Highlight tags remain as non-clickable `#tag` chips.
- The note toolbar sits between the content and the tabs, matching `ChapterDetailDialog`'s order.

## Notes
- Frontend-only; `GET /notes/{id}` already returns the `highlights`/`chapters` summaries used for the lists.
- `npm run type-check` and `npm run lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)