### PR TITLE
Notes: tag filtering on the list + reuse HighlightCard in note detail (#396)

### DIFF
--- a/docs/superpowers/plans/2026-07-13-note-highlights-highlightcard.md
+++ b/docs/superpowers/plans/2026-07-13-note-highlights-highlightcard.md
@@ -1,0 +1,224 @@
+# Reuse HighlightCard in Note Detail Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Render a note's linked highlights in the note detail modal with the shared `HighlightCard` component (as the chapter detail dialog does), instead of the bespoke list, resolving full `Highlight` objects from the already-loaded book context.
+
+**Architecture:** Frontend-only, two files. `NoteViewModal` builds an `id → Highlight` map from `useBookPage().book.chapters[].highlights` and resolves the note's displayable highlights to full `Highlight` objects, passing them to `NoteLinkTabs`. `NoteLinkTabs`'s Highlights tab renders `HighlightCard`s (mirroring `HighlightsSection`); its Chapters tab is unchanged. No backend change, no API/orval regeneration.
+
+**Tech Stack:** React, TypeScript, MUI, TanStack Router. Reused component: `HighlightCard` (`frontend/src/pages/BookPage/Highlights/HighlightCard.tsx`).
+
+## Global Constraints
+
+- The frontend has **no test framework** (no vitest). The verification cycle is: `cd frontend && npm run type-check` (expect no errors) and `npm run lint` (`--max-warnings 0`, expect 0 warnings/errors), plus the manual check in the task.
+- Type checker is **tsc/pyright**, never mypy. Lint is eslint `--max-warnings 0`; formatter is prettier.
+- No backend changes; no orval regeneration.
+- Land the change in **one commit** — the `NoteLinkTabs` prop-type change breaks `NoteViewModal` until it is updated, so any intermediate state fails the type-check/lint gate.
+- Preserve current click behaviour: clicking a highlight calls `onOpenHighlight(id)` (navigates to the highlights deep link; the note modal closes). The Chapters tab is untouched.
+- Post-edit hooks auto-run lint/type-check after each Edit/Write — read their output.
+
+## Reference: how HighlightsSection uses HighlightCard
+
+`frontend/src/pages/BookPage/Structure/ChapterDetailDialog/HighlightsSection.tsx` renders:
+
+```tsx
+<Stack component="ul" sx={{ gap: 2, listStyle: 'none', p: 0, m: 0 }}>
+  {highlights.map((highlight) => (
+    <li key={highlight.id}>
+      <HighlightCard highlight={highlight} bookmark={...} onOpenModal={handleOpenHighlight} />
+    </li>
+  ))}
+</Stack>
+```
+
+`HighlightCard`'s props (from `HighlightCard.tsx`):
+
+```tsx
+export interface HighlightCardProps {
+  highlight: Highlight;                          // full model from '@/api/generated/model'
+  bookmark?: Bookmark;                           // optional — omitted here
+  onOpenModal?: (highlightId: number) => void;   // called on click
+}
+```
+
+`book.chapters` (from `useBookPage().book`) is `ChapterWithHighlights[]`; each `chapter.highlights` is `Highlight[]` — the same full objects `HighlightsSection` passes to `HighlightCard`.
+
+---
+
+### Task 1: Render linked highlights with HighlightCard (both files, one commit)
+
+**Files:**
+- Modify: `frontend/src/pages/BookPage/Notes/components/NoteLinkTabs.tsx`
+- Modify: `frontend/src/pages/BookPage/Notes/NoteViewModal.tsx`
+
+**Interfaces:**
+- Consumes: `HighlightCard` (`onOpenModal: (highlightId: number) => void`); `useBookPage().book.chapters[].highlights: Highlight[]`; the note detail's `activeNote.highlights` (lightweight `{id, text}`, already soft-delete-filtered by the backend).
+- Produces: `NoteLinkTabs` now takes `highlights: Highlight[]` instead of `NoteLinkedHighlight[]`.
+
+- [ ] **Step 1: Rewrite `NoteLinkTabs.tsx`**
+
+Replace the entire file contents with:
+
+```tsx
+import type { Highlight, NoteLinkedChapter } from '@/api/generated/model';
+import { HighlightCard } from '@/pages/BookPage/Highlights/HighlightCard.tsx';
+import { Box, List, ListItemButton, ListItemText, Stack, Tab, Tabs } from '@mui/material';
+import { type ReactElement, useState } from 'react';
+
+interface NoteLinkTabsProps {
+  highlights: Highlight[];
+  chapters: NoteLinkedChapter[];
+  onOpenHighlight: (highlightId: number) => void;
+  onOpenChapter: (chapterId: number) => void;
+}
+
+const formatTabLabel = (label: string, count: number) =>
+  count > 0 ? `${label} (${count})` : label;
+
+/**
+ * Tabs listing a note's linked entities (highlights, chapters). The Highlights
+ * tab reuses the shared `HighlightCard`; the Chapters tab lists clickable rows.
+ * Only tabs whose entity type has items are rendered, mirroring
+ * `ChapterDetailDialog`'s tabbed composition.
+ */
+export const NoteLinkTabs = ({
+  highlights,
+  chapters,
+  onOpenHighlight,
+  onOpenChapter,
+}: NoteLinkTabsProps) => {
+  const tabs = [
+    highlights.length > 0 && {
+      key: 'highlights',
+      label: formatTabLabel('Highlights', highlights.length),
+      content: (
+        <Stack component="ul" sx={{ gap: 2, listStyle: 'none', p: 0, m: 0 }}>
+          {highlights.map((highlight) => (
+            <li key={highlight.id}>
+              <HighlightCard highlight={highlight} onOpenModal={onOpenHighlight} />
+            </li>
+          ))}
+        </Stack>
+      ),
+    },
+    chapters.length > 0 && {
+      key: 'chapters',
+      label: formatTabLabel('Chapters', chapters.length),
+      content: (
+        <List disablePadding>
+          {chapters.map((chapter) => (
+            <ListItemButton key={chapter.id} onClick={() => onOpenChapter(chapter.id)}>
+              <ListItemText primary={chapter.name} />
+            </ListItemButton>
+          ))}
+        </List>
+      ),
+    },
+  ].filter((tab): tab is { key: string; label: string; content: ReactElement } => tab !== false);
+
+  const [activeTab, setActiveTab] = useState(0);
+
+  if (tabs.length === 0) return null;
+
+  // Guard against the active index pointing past the available tabs.
+  const safeActiveTab = Math.min(activeTab, tabs.length - 1);
+
+  return (
+    <Box>
+      <Tabs
+        value={safeActiveTab}
+        onChange={(_, newValue: number) => setActiveTab(newValue)}
+        variant="scrollable"
+        scrollButtons="auto"
+        sx={{ borderBottom: 1, borderColor: 'divider' }}
+      >
+        {tabs.map((tab) => (
+          <Tab key={tab.key} label={tab.label} />
+        ))}
+      </Tabs>
+      <Box sx={{ pt: 1 }}>{tabs[safeActiveTab]?.content}</Box>
+    </Box>
+  );
+};
+```
+
+This drops the `QuoteIcon` import, the `NoteLinkedHighlight` type import, `PREVIEW_WORD_COUNT`, and `formatHighlightPreview` (all now unused), adds `Highlight`/`HighlightCard`/`Stack`, and keeps `List`/`ListItemButton`/`ListItemText` for the Chapters tab.
+
+- [ ] **Step 2: Resolve full highlights in `NoteViewModal.tsx`**
+
+In `frontend/src/pages/BookPage/Notes/NoteViewModal.tsx`:
+
+(a) Add `Highlight` to the model type import and `useMemo` to the React import. The React import currently reads:
+
+```tsx
+import { useRef, useState } from 'react';
+```
+
+Change it to:
+
+```tsx
+import { useMemo, useRef, useState } from 'react';
+```
+
+And add the `Highlight` type import (place it with the other `@/api/generated/model` usage; there is no existing model import in this file, so add one near the top imports):
+
+```tsx
+import type { Highlight } from '@/api/generated/model';
+```
+
+(b) Replace the existing line:
+
+```tsx
+  const highlights = activeNote?.highlights ?? [];
+```
+
+with a resolution of full `Highlight` objects from the loaded book context:
+
+```tsx
+  // The note detail returns lightweight highlight summaries; resolve them to the
+  // full Highlight objects already loaded on the book so we can render HighlightCard.
+  const highlights = useMemo<Highlight[]>(() => {
+    if (!activeNote?.highlights?.length) return [];
+    const byId = new Map<number, Highlight>();
+    for (const chapter of book.chapters) {
+      for (const highlight of chapter.highlights) {
+        byId.set(highlight.id, highlight);
+      }
+    }
+    return activeNote.highlights
+      .map((summary) => byId.get(summary.id))
+      .filter((highlight): highlight is Highlight => highlight !== undefined);
+  }, [book.chapters, activeNote?.highlights]);
+```
+
+Leave `chapters`, `highlightTags`, and the `<NoteLinkTabs ... highlights={highlights} ... />` usage as they are — `highlights` is now `Highlight[]`, matching the updated prop type. The `(highlights.length > 0 || chapters.length > 0)` render guard still holds.
+
+- [ ] **Step 3: Type-check and lint**
+
+Run:
+
+```bash
+cd frontend && npm run type-check && npm run lint
+```
+
+Expected: no type errors, 0 lint warnings. If eslint flags an unused import in `NoteLinkTabs.tsx`, remove that specific import (Step 1 already accounts for the expected set).
+
+- [ ] **Step 4: Manual check + commit**
+
+Manual: run `npm run dev`, open a note that has linked highlights. The Highlights tab now shows `HighlightCard`s identical to the chapter detail dialog (label, tags, flashcard/note indicators, date). Clicking a card navigates to that highlight (note modal closes). A note with only linked chapters still shows just the Chapters tab, unchanged.
+
+Commit both files together:
+
+```bash
+git add frontend/src/pages/BookPage/Notes/components/NoteLinkTabs.tsx frontend/src/pages/BookPage/Notes/NoteViewModal.tsx
+git commit -m "Notes: reuse HighlightCard for linked highlights in note detail (#396 follow-up)"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** frontend resolution from book context (Step 2), `NoteLinkTabs` uses `HighlightCard` with unchanged Chapters tab (Step 1), navigate-on-click preserved (`onOpenModal={onOpenHighlight}`), bookmark omitted, soft-deleted handling inherited (source is `activeNote.highlights`, already filtered; misses filtered out). All spec sections covered.
+- **Placeholder scan:** no TBD/TODO; both files' complete final code is given.
+- **Type consistency:** `NoteLinkTabs` `highlights` prop is `Highlight[]` in both the definition (Step 1) and the value passed from `NoteViewModal` (Step 2, the `useMemo` returns `Highlight[]`). `onOpenModal`/`onOpenHighlight` share signature `(highlightId: number) => void`.
+- **Unused-symbol caution (`--max-warnings 0`):** Step 1 rewrites the whole file so no stale `QuoteIcon`/`formatHighlightPreview`/`NoteLinkedHighlight` remain; `List`/`ListItemButton`/`ListItemText` are retained because the Chapters tab still uses them.

--- a/docs/superpowers/plans/2026-07-13-notes-tag-filtering.md
+++ b/docs/superpowers/plans/2026-07-13-notes-tag-filtering.md
@@ -1,0 +1,350 @@
+# Notes Tag Filtering Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add single-tag filtering to the Notes tab, matching the Highlights/Flashcards tag-filter UX on both desktop and mobile, reusing existing components.
+
+**Architecture:** All changes live in `frontend/src/pages/BookPage/Notes/NotesPage.tsx`. Notes filtering is already server-side via the `highlight_tag_id` query param, so the work is UI wiring: hold the selected tag in local state synced to the `tagId` URL search param, feed it into the notes query, render `HighlightTagsList` in the desktop left sidebar (via `leftSidebarEl` portal) and in a mobile `FilterDrawer` opened by a `FilterFab`.
+
+**Tech Stack:** React, TypeScript, MUI, TanStack Router, `react-dom` `createPortal`. Reused components: `HighlightTagsList`, `FilterDrawer`/`FilterTab`, `FilterFab`.
+
+## Global Constraints
+
+- The frontend has **no test framework** (no vitest). The verification cycle for every task is: `cd frontend && npm run type-check` (expect no errors) and `npm run lint` (expect 0 warnings/errors), plus the manual check described in the task.
+- Type checker is **pyright/tsc**, never mypy. Lint is eslint with `--max-warnings 0`; formatter is prettier.
+- Follow the existing `FlashcardsPage` pattern exactly (`src/pages/BookPage/Flashcards/FlashcardsPage.tsx`) — it is the reference implementation for this wiring.
+- Single-tag selection only. Show all book tags (`book.highlight_tags` / `book.highlight_tag_groups`) with `hideEmptyGroups`. No backend changes.
+- Post-edit hooks auto-run lint/type-check after each Edit/Write — read their output.
+
+---
+
+## Reference: current `NotesPage.tsx`
+
+The file today (abridged to the parts that change):
+
+```tsx
+export const NotesPage = () => {
+  const { book } = useBookPage();
+  const navigate = useNavigate({ from: '/book/$bookId/notes' });
+  const { kind, chapterId, tagId } = useSearch({ from: '/book/$bookId/notes' });
+
+  const params: GetNotesForBookApiV1BooksBookIdNotesGetParams = {
+    kind: (kind as NoteKindValue | undefined) ?? undefined,
+    chapter_id: chapterId,
+    highlight_tag_id: tagId,
+  };
+  const { data, isLoading, isError } = useGetNotesForBookApiV1BooksBookIdNotesGet(book.id, params);
+  const noteModals = useNoteModals();
+  // ...
+```
+
+`useBookPage()` also exposes `isDesktop`, `leftSidebarEl`, and `fabContainerEl` (confirmed in `BookPageContext.tsx`), currently unused by `NotesPage`. `book.highlight_tags` and `book.highlight_tag_groups` exist (used by `HighlightsPage`/`FlashcardsPage`).
+
+---
+
+### Task 1: Selected-tag state, URL sync, and tag-aware empty message
+
+Wire a `selectedTagId` state synced to the `tagId` search param, feed it into the notes query, add the `handleTagClick` callback that updates state + URL, and make the empty message tag-aware. No visible tag UI yet — this task is verified by editing the URL directly.
+
+**Files:**
+- Modify: `frontend/src/pages/BookPage/Notes/NotesPage.tsx`
+
+**Interfaces:**
+- Consumes: `useBookPage()` → `{ book, isDesktop, leftSidebarEl, fabContainerEl }`; `useGetNotesForBookApiV1BooksBookIdNotesGet(bookId, params)`; the `tagId` search param from `useSearch({ from: '/book/$bookId/notes' })`.
+- Produces (used by Tasks 2 & 3): `selectedTagId: number | undefined`, `handleTagClick: (newTagId: number | null) => void`.
+
+- [ ] **Step 1: Add React imports**
+
+At the top of `NotesPage.tsx`, add `useEffect` and `useState` to the (currently absent) React import. Insert this import line after the existing `@tanstack/react-router` import:
+
+```tsx
+import { useEffect, useState } from 'react';
+```
+
+- [ ] **Step 2: Add state and URL sync inside `NotesPage`**
+
+Replace the opening of the component:
+
+```tsx
+export const NotesPage = () => {
+  const { book } = useBookPage();
+  const navigate = useNavigate({ from: '/book/$bookId/notes' });
+  const { kind, chapterId, tagId } = useSearch({ from: '/book/$bookId/notes' });
+
+  const params: GetNotesForBookApiV1BooksBookIdNotesGetParams = {
+    kind: (kind as NoteKindValue | undefined) ?? undefined,
+    chapter_id: chapterId,
+    highlight_tag_id: tagId,
+  };
+```
+
+with:
+
+```tsx
+export const NotesPage = () => {
+  const { book, isDesktop, leftSidebarEl, fabContainerEl } = useBookPage();
+  const navigate = useNavigate({ from: '/book/$bookId/notes' });
+  const { kind, chapterId, tagId } = useSearch({ from: '/book/$bookId/notes' });
+
+  const [selectedTagId, setSelectedTagId] = useState<number | undefined>(tagId);
+
+  useEffect(() => {
+    setSelectedTagId(tagId);
+  }, [tagId]);
+
+  const params: GetNotesForBookApiV1BooksBookIdNotesGetParams = {
+    kind: (kind as NoteKindValue | undefined) ?? undefined,
+    chapter_id: chapterId,
+    highlight_tag_id: selectedTagId,
+  };
+```
+
+Note: `isDesktop`, `leftSidebarEl`, and `fabContainerEl` are destructured now but only consumed in Tasks 2–3. That would trip the `--max-warnings 0` lint as unused, so **also complete Steps 3–4 in this same task before running lint** — the empty-message change does not use them, so keep them out until Task 2 if you are committing Task 1 standalone. To keep Task 1 lint-clean on its own, destructure only what Task 1 uses:
+
+```tsx
+  const { book } = useBookPage();
+```
+
+and defer adding `isDesktop, leftSidebarEl, fabContainerEl` to Task 2, Step 1.
+
+- [ ] **Step 3: Add the `handleTagClick` callback**
+
+Immediately after the existing `handleKindFilter` function, add:
+
+```tsx
+  const handleTagClick = (newTagId: number | null) => {
+    setSelectedTagId(newTagId || undefined);
+    void navigate({
+      search: (prev) => ({ ...prev, tagId: newTagId || undefined }),
+      replace: true,
+    });
+  };
+```
+
+- [ ] **Step 4: Make the empty message tag-aware**
+
+Replace the empty-state block:
+
+```tsx
+      {!isLoading && !isError && notes.length === 0 && (
+        <Typography color="text.secondary">
+          No notes yet. Create notes about characters, terms, and concepts as you read.
+        </Typography>
+      )}
+```
+
+with:
+
+```tsx
+      {!isLoading && !isError && notes.length === 0 && (
+        <Typography color="text.secondary">
+          {selectedTagId
+            ? 'No notes found with the selected tag.'
+            : 'No notes yet. Create notes about characters, terms, and concepts as you read.'}
+        </Typography>
+      )}
+```
+
+- [ ] **Step 5: Type-check and lint**
+
+Run:
+
+```bash
+cd frontend && npm run type-check && npm run lint
+```
+
+Expected: no type errors, 0 lint warnings. (`handleTagClick` is not yet referenced by JSX — if eslint flags it as unused, that is expected and resolved in Task 2/3; if you commit Task 1 standalone, temporarily reference it is unnecessary — instead land Task 2 in the same commit. See Step 6.)
+
+- [ ] **Step 6: Manual check + commit**
+
+Manual: run `npm run dev`, open a book's Notes tab, and append `?tagId=<id>` (an id of a tag on some highlight) to the URL. The notes list should re-fetch filtered to that tag; with a tag that has no notes, the "No notes found with the selected tag." message shows. Removing the param restores the full list.
+
+Because `handleTagClick` is only consumed by the UI added in Tasks 2–3, commit Tasks 1–3 together (recommended) OR, if committing incrementally, land Task 2 before running the lint gate so `handleTagClick` has a consumer. When ready:
+
+```bash
+git add frontend/src/pages/BookPage/Notes/NotesPage.tsx
+git commit -m "Notes: tag filter state synced to tagId search param (#396)"
+```
+
+---
+
+### Task 2: Desktop tag sidebar
+
+Render `HighlightTagsList` in the desktop left sidebar via a `createPortal` into `leftSidebarEl`, mirroring `FlashcardsSidebar`.
+
+**Files:**
+- Modify: `frontend/src/pages/BookPage/Notes/NotesPage.tsx`
+
+**Interfaces:**
+- Consumes: `selectedTagId` and `handleTagClick` (Task 1); `isDesktop`, `leftSidebarEl` from `useBookPage()`; `book.highlight_tags`, `book.highlight_tag_groups`.
+
+- [ ] **Step 1: Ensure layout hooks are destructured**
+
+Confirm the component destructures the layout fields (add any missing):
+
+```tsx
+  const { book, isDesktop, leftSidebarEl, fabContainerEl } = useBookPage();
+```
+
+(`fabContainerEl` is consumed in Task 3; if committing Task 2 alone, destructure only `book, isDesktop, leftSidebarEl` here and add `fabContainerEl` in Task 3.)
+
+- [ ] **Step 2: Add imports**
+
+Add `Divider` to the existing MUI import, and add the portal + component imports. The MUI import becomes:
+
+```tsx
+import { Box, Button, Divider, Stack, ToggleButton, ToggleButtonGroup, Typography } from '@mui/material';
+```
+
+Add these imports (place the `createPortal` import after the router import, and the component imports alongside the existing `./NoteCard` group):
+
+```tsx
+import { createPortal } from 'react-dom';
+
+import { HighlightTagsList } from '../navigation/HighlightTagsList.tsx';
+```
+
+- [ ] **Step 3: Portal the sidebar into `leftSidebarEl`**
+
+As the first child inside the top-level `<Box>` returned by `NotesPage` (before the toolbar `<Box>`), add:
+
+```tsx
+      {isDesktop &&
+        leftSidebarEl &&
+        createPortal(
+          <>
+            <Divider sx={{ mb: 4 }} />
+            <HighlightTagsList
+              tags={book.highlight_tags}
+              tagGroups={book.highlight_tag_groups}
+              bookId={book.id}
+              selectedTag={selectedTagId}
+              onTagClick={handleTagClick}
+              hideEmptyGroups
+            />
+          </>,
+          leftSidebarEl
+        )}
+```
+
+- [ ] **Step 4: Type-check and lint**
+
+Run:
+
+```bash
+cd frontend && npm run type-check && npm run lint
+```
+
+Expected: no type errors, 0 lint warnings.
+
+- [ ] **Step 5: Manual check + commit**
+
+Manual: on a desktop-width viewport, the Notes tab left sidebar shows the tag list. Clicking a tag filters the notes list and sets `?tagId=` in the URL; clicking the selected tag again clears the filter. Commit (skip if bundling with Task 1):
+
+```bash
+git add frontend/src/pages/BookPage/Notes/NotesPage.tsx
+git commit -m "Notes: desktop tag-filter sidebar (#396)"
+```
+
+---
+
+### Task 3: Mobile filter FAB + drawer
+
+Add the mobile `FilterFab` (portaled into `fabContainerEl`) and a single-tab `FilterDrawer` containing `HighlightTagsList`, matching the Flashcards mobile pattern.
+
+**Files:**
+- Modify: `frontend/src/pages/BookPage/Notes/NotesPage.tsx`
+
+**Interfaces:**
+- Consumes: `selectedTagId`, `handleTagClick` (Task 1); `isDesktop`, `fabContainerEl` (Task 2/`useBookPage`); `FilterFab`, `FilterDrawer`, `FilterTab`.
+
+- [ ] **Step 1: Add imports and drawer-open state**
+
+Add these imports alongside the existing component imports:
+
+```tsx
+import { FilterFab } from '../common/FilterFab.tsx';
+import { FilterDrawer, type FilterTab } from '../navigation/FilterDrawer.tsx';
+```
+
+Add drawer state near the other `useState` calls in `NotesPage`:
+
+```tsx
+  const [filterDrawerOpen, setFilterDrawerOpen] = useState(false);
+```
+
+- [ ] **Step 2: Build the single Tags tab**
+
+After `const notes = data?.notes ?? [];`, add:
+
+```tsx
+  const filterTabs: FilterTab[] = [
+    {
+      label: 'Tags',
+      content: (
+        <HighlightTagsList
+          tags={book.highlight_tags}
+          tagGroups={book.highlight_tag_groups}
+          bookId={book.id}
+          selectedTag={selectedTagId}
+          onTagClick={(id) => {
+            handleTagClick(id);
+            setFilterDrawerOpen(false);
+          }}
+          hideTitle
+          hideEmptyGroups
+        />
+      ),
+    },
+  ];
+```
+
+- [ ] **Step 3: Render the FAB portal and drawer**
+
+Just before the closing `<NoteModals controller={noteModals} />` line, add:
+
+```tsx
+      {!isDesktop &&
+        fabContainerEl &&
+        createPortal(
+          <FilterFab
+            filterEnabled={!!selectedTagId}
+            onClick={() => setFilterDrawerOpen(true)}
+          />,
+          fabContainerEl
+        )}
+      {!isDesktop && (
+        <FilterDrawer
+          open={filterDrawerOpen}
+          onClose={() => setFilterDrawerOpen(false)}
+          tabs={filterTabs}
+        />
+      )}
+```
+
+- [ ] **Step 4: Type-check and lint**
+
+Run:
+
+```bash
+cd frontend && npm run type-check && npm run lint
+```
+
+Expected: no type errors, 0 lint warnings.
+
+- [ ] **Step 5: Manual check + commit**
+
+Manual: at a mobile-width viewport, the filter FAB appears; it is highlighted (primary color) when a tag is active. Tapping it opens the drawer with a "Tags" tab; selecting a tag filters the notes list, closes the drawer, and sets `?tagId=`. Commit (skip if bundling with Tasks 1–2):
+
+```bash
+git add frontend/src/pages/BookPage/Notes/NotesPage.tsx
+git commit -m "Notes: mobile tag-filter FAB and drawer (#396)"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** state/URL sync (Task 1), desktop sidebar (Task 2), mobile FAB+drawer (Task 3), tag-aware empty state (Task 1), all-book-tags with `hideEmptyGroups` (Tasks 2–3), single-tag selection (throughout). No backend work (unchanged). All spec sections covered.
+- **Unused-symbol caution:** the `--max-warnings 0` lint means a symbol destructured/defined before its consumer exists will fail the gate. The plan flags this at each step — either bundle Tasks 1–3 into one commit (recommended, single small file) or add each layout field / callback only in the task that consumes it. The final state destructures `{ book, isDesktop, leftSidebarEl, fabContainerEl }` and uses every one.
+- **Type consistency:** `handleTagClick` signature `(newTagId: number | null) => void` matches `HighlightTagsList`'s `onTagClick` prop and `FlashcardsPage`'s usage. `selectedTag` prop takes `number | undefined`.

--- a/docs/superpowers/specs/2026-07-13-note-highlights-highlightcard-design.md
+++ b/docs/superpowers/specs/2026-07-13-note-highlights-highlightcard-design.md
@@ -1,0 +1,78 @@
+# Notes: reuse `HighlightCard` in the note detail's Highlights tab
+
+**Context:** Part of the Book Notes feature follow-ups. Unrelated to the tag-filtering
+work on the same branch.
+
+## Problem
+
+The note detail modal (`NoteViewModal` → `NoteLinkTabs`) renders a note's linked
+highlights with a bespoke `List`/`ListItemButton` row and a hand-rolled text-preview
+helper (`formatHighlightPreview`). The app already has a canonical highlight component,
+`HighlightCard` (`frontend/src/pages/BookPage/Highlights/HighlightCard.tsx`), used e.g.
+by `ChapterDetailDialog/HighlightsSection.tsx`. The note detail should use that same
+component instead of its own list, for visual and behavioural consistency.
+
+## Approach
+
+Resolve full `Highlight` objects on the **frontend from the already-loaded book
+context** — no backend change.
+
+`HighlightCard` requires the full `Highlight` shape (`label`, `datetime`, `page`,
+`note`, `flashcards`, `highlight_tags`, `text`). The note detail endpoint only returns
+lightweight `NoteLinkedHighlight` summaries (`{id, text}`). However, `NoteViewModal`
+already consumes `useBookPage().book`, whose `chapters[].highlights` are the exact full
+`Highlight` objects `HighlightsSection` feeds to `HighlightCard`. So we look the full
+objects up by id rather than enriching the API.
+
+This was chosen over a backend enrichment of `GET /notes/{id}` because: the note **list**
+cards (`NoteCard`) don't render highlights at all (so no payload benefit to the list),
+the book context already holds HighlightCard-ready highlights, and it is far less code
+(no repo/label-resolution/N+1 work, no orval regen).
+
+**Accepted trade-off:** a linked highlight that is not present in the loaded book
+chapters would not render. In practice a note can only link highlights belonging to its
+book, and the book detail loads all of them, so this should not occur; such misses are
+filtered out silently (consistent with the current soft-deleted handling).
+
+## Changes
+
+### `NoteViewModal.tsx`
+
+- Build an `id → Highlight` map from `book.chapters.flatMap((c) => c.highlights)`.
+- Map the note's displayable highlights (`activeNote.highlights`, which the backend
+  already filters to exclude soft-deleted) to their full `Highlight` objects via the map,
+  filtering out any ids not found.
+- Pass the resulting `Highlight[]` to `NoteLinkTabs` (replacing the `NoteLinkedHighlight[]`
+  it passes today).
+- `handleOpenHighlight` / `handleOpenChapter` navigation is unchanged.
+
+### `NoteLinkTabs.tsx`
+
+- Change the `highlights` prop type from `NoteLinkedHighlight[]` to `Highlight[]`.
+- Render the Highlights tab as a `<Stack component="ul">` of `HighlightCard`s (mirroring
+  `HighlightsSection`), each `<HighlightCard highlight={h} onOpenModal={onOpenHighlight} />`.
+- Remove the now-unused `formatHighlightPreview` helper, `PREVIEW_WORD_COUNT`, and the
+  `QuoteIcon` / `List` / `ListItemButton` / `ListItemText` imports (only if they become
+  unused — the Chapters tab still uses `List`/`ListItemButton`/`ListItemText`).
+- The **Chapters tab is unchanged** (still a `NoteLinkedChapter` list).
+
+### Behaviour
+
+- Clicking a highlight card calls `onOpenHighlight(id)` — navigates to the highlights
+  page deep link and the note modal closes — identical to today.
+- `HighlightCard`'s optional `bookmark` prop is omitted (no bookmark map is readily
+  available in the note modal; not essential here).
+
+## Out of scope
+
+- No backend changes; no orval regeneration.
+- Chapters tab behaviour/appearance.
+- Opening a `HighlightViewModal` in place (navigation behaviour is preserved).
+- Bookmark indicators on the cards.
+
+## Verification
+
+- `cd frontend && npm run type-check` (no errors) and `npm run lint` (`--max-warnings 0`).
+- Manual: open a note with linked highlights; the Highlights tab shows `HighlightCard`s
+  identical to the chapter detail dialog; clicking one navigates to that highlight; a note
+  with only chapters still shows just the Chapters tab.

--- a/docs/superpowers/specs/2026-07-13-notes-tag-filtering-design.md
+++ b/docs/superpowers/specs/2026-07-13-notes-tag-filtering-design.md
@@ -1,0 +1,97 @@
+# Notes: tag filtering on the notes list
+
+**Issue:** [crossbill-web#396](https://github.com/Crossbill-Highlights/crossbill-web/issues/396) — part of the Book Notes feature follow-ups (PR #389).
+
+## Goal
+
+Add tag filtering to the Notes tab, working the same way as the Highlights view's
+tag filtering. The user can filter the notes list by a single highlight tag, with
+identical interaction/UX to the existing Highlights and Flashcards filters on both
+desktop and mobile, reusing the existing tag-filter components.
+
+## Context
+
+- Notes filtering is already **server-side**: the list endpoint accepts
+  `GET /api/v1/books/{book_id}/notes?highlight_tag_id=<id>`, exposed as the
+  `highlight_tag_id` param on `useGetNotesForBookApiV1BooksBookIdNotesGet`.
+- The notes route (`src/routes/book.$bookId/notes.tsx`) already validates a `tagId`
+  search param, and `NotesPage` already threads it into the query params.
+- `BookPageContext` exposes `isDesktop`, `leftSidebarEl`, and `fabContainerEl` — the
+  same layout hooks the Flashcards view uses for its desktop sidebar and mobile
+  filter drawer. `NotesPage` currently leaves both portals empty.
+- Reusable components already exist:
+  - `HighlightTagsList` (`src/pages/BookPage/navigation/HighlightTagsList.tsx`) —
+    the tag list with grouping, drag-to-organize, `selectedTag` / `onTagClick`,
+    and `hideTitle` / `hideEmptyGroups` props.
+  - `FilterDrawer` / `FilterTab` (`src/pages/BookPage/navigation/FilterDrawer.tsx`).
+  - `FilterFab` (`src/pages/BookPage/common/FilterFab.tsx`).
+
+**Closest analog:** `FlashcardsPage` — it wires all of the above together. The main
+difference is that Flashcards filters client-side while Notes filters server-side,
+which simplifies the Notes work: the selected tag only needs to flow into the
+`tagId` search param and the query re-fetches automatically.
+
+## Decisions
+
+- **Single-tag selection** — matches the existing Highlights/Flashcards UX (one
+  active tag at a time) and the backend's single `highlight_tag_id` param. No
+  multi-select.
+- **All book tags shown** — pass `book.highlight_tags` / `book.highlight_tag_groups`
+  with `hideEmptyGroups`, same as the Highlights view. No extra query to compute
+  which tags have notes.
+
+## Design
+
+### State & URL (in `NotesPage`)
+
+- Add `selectedTagId` state, initialized from the `tagId` search param, kept in sync
+  via `useEffect` on `tagId` (same pattern as `FlashcardsPage`).
+- Add a `handleTagClick(newTagId: number | null)` callback that sets the state and
+  writes the URL:
+  `navigate({ search: (prev) => ({ ...prev, tagId: newTagId || undefined }), replace: true })`.
+- Feed `selectedTagId` into `params.highlight_tag_id` (replacing the direct read of
+  `tagId`), so the notes query re-fetches when the selection changes.
+
+### Desktop
+
+Portal a small sidebar component (leading `Divider` + `HighlightTagsList`) into
+`leftSidebarEl`, guarded by `isDesktop && leftSidebarEl`, mirroring `FlashcardsSidebar`:
+
+```
+<HighlightTagsList
+  tags={book.highlight_tags}
+  tagGroups={book.highlight_tag_groups}
+  bookId={book.id}
+  selectedTag={selectedTagId}
+  onTagClick={handleTagClick}
+  hideEmptyGroups
+/>
+```
+
+### Mobile
+
+- Portal a `FilterFab` into `fabContainerEl` (guarded by `fabContainerEl` and rendered
+  in the non-desktop branch), with `filterEnabled={!!selectedTagId}`, opening a
+  `FilterDrawer`.
+- The drawer has a **single "Tags" tab** rendering `HighlightTagsList` with
+  `hideTitle` and `hideEmptyGroups`. Selecting a tag applies it via `handleTagClick`
+  and closes the drawer. (Unlike Flashcards, Notes has no chapter-nav sidebar today,
+  so there is only the one tab.)
+
+### Empty state
+
+When a tag is selected but the filtered result is empty, show a tag-aware message
+("No notes found with the selected tag.") instead of the generic "No notes yet…".
+
+## Out of scope
+
+- Multi-tag selection.
+- Chapter filtering changes (the `chapterId` param is untouched).
+- Any backend work — the endpoint and search param already exist.
+
+## Testing / verification
+
+- `cd frontend && npm run type-check` and `npm run lint` pass.
+- Manual: on a book with tagged highlights and notes, selecting a tag (desktop
+  sidebar and mobile drawer) filters the notes list and updates the URL; clearing it
+  restores the full list; deep-linking with `?tagId=` pre-selects the tag.

--- a/frontend/src/pages/BookPage/Notes/NoteViewModal.tsx
+++ b/frontend/src/pages/BookPage/Notes/NoteViewModal.tsx
@@ -1,3 +1,4 @@
+import type { Highlight } from '@/api/generated/model';
 import {
   getGetNotesForBookApiV1BooksBookIdNotesGetQueryKey,
   useDeleteNoteApiV1NotesNoteIdDelete,
@@ -13,7 +14,7 @@ import { markdownStyles } from '@/theme/theme';
 import { Box, Button, Chip, Stack, Typography, useTheme } from '@mui/material';
 import { useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
-import { useRef, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 
 import { NoteEditorForm, type NoteEditorFormHandle } from './NoteEditorForm';
@@ -98,7 +99,20 @@ export const NoteViewModal = ({ noteId, onClose }: NoteViewModalProps) => {
 
   const chapters = activeNote?.chapters ?? [];
   const highlightTags = activeNote?.highlight_tags ?? [];
-  const highlights = activeNote?.highlights ?? [];
+  // The note detail returns lightweight highlight summaries; resolve them to the
+  // full Highlight objects already loaded on the book so we can render HighlightCard.
+  const highlights = useMemo<Highlight[]>(() => {
+    if (!activeNote?.highlights?.length) return [];
+    const byId = new Map<number, Highlight>();
+    for (const chapter of book.chapters) {
+      for (const highlight of chapter.highlights) {
+        byId.set(highlight.id, highlight);
+      }
+    }
+    return activeNote.highlights
+      .map((summary) => byId.get(summary.id))
+      .filter((highlight): highlight is Highlight => highlight !== undefined);
+  }, [book.chapters, activeNote]);
 
   const footerActions = isEditing ? (
     <Box sx={{ display: 'flex', gap: 1, width: '100%', justifyContent: 'flex-end' }}>

--- a/frontend/src/pages/BookPage/Notes/NotesPage.tsx
+++ b/frontend/src/pages/BookPage/Notes/NotesPage.tsx
@@ -3,9 +3,22 @@ import { useGetNotesForBookApiV1BooksBookIdNotesGet } from '@/api/generated/note
 import { Spinner } from '@/components/animations/Spinner.tsx';
 import { useBookPage } from '@/pages/BookPage/BookPageContext';
 import { AddIcon } from '@/theme/Icons.tsx';
-import { Box, Button, Stack, ToggleButton, ToggleButtonGroup, Typography } from '@mui/material';
+import {
+  Box,
+  Button,
+  Divider,
+  Stack,
+  ToggleButton,
+  ToggleButtonGroup,
+  Typography,
+} from '@mui/material';
 import { useNavigate, useSearch } from '@tanstack/react-router';
+import { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
 
+import { FilterFab } from '../common/FilterFab.tsx';
+import { FilterDrawer, type FilterTab } from '../navigation/FilterDrawer.tsx';
+import { HighlightTagsList } from '../navigation/HighlightTagsList.tsx';
 import { NoteCard } from './NoteCard';
 import { NoteModals } from './NoteModals';
 import { useNoteModals } from './hooks/useNoteModals';
@@ -32,14 +45,21 @@ const NoteKindFilter = ({ value, onChange }: NoteKindFilterProps) => (
 );
 
 export const NotesPage = () => {
-  const { book } = useBookPage();
+  const { book, isDesktop, leftSidebarEl, fabContainerEl } = useBookPage();
   const navigate = useNavigate({ from: '/book/$bookId/notes' });
   const { kind, chapterId, tagId } = useSearch({ from: '/book/$bookId/notes' });
+
+  const [selectedTagId, setSelectedTagId] = useState<number | undefined>(tagId);
+  const [filterDrawerOpen, setFilterDrawerOpen] = useState(false);
+
+  useEffect(() => {
+    setSelectedTagId(tagId);
+  }, [tagId]);
 
   const params: GetNotesForBookApiV1BooksBookIdNotesGetParams = {
     kind: (kind as NoteKindValue | undefined) ?? undefined,
     chapter_id: chapterId,
-    highlight_tag_id: tagId,
+    highlight_tag_id: selectedTagId,
   };
   const { data, isLoading, isError } = useGetNotesForBookApiV1BooksBookIdNotesGet(book.id, params);
   const noteModals = useNoteModals();
@@ -48,12 +68,57 @@ export const NotesPage = () => {
     void navigate({ search: (prev) => ({ ...prev, kind: value ?? undefined }) });
   };
 
+  const handleTagClick = (newTagId: number | null) => {
+    setSelectedTagId(newTagId || undefined);
+    void navigate({
+      search: (prev) => ({ ...prev, tagId: newTagId || undefined }),
+      replace: true,
+    });
+  };
+
   // NOTE: the orval axios mutator unwraps the response (`.then(({ data }) => data)`),
   // so the generated GET hook's `data` is the payload itself, not an AxiosResponse.
   const notes = data?.notes ?? [];
 
+  const filterTabs: FilterTab[] = [
+    {
+      label: 'Tags',
+      content: (
+        <HighlightTagsList
+          tags={book.highlight_tags}
+          tagGroups={book.highlight_tag_groups}
+          bookId={book.id}
+          selectedTag={selectedTagId}
+          onTagClick={(id) => {
+            handleTagClick(id);
+            setFilterDrawerOpen(false);
+          }}
+          hideTitle
+          hideEmptyGroups
+        />
+      ),
+    },
+  ];
+
   return (
     <Box>
+      {isDesktop &&
+        leftSidebarEl &&
+        createPortal(
+          <>
+            <Divider sx={{ mb: 4 }} />
+            <HighlightTagsList
+              tags={book.highlight_tags}
+              tagGroups={book.highlight_tag_groups}
+              bookId={book.id}
+              selectedTag={selectedTagId}
+              onTagClick={handleTagClick}
+              hideEmptyGroups
+            />
+          </>,
+          leftSidebarEl
+        )}
+
       <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 2, flexWrap: 'wrap' }}>
         <NoteKindFilter
           value={(kind as NoteKindValue | undefined) ?? null}
@@ -69,7 +134,9 @@ export const NotesPage = () => {
       {isError && <Typography color="error">Failed to load notes.</Typography>}
       {!isLoading && !isError && notes.length === 0 && (
         <Typography color="text.secondary">
-          No notes yet. Create notes about characters, terms, and concepts as you read.
+          {selectedTagId
+            ? 'No notes found with the selected tag.'
+            : 'No notes yet. Create notes about characters, terms, and concepts as you read.'}
         </Typography>
       )}
 
@@ -80,6 +147,20 @@ export const NotesPage = () => {
           </li>
         ))}
       </Stack>
+
+      {!isDesktop &&
+        fabContainerEl &&
+        createPortal(
+          <FilterFab filterEnabled={!!selectedTagId} onClick={() => setFilterDrawerOpen(true)} />,
+          fabContainerEl
+        )}
+      {!isDesktop && (
+        <FilterDrawer
+          open={filterDrawerOpen}
+          onClose={() => setFilterDrawerOpen(false)}
+          tabs={filterTabs}
+        />
+      )}
 
       <NoteModals controller={noteModals} />
     </Box>

--- a/frontend/src/pages/BookPage/Notes/components/NoteLinkTabs.tsx
+++ b/frontend/src/pages/BookPage/Notes/components/NoteLinkTabs.tsx
@@ -1,10 +1,10 @@
-import type { NoteLinkedChapter, NoteLinkedHighlight } from '@/api/generated/model';
-import { QuoteIcon } from '@/theme/Icons.tsx';
-import { Box, List, ListItemButton, ListItemText, Tab, Tabs } from '@mui/material';
+import type { Highlight, NoteLinkedChapter } from '@/api/generated/model';
+import { HighlightCard } from '@/pages/BookPage/Highlights/HighlightCard.tsx';
+import { Box, List, ListItemButton, ListItemText, Stack, Tab, Tabs } from '@mui/material';
 import { type ReactElement, useState } from 'react';
 
 interface NoteLinkTabsProps {
-  highlights: NoteLinkedHighlight[];
+  highlights: Highlight[];
   chapters: NoteLinkedChapter[];
   onOpenHighlight: (highlightId: number) => void;
   onOpenChapter: (chapterId: number) => void;
@@ -13,28 +13,11 @@ interface NoteLinkTabsProps {
 const formatTabLabel = (label: string, count: number) =>
   count > 0 ? `${label} (${count})` : label;
 
-const PREVIEW_WORD_COUNT = 30;
-
 /**
- * Preview a highlight's text like `HighlightCard`: prepend `...` when it starts
- * mid-sentence (lowercase) and append `...` when truncated to the preview length.
- */
-const formatHighlightPreview = (text: string) => {
-  const startsWithLowercase =
-    text.length > 0 && text[0] === text[0].toLowerCase() && text[0] !== text[0].toUpperCase();
-  const withLeadingEllipsis = startsWithLowercase ? `...${text}` : text;
-
-  const words = withLeadingEllipsis.split(/\s+/);
-  return words.length > PREVIEW_WORD_COUNT
-    ? words.slice(0, PREVIEW_WORD_COUNT).join(' ') + '...'
-    : withLeadingEllipsis;
-};
-
-/**
- * Tabs listing a note's linked entities (highlights, chapters) as clickable
- * rows. Each row navigates to the target entity via its deep link. Only tabs
- * whose entity type has items are rendered, mirroring `ChapterDetailDialog`'s
- * tabbed composition.
+ * Tabs listing a note's linked entities (highlights, chapters). The Highlights
+ * tab reuses the shared `HighlightCard`; the Chapters tab lists clickable rows.
+ * Only tabs whose entity type has items are rendered, mirroring
+ * `ChapterDetailDialog`'s tabbed composition.
  */
 export const NoteLinkTabs = ({
   highlights,
@@ -47,20 +30,13 @@ export const NoteLinkTabs = ({
       key: 'highlights',
       label: formatTabLabel('Highlights', highlights.length),
       content: (
-        <List disablePadding>
+        <Stack component="ul" sx={{ gap: 2, listStyle: 'none', p: 0, m: 0 }}>
           {highlights.map((highlight) => (
-            <ListItemButton
-              key={highlight.id}
-              onClick={() => onOpenHighlight(highlight.id)}
-              sx={{ alignItems: 'start', gap: 1.5 }}
-            >
-              <QuoteIcon
-                sx={{ fontSize: 20, color: 'primary.main', flexShrink: 0, mt: 0.3, opacity: 0.7 }}
-              />
-              <ListItemText primary={formatHighlightPreview(highlight.text)} />
-            </ListItemButton>
+            <li key={highlight.id}>
+              <HighlightCard highlight={highlight} onOpenModal={onOpenHighlight} />
+            </li>
           ))}
-        </List>
+        </Stack>
       ),
     },
     chapters.length > 0 && {


### PR DESCRIPTION
Two related follow-ups to the Book Notes feature, both scoped to the Notes tab. No backend changes.

## 1. Tag filtering on the notes list (#396)
Adds single-tag filtering to the Notes tab, matching the Highlights/Flashcards tag-filter UX on both desktop and mobile.

- Reuses `HighlightTagsList` in a desktop left-sidebar portal and a mobile `FilterFab` + `FilterDrawer` (same components as the Highlights/Flashcards views).
- Selection is synced to the `tagId` URL search param and feeds the existing server-side `highlight_tag_id` filter — deep-linkable via `?tagId=`.
- Shows all book tags (with `hideEmptyGroups`); tag-aware empty state.
- Single-tag selection, matching the existing highlights UX and the single-value backend param.

## 2. Reuse `HighlightCard` in the note detail (#396 follow-up)
The note detail modal's Highlights tab now renders the shared `HighlightCard` (as the chapter detail dialog does) instead of a bespoke list.

- Full `Highlight` objects are resolved on the frontend from the already-loaded book context (`book.chapters[].highlights`) by id — no backend change, no payload growth.
- Click-to-navigate behavior and the Chapters tab are unchanged.

## Verification
- `frontend`: `npm run type-check` and `npm run lint` (`--max-warnings 0`) both clean.
- Frontend has no test framework; changes verified via type-check, lint, and manual review.

Design specs and implementation plans are included under `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
