### PR TITLE
Mobile nav: group Flashcards & Sessions under a "More" menu (#397)

### DIFF
--- a/frontend/src/pages/BookPage/navigation/MobileBottomNav.tsx
+++ b/frontend/src/pages/BookPage/navigation/MobileBottomNav.tsx
@@ -1,6 +1,21 @@
-import { BottomNavigation, BottomNavigationAction, Paper } from '@mui/material';
+import { MoreIcon } from '@/theme/Icons.tsx';
+import {
+  BottomNavigation,
+  BottomNavigationAction,
+  ListItemIcon,
+  ListItemText,
+  Menu,
+  MenuItem,
+  Paper,
+} from '@mui/material';
 import { useNavigate, useParams, useRouterState } from '@tanstack/react-router';
+import { useState } from 'react';
 import { BOOK_PAGE_ROUTES } from './bookPageRoutes.ts';
+
+const MORE_VALUE = 'more';
+
+const PRIMARY_ROUTES = BOOK_PAGE_ROUTES.filter((route) => !route.overflow);
+const OVERFLOW_ROUTES = BOOK_PAGE_ROUTES.filter((route) => route.overflow);
 
 const getActivePage = (pathname: string): string => {
   const match = BOOK_PAGE_ROUTES.find((route) => pathname.includes(`/${route.segment}`));
@@ -12,14 +27,32 @@ export const MobileBottomNav = () => {
   const { location } = useRouterState();
   const navigate = useNavigate();
 
-  const activePage = getActivePage(location.pathname);
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+  const menuOpen = Boolean(anchorEl);
 
-  const handleChange = (_event: React.SyntheticEvent, newValue: string) => {
+  const activePage = getActivePage(location.pathname);
+  const isOverflowActive = OVERFLOW_ROUTES.some((route) => route.segment === activePage);
+  // Highlight the "More" tab whenever the active destination lives in the menu.
+  const bottomNavValue = isOverflowActive ? MORE_VALUE : activePage;
+
+  const goToSegment = (segment: string) => {
     void navigate({
-      to: `/book/$bookId/${newValue}`,
+      to: `/book/$bookId/${segment}`,
       params: { bookId: bookId! },
       replace: true,
     });
+  };
+
+  const handleChange = (_event: React.SyntheticEvent, newValue: string) => {
+    // The "More" tab opens the overflow menu (handled by its onClick) rather
+    // than navigating anywhere itself.
+    if (newValue === MORE_VALUE) return;
+    goToSegment(newValue);
+  };
+
+  const handleOverflowSelect = (segment: string) => {
+    setAnchorEl(null);
+    goToSegment(segment);
   };
 
   return (
@@ -34,8 +67,8 @@ export const MobileBottomNav = () => {
         pb: 'env(safe-area-inset-bottom)',
       }}
     >
-      <BottomNavigation value={activePage} onChange={handleChange} showLabels>
-        {BOOK_PAGE_ROUTES.map((route) => {
+      <BottomNavigation value={bottomNavValue} onChange={handleChange} showLabels>
+        {PRIMARY_ROUTES.map((route) => {
           const Icon = route.icon;
           return (
             <BottomNavigationAction
@@ -46,7 +79,36 @@ export const MobileBottomNav = () => {
             />
           );
         })}
+        <BottomNavigationAction
+          value={MORE_VALUE}
+          label="More"
+          icon={<MoreIcon />}
+          onClick={(event) => setAnchorEl(event.currentTarget)}
+        />
       </BottomNavigation>
+      <Menu
+        anchorEl={anchorEl}
+        open={menuOpen}
+        onClose={() => setAnchorEl(null)}
+        anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
+        transformOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+      >
+        {OVERFLOW_ROUTES.map((route) => {
+          const Icon = route.icon;
+          return (
+            <MenuItem
+              key={route.segment}
+              selected={route.segment === activePage}
+              onClick={() => handleOverflowSelect(route.segment)}
+            >
+              <ListItemIcon>
+                <Icon fontSize="small" />
+              </ListItemIcon>
+              <ListItemText>{route.label}</ListItemText>
+            </MenuItem>
+          );
+        })}
+      </Menu>
     </Paper>
   );
 };

--- a/frontend/src/pages/BookPage/navigation/bookPageRoutes.ts
+++ b/frontend/src/pages/BookPage/navigation/bookPageRoutes.ts
@@ -19,6 +19,12 @@ export interface BookPageRouteConfig {
   segment: string;
   label: string;
   icon: SvgIconComponent;
+  /**
+   * When true, the route is tucked into the "More" overflow menu on the mobile
+   * bottom navigation instead of getting a top-level tab. Desktop nav shows all
+   * routes regardless.
+   */
+  overflow?: boolean;
 }
 
 export const BOOK_PAGE_ROUTES: BookPageRouteConfig[] = [
@@ -39,6 +45,7 @@ export const BOOK_PAGE_ROUTES: BookPageRouteConfig[] = [
     segment: 'flashcards',
     label: 'Flashcards',
     icon: FlashcardsIcon,
+    overflow: true,
   },
   {
     to: '/book/$bookId/notes',
@@ -51,5 +58,6 @@ export const BOOK_PAGE_ROUTES: BookPageRouteConfig[] = [
     segment: 'sessions',
     label: 'Sessions',
     icon: ReadingSessionIcon,
+    overflow: true,
   },
 ];

--- a/frontend/src/theme/Icons.tsx
+++ b/frontend/src/theme/Icons.tsx
@@ -12,6 +12,7 @@ export {
   ExpandMore as ExpandMoreIcon,
   FilterList as FilterListIcon,
   Menu as MenuIcon,
+  MoreHoriz as MoreIcon,
   KeyboardArrowUp as ScrollToTopIcon,
 } from '@mui/icons-material';
 


### PR DESCRIPTION
## Summary
The mobile bottom navigation showed all five book-page tabs (Structure, Highlights, Flashcards, Notes, Sessions), which crowds small screens. This groups the two less-frequently-used destinations — **Flashcards** and **Sessions** — behind a **"More"** overflow menu, keeping the top-level bar to Structure · Highlights · Notes · More.

## Changes
- **`bookPageRoutes.ts`** — add an `overflow?` flag; set it on Flashcards & Sessions.
- **`MobileBottomNav.tsx`** — render primary routes as top-level tabs plus a "More" action that opens an MUI `Menu` with the overflow routes. The "More" tab is highlighted whenever an overflow destination is active. The menu is right-anchored and opens upward so it stays within the viewport above the bottom bar.
- **`Icons.tsx`** — export `MoreIcon` (`MoreHoriz`) for the overflow action.

Desktop nav (`DesktopNavLinks`) iterates all routes and is **unaffected**.

## Verification
Rendered the real `MobileBottomNav` in headless chromium (real router + app theme) since a live book page needs auth/seed data:
- Primary bar shows Structure · Highlights · Notes · More; Flashcards & Sessions removed from top level.
- On an overflow route (e.g. Sessions), the "More" tab is highlighted while others are muted.
- Opening "More" shows a menu containing exactly `["Flashcards", "Sessions"]`, fully within the viewport (`onScreen=true`) and opening upward above the bottom bar.
- `type-check` and `eslint` pass.

Fixes #397

🤖 Generated with [Claude Code](https://claude.com/claude-code)