### PR TITLE
Fix: highlight note not appearing immediately after save

### DIFF
--- a/frontend/src/pages/BookPage/Highlights/HighlightViewModal/components/HighlightNote.tsx
+++ b/frontend/src/pages/BookPage/Highlights/HighlightViewModal/components/HighlightNote.tsx
@@ -1,5 +1,13 @@
 import { getGetBookDetailsApiV1BooksBookIdGetQueryKey } from '@/api/generated/books/books.ts';
-import { useUpdateHighlightNoteApiV1HighlightsHighlightIdNotePost } from '@/api/generated/highlights/highlights.ts';
+import {
+  getSearchBookHighlightsApiV1BooksBookIdHighlightsGetQueryKey,
+  useUpdateHighlightNoteApiV1HighlightsHighlightIdNotePost,
+} from '@/api/generated/highlights/highlights.ts';
+import type {
+  BookDetails,
+  BookHighlightSearchResponse,
+  ChapterWithHighlights,
+} from '@/api/generated/model';
 import { Collapsable } from '@/components/animations/Collapsable.tsx';
 import { useSnackbar } from '@/context/SnackbarContext.tsx';
 import { Box, Button, TextField, Typography } from '@mui/material';
@@ -61,6 +69,27 @@ export const HighlightNote = ({
   );
 };
 
+/**
+ * Return a copy of `chapters` with the note of the given highlight replaced.
+ * The chapter/highlight objects are only cloned along the affected path so
+ * downstream memoized selectors recompute for the changed highlight.
+ */
+const withPatchedHighlightNote = (
+  chapters: ChapterWithHighlights[],
+  highlightId: number,
+  note: string | null
+): ChapterWithHighlights[] =>
+  chapters.map((chapter) =>
+    chapter.highlights.some((highlight) => highlight.id === highlightId)
+      ? {
+          ...chapter,
+          highlights: chapter.highlights.map((highlight) =>
+            highlight.id === highlightId ? { ...highlight, note } : highlight
+          ),
+        }
+      : chapter
+  );
+
 const useNoteMutations = (
   bookId: number,
   highlightId: number,
@@ -71,7 +100,30 @@ const useNoteMutations = (
 
   const updateNoteMutation = useUpdateHighlightNoteApiV1HighlightsHighlightIdNotePost({
     mutation: {
-      onSuccess: () => {
+      onSuccess: (response) => {
+        const note = response.highlight.note ?? null;
+
+        // Update the cached highlight in place so the new note shows immediately
+        // in every view (highlight cards, the modal's highlight data) without
+        // waiting for a refetch. The modal can be driven either by the book
+        // details query or by the search query, so patch both.
+        queryClient.setQueryData<BookDetails>(
+          getGetBookDetailsApiV1BooksBookIdGetQueryKey(bookId),
+          (old) =>
+            old
+              ? { ...old, chapters: withPatchedHighlightNote(old.chapters, highlightId, note) }
+              : old
+        );
+        queryClient.setQueriesData<BookHighlightSearchResponse>(
+          { queryKey: getSearchBookHighlightsApiV1BooksBookIdHighlightsGetQueryKey(bookId) },
+          (old) =>
+            old
+              ? { ...old, chapters: withPatchedHighlightNote(old.chapters, highlightId, note) }
+              : old
+        );
+
+        // Keep the server as the source of truth for anything the in-place
+        // patch didn't cover.
         void queryClient.invalidateQueries({
           queryKey: getGetBookDetailsApiV1BooksBookIdGetQueryKey(bookId),
         });


### PR DESCRIPTION
The inline Note section in the Highlight dialog only synced its change via
invalidateQueries(bookDetails), which (a) waited for a network refetch before
the note propagated to the highlight cards and the modal's highlight data, and
(b) never touched the search-highlights query, so the note stayed stale when
the modal was opened from search results.

Patch the updated highlight's note into the book-details and search caches in
place from the mutation response so it shows immediately everywhere, keeping
the book-details invalidation as an eventual-consistency fallback.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012u5VArRUa5Az6KWgQ9ia1z