### PR TITLE
Add unlinking of note links to highlights and chapters

### DIFF
--- a/frontend/src/components/buttons/IconButtonWithTooltip.tsx
+++ b/frontend/src/components/buttons/IconButtonWithTooltip.tsx
@@ -1,4 +1,4 @@
-import { IconButton, Tooltip } from '@mui/material';
+import { IconButton, Tooltip, type IconButtonProps } from '@mui/material';
 import type { ReactNode } from 'react';
 
 interface IconButtonWithTooltipProps {
@@ -7,6 +7,8 @@ interface IconButtonWithTooltipProps {
   disabled?: boolean;
   ariaLabel?: string;
   icon: ReactNode;
+  edge?: IconButtonProps['edge'];
+  sx?: IconButtonProps['sx'];
 }
 
 export const IconButtonWithTooltip = ({
@@ -15,10 +17,19 @@ export const IconButtonWithTooltip = ({
   disabled,
   ariaLabel,
   icon,
+  edge,
+  sx,
 }: IconButtonWithTooltipProps) => {
   return (
     <Tooltip title={title}>
-      <IconButton onClick={onClick} disabled={disabled} aria-label={ariaLabel} size="small">
+      <IconButton
+        onClick={onClick}
+        disabled={disabled}
+        aria-label={ariaLabel}
+        size="small"
+        edge={edge}
+        sx={sx}
+      >
         {icon}
       </IconButton>
     </Tooltip>

--- a/frontend/src/components/buttons/UnlinkButton.tsx
+++ b/frontend/src/components/buttons/UnlinkButton.tsx
@@ -1,0 +1,31 @@
+import { IconButtonWithTooltip } from '@/components/buttons/IconButtonWithTooltip.tsx';
+import { LinkOffIcon } from '@/theme/Icons.tsx';
+import type { IconButtonProps } from '@mui/material';
+
+interface UnlinkButtonProps {
+  /** Tooltip text; also used as the accessible name. */
+  title: string;
+  onClick: () => void;
+  disabled?: boolean;
+  edge?: IconButtonProps['edge'];
+  sx?: IconButtonProps['sx'];
+}
+
+/**
+ * Icon button for removing an entity link. Stops click propagation so it can
+ * sit inside clickable cards and rows without triggering their own onClick.
+ */
+export const UnlinkButton = ({ title, onClick, disabled = false, edge, sx }: UnlinkButtonProps) => (
+  <IconButtonWithTooltip
+    title={title}
+    ariaLabel={title}
+    disabled={disabled}
+    edge={edge}
+    sx={sx}
+    onClick={(event) => {
+      event.stopPropagation();
+      onClick();
+    }}
+    icon={<LinkOffIcon fontSize="small" />}
+  />
+);

--- a/frontend/src/pages/BookPage/Highlights/HighlightViewModal/components/HighlightNotesSection.tsx
+++ b/frontend/src/pages/BookPage/Highlights/HighlightViewModal/components/HighlightNotesSection.tsx
@@ -1,18 +1,13 @@
-import type { Highlight, NoteUpdateRequest, NoteWithLinks } from '@/api/generated/model';
-import {
-  getGetNotesForBookApiV1BooksBookIdNotesGetQueryKey,
-  useUpdateNoteApiV1NotesNoteIdPut,
-} from '@/api/generated/notes/notes.ts';
+import type { Highlight, NoteWithLinks } from '@/api/generated/model';
 import { Spinner } from '@/components/animations/Spinner.tsx';
-import { useSnackbar } from '@/context/SnackbarContext.tsx';
 import { NoteCard } from '@/pages/BookPage/Notes/NoteCard';
 import { NoteModals } from '@/pages/BookPage/Notes/NoteModals';
+import { NotePickerDialog } from '@/pages/BookPage/Notes/components/NotePickerDialog.tsx';
+import { useNoteLinks } from '@/pages/BookPage/Notes/hooks/useNoteLinks';
 import { useNoteModals } from '@/pages/BookPage/Notes/hooks/useNoteModals';
-import { AddIcon, LinkIcon } from '@/theme/Icons.tsx';
-import { Box, Button, Stack, Typography } from '@mui/material';
-import { useQueryClient } from '@tanstack/react-query';
+import { AddIcon, LinkIcon, LinkOffIcon } from '@/theme/Icons.tsx';
+import { Box, Button, IconButton, Stack, Tooltip, Typography } from '@mui/material';
 import { useState } from 'react';
-import { NotePickerDialog } from './NotePickerDialog.tsx';
 
 interface HighlightNotesSectionProps {
   highlight: Highlight;
@@ -25,9 +20,9 @@ interface HighlightNotesSectionProps {
 
 /**
  * Notes tab of the highlight modal: lists notes linked to the highlight and
- * offers creating a new pre-linked note or linking an existing one. Creating
- * and linking both invalidate the notes-for-book query (prefix match), so the
- * filtered list here refreshes immediately.
+ * offers creating a new pre-linked note, linking an existing one, or removing
+ * a link. Link changes invalidate the notes-for-book query (prefix match), so
+ * the filtered list here refreshes immediately.
  */
 export const HighlightNotesSection = ({
   highlight,
@@ -36,40 +31,11 @@ export const HighlightNotesSection = ({
   isLoading,
   disabled = false,
 }: HighlightNotesSectionProps) => {
-  const queryClient = useQueryClient();
-  const { showSnackbar } = useSnackbar();
   const noteModals = useNoteModals({ syncToUrl: false });
   const [pickerOpen, setPickerOpen] = useState(false);
+  const noteLinks = useNoteLinks({ bookId });
 
-  const updateNoteMutation = useUpdateNoteApiV1NotesNoteIdPut({
-    mutation: {
-      onSuccess: () => {
-        void queryClient.invalidateQueries({
-          queryKey: getGetNotesForBookApiV1BooksBookIdNotesGetQueryKey(bookId),
-        });
-        setPickerOpen(false);
-        showSnackbar('Highlight added to note.', 'success');
-      },
-      onError: (error: Error) => {
-        console.error('Failed to add highlight to note:', error);
-        showSnackbar('Failed to add highlight to note. Please try again.', 'error');
-      },
-    },
-  });
-
-  const handleAddToExistingNote = async (note: NoteWithLinks) => {
-    const payload: NoteUpdateRequest = {
-      title: note.title,
-      body: note.body,
-      kind: note.kind as NoteUpdateRequest['kind'],
-      chapter_ids: note.chapter_ids,
-      highlight_ids: [...new Set([...note.highlight_ids, highlight.id])],
-      tag_ids: note.tag_ids,
-    };
-    await updateNoteMutation.mutateAsync({ noteId: note.id, data: payload });
-  };
-
-  const isDisabled = disabled || updateNoteMutation.isPending;
+  const isDisabled = disabled || noteLinks.isPending;
 
   return (
     <Box>
@@ -100,7 +66,25 @@ export const HighlightNotesSection = ({
       <Stack component="ul" sx={{ gap: 2, listStyle: 'none', p: 0, m: 0 }}>
         {notes.map((note) => (
           <li key={note.id}>
-            <NoteCard note={note} onClick={() => noteModals.openView(note)} />
+            <NoteCard
+              note={note}
+              onClick={() => noteModals.openView(note)}
+              action={
+                <Tooltip title="Unlink from highlight">
+                  <IconButton
+                    aria-label="Unlink note"
+                    size="small"
+                    disabled={isDisabled}
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      noteLinks.unlinkHighlight(note, highlight.id);
+                    }}
+                  >
+                    <LinkOffIcon fontSize="small" />
+                  </IconButton>
+                </Tooltip>
+              }
+            />
           </li>
         ))}
       </Stack>
@@ -113,7 +97,10 @@ export const HighlightNotesSection = ({
         open={pickerOpen}
         onClose={() => setPickerOpen(false)}
         bookId={bookId}
-        onSelect={(note) => void handleAddToExistingNote(note)}
+        title="Add highlight to note"
+        onSelect={(note) =>
+          noteLinks.linkHighlight(note, highlight.id, { onSuccess: () => setPickerOpen(false) })
+        }
       />
     </Box>
   );

--- a/frontend/src/pages/BookPage/Highlights/HighlightViewModal/components/HighlightNotesSection.tsx
+++ b/frontend/src/pages/BookPage/Highlights/HighlightViewModal/components/HighlightNotesSection.tsx
@@ -1,12 +1,13 @@
 import type { Highlight, NoteWithLinks } from '@/api/generated/model';
 import { Spinner } from '@/components/animations/Spinner.tsx';
+import { UnlinkButton } from '@/components/buttons/UnlinkButton.tsx';
 import { NoteCard } from '@/pages/BookPage/Notes/NoteCard';
 import { NoteModals } from '@/pages/BookPage/Notes/NoteModals';
 import { NotePickerDialog } from '@/pages/BookPage/Notes/components/NotePickerDialog.tsx';
 import { useNoteLinks } from '@/pages/BookPage/Notes/hooks/useNoteLinks';
 import { useNoteModals } from '@/pages/BookPage/Notes/hooks/useNoteModals';
-import { AddIcon, LinkIcon, LinkOffIcon } from '@/theme/Icons.tsx';
-import { Box, Button, IconButton, Stack, Tooltip, Typography } from '@mui/material';
+import { AddIcon, LinkIcon } from '@/theme/Icons.tsx';
+import { Box, Button, Stack, Typography } from '@mui/material';
 import { useState } from 'react';
 
 interface HighlightNotesSectionProps {
@@ -70,19 +71,11 @@ export const HighlightNotesSection = ({
               note={note}
               onClick={() => noteModals.openView(note)}
               action={
-                <Tooltip title="Unlink from highlight">
-                  <IconButton
-                    aria-label="Unlink note"
-                    size="small"
-                    disabled={isDisabled}
-                    onClick={(event) => {
-                      event.stopPropagation();
-                      noteLinks.unlinkHighlight(note, highlight.id);
-                    }}
-                  >
-                    <LinkOffIcon fontSize="small" />
-                  </IconButton>
-                </Tooltip>
+                <UnlinkButton
+                  title="Unlink from highlight"
+                  disabled={isDisabled}
+                  onClick={() => noteLinks.unlinkHighlight(note, highlight.id)}
+                />
               }
             />
           </li>

--- a/frontend/src/pages/BookPage/Notes/NoteCard.tsx
+++ b/frontend/src/pages/BookPage/Notes/NoteCard.tsx
@@ -1,6 +1,7 @@
 import type { NoteWithLinks } from '@/api/generated/model';
 import { markdownStyles } from '@/theme/theme';
 import { Box, Chip, Stack, styled, Typography, useTheme } from '@mui/material';
+import type { ReactNode } from 'react';
 import ReactMarkdown from 'react-markdown';
 
 import { NOTE_KIND_LABELS, type NoteKindValue } from './noteKinds';
@@ -8,6 +9,11 @@ import { NOTE_KIND_LABELS, type NoteKindValue } from './noteKinds';
 interface NoteCardProps {
   note: NoteWithLinks;
   onClick: () => void;
+  /**
+   * Right-aligned action in the title row (e.g. an unlink button). The whole
+   * card is clickable, so the action must stopPropagation on its own click.
+   */
+  action?: ReactNode;
 }
 
 const NoteStyled = styled(Box)(({ theme }) => ({
@@ -26,7 +32,7 @@ const NoteStyled = styled(Box)(({ theme }) => ({
   },
 }));
 
-export const NoteCard = ({ note, onClick }: NoteCardProps) => {
+export const NoteCard = ({ note, onClick, action }: NoteCardProps) => {
   const theme = useTheme();
 
   return (
@@ -35,15 +41,20 @@ export const NoteCard = ({ note, onClick }: NoteCardProps) => {
       tabIndex={0}
       onClick={onClick}
       onKeyDown={(event) => {
+        // Ignore keys bubbling from the action button — only the card itself.
+        if (event.target !== event.currentTarget) return;
         if (event.key === 'Enter' || event.key === ' ') {
           event.preventDefault();
           onClick();
         }
       }}
     >
-      <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 0.5 }}>
-        <Typography variant="h3">{note.title}</Typography>
-        {note.kind && <Chip size="small" label={NOTE_KIND_LABELS[note.kind as NoteKindValue]} />}
+      <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ mb: 0.5 }}>
+        <Stack direction="row" spacing={1} alignItems="center">
+          <Typography variant="h3">{note.title}</Typography>
+          {note.kind && <Chip size="small" label={NOTE_KIND_LABELS[note.kind as NoteKindValue]} />}
+        </Stack>
+        {action}
       </Stack>
       {note.body && (
         <Box

--- a/frontend/src/pages/BookPage/Notes/NoteViewModal.tsx
+++ b/frontend/src/pages/BookPage/Notes/NoteViewModal.tsx
@@ -20,6 +20,7 @@ import ReactMarkdown from 'react-markdown';
 import { NoteEditorForm, type NoteEditorFormHandle } from './NoteEditorForm';
 import { NoteTabs } from './components/NoteTabs';
 import { NoteToolbar } from './components/NoteToolbar';
+import { useNoteLinks } from './hooks/useNoteLinks';
 import { NOTE_KIND_LABELS, type NoteKindValue } from './noteKinds';
 
 interface NoteViewModalProps {
@@ -94,6 +95,8 @@ export const NoteViewModal = ({ noteId, onClose }: NoteViewModalProps) => {
   const handleConfirmDelete = () => {
     void deleteMutation.mutateAsync({ noteId });
   };
+
+  const noteLinks = useNoteLinks({ bookId: book.id });
 
   const isDeleting = deleteMutation.isPending;
 
@@ -198,7 +201,11 @@ export const NoteViewModal = ({ noteId, onClose }: NoteViewModalProps) => {
               chapters={chapters}
               onOpenHighlight={handleOpenHighlight}
               onOpenChapter={handleOpenChapter}
-              disabled={isDeleting}
+              onUnlinkHighlight={(highlightId) =>
+                noteLinks.unlinkHighlight(activeNote, highlightId)
+              }
+              onUnlinkChapter={(chapterId) => noteLinks.unlinkChapter(activeNote, chapterId)}
+              disabled={isDeleting || noteLinks.isPending}
             />
           </Stack>
         ) : isError ? (

--- a/frontend/src/pages/BookPage/Notes/components/NotePickerDialog.tsx
+++ b/frontend/src/pages/BookPage/Notes/components/NotePickerDialog.tsx
@@ -8,10 +8,17 @@ interface NotePickerDialogProps {
   open: boolean;
   onClose: () => void;
   bookId: number;
+  title: string;
   onSelect: (note: NoteWithLinks) => void;
 }
 
-export const NotePickerDialog = ({ open, onClose, bookId, onSelect }: NotePickerDialogProps) => {
+export const NotePickerDialog = ({
+  open,
+  onClose,
+  bookId,
+  title,
+  onSelect,
+}: NotePickerDialogProps) => {
   const { data, isLoading } = useGetNotesForBookApiV1BooksBookIdNotesGet(bookId, undefined, {
     query: { enabled: open },
   });
@@ -21,7 +28,7 @@ export const NotePickerDialog = ({ open, onClose, bookId, onSelect }: NotePicker
   const notes = data?.notes ?? [];
 
   return (
-    <CommonDialog open={open} onClose={onClose} title="Add highlight to note" maxWidth="sm">
+    <CommonDialog open={open} onClose={onClose} title={title} maxWidth="sm">
       {isLoading && <Spinner />}
       {!isLoading && notes.length === 0 && (
         <Typography color="text.secondary">No notes in this book yet.</Typography>

--- a/frontend/src/pages/BookPage/Notes/components/NoteTabs.tsx
+++ b/frontend/src/pages/BookPage/Notes/components/NoteTabs.tsx
@@ -1,7 +1,19 @@
 import type { Highlight, NoteLinkedChapter, NoteWithLinks } from '@/api/generated/model';
 import { HighlightCard } from '@/pages/BookPage/Highlights/HighlightCard.tsx';
 import { NoteFlashcardSection } from '@/pages/BookPage/Notes/components/NoteFlashcardSection.tsx';
-import { Box, List, ListItemButton, ListItemText, Stack, Tab, Tabs } from '@mui/material';
+import { LinkOffIcon } from '@/theme/Icons.tsx';
+import {
+  Box,
+  IconButton,
+  List,
+  ListItem,
+  ListItemButton,
+  ListItemText,
+  Stack,
+  Tab,
+  Tabs,
+  Tooltip,
+} from '@mui/material';
 import { type ReactElement, useState } from 'react';
 
 interface NoteTabsProps {
@@ -11,6 +23,8 @@ interface NoteTabsProps {
   chapters: NoteLinkedChapter[];
   onOpenHighlight: (highlightId: number) => void;
   onOpenChapter: (chapterId: number) => void;
+  onUnlinkHighlight?: (highlightId: number) => void;
+  onUnlinkChapter?: (chapterId: number) => void;
   disabled?: boolean;
 }
 
@@ -31,6 +45,8 @@ export const NoteTabs = ({
   chapters,
   onOpenHighlight,
   onOpenChapter,
+  onUnlinkHighlight,
+  onUnlinkChapter,
   disabled = false,
 }: NoteTabsProps) => {
   const tabs = [
@@ -40,9 +56,22 @@ export const NoteTabs = ({
       content: (
         <Stack component="ul" sx={{ gap: 2, listStyle: 'none', p: 0, m: 0 }}>
           {highlights.map((highlight) => (
-            <li key={highlight.id}>
+            <Box component="li" key={highlight.id} sx={{ position: 'relative' }}>
               <HighlightCard highlight={highlight} onOpenModal={onOpenHighlight} />
-            </li>
+              {onUnlinkHighlight && (
+                <Tooltip title="Unlink from note">
+                  <IconButton
+                    aria-label="Unlink highlight"
+                    size="small"
+                    disabled={disabled}
+                    onClick={() => onUnlinkHighlight(highlight.id)}
+                    sx={{ position: 'absolute', top: 8, right: 8 }}
+                  >
+                    <LinkOffIcon fontSize="small" />
+                  </IconButton>
+                </Tooltip>
+              )}
+            </Box>
           ))}
         </Stack>
       ),
@@ -53,9 +82,29 @@ export const NoteTabs = ({
       content: (
         <List disablePadding>
           {chapters.map((chapter) => (
-            <ListItemButton key={chapter.id} onClick={() => onOpenChapter(chapter.id)}>
-              <ListItemText primary={chapter.name} />
-            </ListItemButton>
+            <ListItem
+              key={chapter.id}
+              disablePadding
+              secondaryAction={
+                onUnlinkChapter && (
+                  <Tooltip title="Unlink from note">
+                    <IconButton
+                      edge="end"
+                      aria-label="Unlink chapter"
+                      size="small"
+                      disabled={disabled}
+                      onClick={() => onUnlinkChapter(chapter.id)}
+                    >
+                      <LinkOffIcon fontSize="small" />
+                    </IconButton>
+                  </Tooltip>
+                )
+              }
+            >
+              <ListItemButton onClick={() => onOpenChapter(chapter.id)}>
+                <ListItemText primary={chapter.name} />
+              </ListItemButton>
+            </ListItem>
           ))}
         </List>
       ),

--- a/frontend/src/pages/BookPage/Notes/components/NoteTabs.tsx
+++ b/frontend/src/pages/BookPage/Notes/components/NoteTabs.tsx
@@ -1,19 +1,8 @@
 import type { Highlight, NoteLinkedChapter, NoteWithLinks } from '@/api/generated/model';
+import { UnlinkButton } from '@/components/buttons/UnlinkButton.tsx';
 import { HighlightCard } from '@/pages/BookPage/Highlights/HighlightCard.tsx';
 import { NoteFlashcardSection } from '@/pages/BookPage/Notes/components/NoteFlashcardSection.tsx';
-import { LinkOffIcon } from '@/theme/Icons.tsx';
-import {
-  Box,
-  IconButton,
-  List,
-  ListItem,
-  ListItemButton,
-  ListItemText,
-  Stack,
-  Tab,
-  Tabs,
-  Tooltip,
-} from '@mui/material';
+import { Box, List, ListItem, ListItemButton, ListItemText, Stack, Tab, Tabs } from '@mui/material';
 import { type ReactElement, useState } from 'react';
 
 interface NoteTabsProps {
@@ -59,17 +48,12 @@ export const NoteTabs = ({
             <Box component="li" key={highlight.id} sx={{ position: 'relative' }}>
               <HighlightCard highlight={highlight} onOpenModal={onOpenHighlight} />
               {onUnlinkHighlight && (
-                <Tooltip title="Unlink from note">
-                  <IconButton
-                    aria-label="Unlink highlight"
-                    size="small"
-                    disabled={disabled}
-                    onClick={() => onUnlinkHighlight(highlight.id)}
-                    sx={{ position: 'absolute', top: 8, right: 8 }}
-                  >
-                    <LinkOffIcon fontSize="small" />
-                  </IconButton>
-                </Tooltip>
+                <UnlinkButton
+                  title="Unlink from note"
+                  disabled={disabled}
+                  onClick={() => onUnlinkHighlight(highlight.id)}
+                  sx={{ position: 'absolute', top: 8, right: 8 }}
+                />
               )}
             </Box>
           ))}
@@ -87,17 +71,12 @@ export const NoteTabs = ({
               disablePadding
               secondaryAction={
                 onUnlinkChapter && (
-                  <Tooltip title="Unlink from note">
-                    <IconButton
-                      edge="end"
-                      aria-label="Unlink chapter"
-                      size="small"
-                      disabled={disabled}
-                      onClick={() => onUnlinkChapter(chapter.id)}
-                    >
-                      <LinkOffIcon fontSize="small" />
-                    </IconButton>
-                  </Tooltip>
+                  <UnlinkButton
+                    edge="end"
+                    title="Unlink from note"
+                    disabled={disabled}
+                    onClick={() => onUnlinkChapter(chapter.id)}
+                  />
                 )
               }
             >

--- a/frontend/src/pages/BookPage/Notes/hooks/useNoteLinks.ts
+++ b/frontend/src/pages/BookPage/Notes/hooks/useNoteLinks.ts
@@ -1,0 +1,112 @@
+import type { NoteUpdateRequest, NoteWithLinks } from '@/api/generated/model';
+import {
+  getGetNoteApiV1NotesNoteIdGetQueryKey,
+  getGetNotesForBookApiV1BooksBookIdNotesGetQueryKey,
+  useUpdateNoteApiV1NotesNoteIdPut,
+} from '@/api/generated/notes/notes.ts';
+import { useSnackbar } from '@/context/SnackbarContext.tsx';
+import { useQueryClient } from '@tanstack/react-query';
+
+interface UseNoteLinksOptions {
+  bookId: number;
+}
+
+interface MutateOptions {
+  onSuccess?: () => void;
+}
+
+/**
+ * Adds or removes a note's link to a highlight or chapter. There is no
+ * dedicated link/unlink endpoint — links are replaced wholesale on note
+ * update — so each operation re-sends the full note with the target id added
+ * to or filtered out of the relevant array.
+ */
+export const useNoteLinks = ({ bookId }: UseNoteLinksOptions) => {
+  const queryClient = useQueryClient();
+  const { showSnackbar } = useSnackbar();
+
+  const updateNoteMutation = useUpdateNoteApiV1NotesNoteIdPut({
+    mutation: {
+      onSuccess: (_data, { noteId }) => {
+        void queryClient.invalidateQueries({
+          queryKey: getGetNotesForBookApiV1BooksBookIdNotesGetQueryKey(bookId),
+        });
+        void queryClient.invalidateQueries({
+          queryKey: getGetNoteApiV1NotesNoteIdGetQueryKey(noteId),
+        });
+      },
+      onError: (error: Error) => {
+        console.error('Failed to update note links:', error);
+        showSnackbar('Failed to update note links. Please try again.', 'error');
+      },
+    },
+  });
+
+  const updateLinks = (
+    note: NoteWithLinks,
+    links: Partial<NoteUpdateRequest>,
+    successMessage: string,
+    options?: MutateOptions
+  ) => {
+    const payload: NoteUpdateRequest = {
+      title: note.title,
+      body: note.body,
+      kind: note.kind as NoteUpdateRequest['kind'],
+      chapter_ids: note.chapter_ids,
+      highlight_ids: note.highlight_ids,
+      tag_ids: note.tag_ids,
+      ...links,
+    };
+    updateNoteMutation.mutate(
+      { noteId: note.id, data: payload },
+      {
+        onSuccess: () => {
+          showSnackbar(successMessage, 'success');
+          options?.onSuccess?.();
+        },
+      }
+    );
+  };
+
+  const linkHighlight = (note: NoteWithLinks, highlightId: number, options?: MutateOptions) => {
+    updateLinks(
+      note,
+      { highlight_ids: [...new Set([...note.highlight_ids, highlightId])] },
+      'Highlight added to note.',
+      options
+    );
+  };
+
+  const unlinkHighlight = (note: NoteWithLinks, highlightId: number) => {
+    updateLinks(
+      note,
+      { highlight_ids: note.highlight_ids.filter((id) => id !== highlightId) },
+      'Link removed.'
+    );
+  };
+
+  const linkChapter = (note: NoteWithLinks, chapterId: number, options?: MutateOptions) => {
+    updateLinks(
+      note,
+      { chapter_ids: [...new Set([...note.chapter_ids, chapterId])] },
+      'Chapter added to note.',
+      options
+    );
+  };
+
+  const unlinkChapter = (note: NoteWithLinks, chapterId: number) => {
+    updateLinks(
+      note,
+      { chapter_ids: note.chapter_ids.filter((id) => id !== chapterId) },
+      'Link removed.'
+    );
+  };
+
+  return {
+    linkHighlight,
+    unlinkHighlight,
+    linkChapter,
+    unlinkChapter,
+    isPending: updateNoteMutation.isPending,
+  };
+};

--- a/frontend/src/pages/BookPage/Structure/ChapterDetailDialog/NotesSection.tsx
+++ b/frontend/src/pages/BookPage/Structure/ChapterDetailDialog/NotesSection.tsx
@@ -1,13 +1,14 @@
 import type { ChapterWithHighlights } from '@/api/generated/model';
 import { useGetNotesForBookApiV1BooksBookIdNotesGet } from '@/api/generated/notes/notes.ts';
 import { Spinner } from '@/components/animations/Spinner.tsx';
+import { UnlinkButton } from '@/components/buttons/UnlinkButton.tsx';
 import { NoteCard } from '@/pages/BookPage/Notes/NoteCard';
 import { NoteModals } from '@/pages/BookPage/Notes/NoteModals';
 import { NotePickerDialog } from '@/pages/BookPage/Notes/components/NotePickerDialog.tsx';
 import { useNoteLinks } from '@/pages/BookPage/Notes/hooks/useNoteLinks';
 import { useNoteModals } from '@/pages/BookPage/Notes/hooks/useNoteModals';
-import { AddIcon, LinkIcon, LinkOffIcon } from '@/theme/Icons.tsx';
-import { Box, Button, IconButton, Stack, Tooltip, Typography } from '@mui/material';
+import { AddIcon, LinkIcon } from '@/theme/Icons.tsx';
+import { Box, Button, Stack, Typography } from '@mui/material';
 import { useState } from 'react';
 
 interface NotesSectionProps {
@@ -62,19 +63,11 @@ export const NotesSection = ({ chapter, bookId }: NotesSectionProps) => {
               note={note}
               onClick={() => noteModals.openView(note)}
               action={
-                <Tooltip title="Unlink from chapter">
-                  <IconButton
-                    aria-label="Unlink note"
-                    size="small"
-                    disabled={isDisabled}
-                    onClick={(event) => {
-                      event.stopPropagation();
-                      noteLinks.unlinkChapter(note, chapter.id);
-                    }}
-                  >
-                    <LinkOffIcon fontSize="small" />
-                  </IconButton>
-                </Tooltip>
+                <UnlinkButton
+                  title="Unlink from chapter"
+                  disabled={isDisabled}
+                  onClick={() => noteLinks.unlinkChapter(note, chapter.id)}
+                />
               }
             />
           </li>

--- a/frontend/src/pages/BookPage/Structure/ChapterDetailDialog/NotesSection.tsx
+++ b/frontend/src/pages/BookPage/Structure/ChapterDetailDialog/NotesSection.tsx
@@ -3,9 +3,12 @@ import { useGetNotesForBookApiV1BooksBookIdNotesGet } from '@/api/generated/note
 import { Spinner } from '@/components/animations/Spinner.tsx';
 import { NoteCard } from '@/pages/BookPage/Notes/NoteCard';
 import { NoteModals } from '@/pages/BookPage/Notes/NoteModals';
+import { NotePickerDialog } from '@/pages/BookPage/Notes/components/NotePickerDialog.tsx';
+import { useNoteLinks } from '@/pages/BookPage/Notes/hooks/useNoteLinks';
 import { useNoteModals } from '@/pages/BookPage/Notes/hooks/useNoteModals';
-import { AddIcon } from '@/theme/Icons.tsx';
-import { Box, Button, Stack, Typography } from '@mui/material';
+import { AddIcon, LinkIcon, LinkOffIcon } from '@/theme/Icons.tsx';
+import { Box, Button, IconButton, Stack, Tooltip, Typography } from '@mui/material';
+import { useState } from 'react';
 
 interface NotesSectionProps {
   chapter: ChapterWithHighlights;
@@ -17,19 +20,33 @@ export const NotesSection = ({ chapter, bookId }: NotesSectionProps) => {
     chapter_id: chapter.id,
   });
   const noteModals = useNoteModals({ syncToUrl: false });
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const noteLinks = useNoteLinks({ bookId });
 
   // NOTE: the orval axios mutator unwraps the response (`.then(({ data }) => data)`),
   // so the generated GET hook's `data` is the payload itself, not an AxiosResponse.
   const notes = data?.notes ?? [];
 
+  const isDisabled = noteLinks.isPending;
+
   return (
     <Box>
-      <Box sx={{ display: 'flex', justifyContent: 'flex-end', mb: 2 }}>
+      <Box sx={{ display: 'flex', justifyContent: 'flex-end', gap: 1, mb: 2 }}>
+        <Button
+          variant="outlined"
+          size="small"
+          startIcon={<LinkIcon />}
+          onClick={() => setPickerOpen(true)}
+          disabled={isDisabled}
+        >
+          Link existing note
+        </Button>
         <Button
           variant="outlined"
           size="small"
           startIcon={<AddIcon />}
           onClick={noteModals.openCreate}
+          disabled={isDisabled}
         >
           Add note
         </Button>
@@ -41,11 +58,38 @@ export const NotesSection = ({ chapter, bookId }: NotesSectionProps) => {
       <Stack component="ul" sx={{ gap: 2, listStyle: 'none', p: 0, m: 0 }}>
         {notes.map((note) => (
           <li key={note.id}>
-            <NoteCard note={note} onClick={() => noteModals.openView(note)} />
+            <NoteCard
+              note={note}
+              onClick={() => noteModals.openView(note)}
+              action={
+                <Tooltip title="Unlink from chapter">
+                  <IconButton
+                    aria-label="Unlink note"
+                    size="small"
+                    disabled={isDisabled}
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      noteLinks.unlinkChapter(note, chapter.id);
+                    }}
+                  >
+                    <LinkOffIcon fontSize="small" />
+                  </IconButton>
+                </Tooltip>
+              }
+            />
           </li>
         ))}
       </Stack>
       <NoteModals controller={noteModals} initialChapterIds={[chapter.id]} />
+      <NotePickerDialog
+        open={pickerOpen}
+        onClose={() => setPickerOpen(false)}
+        bookId={bookId}
+        title="Add chapter to note"
+        onSelect={(note) =>
+          noteLinks.linkChapter(note, chapter.id, { onSuccess: () => setPickerOpen(false) })
+        }
+      />
     </Box>
   );
 };

--- a/frontend/src/theme/Icons.tsx
+++ b/frontend/src/theme/Icons.tsx
@@ -40,6 +40,7 @@ export {
   Delete as DeleteIcon,
   Edit as EditIcon,
   Link as LinkIcon,
+  LinkOff as LinkOffIcon,
   NoteAdd as NoteAddIcon,
   Refresh as RegenerateIcon,
   SwapVert as SortIcon,


### PR DESCRIPTION
## Summary

Notes could be linked to highlights and chapters, but there was no UI to remove a link. This adds unlinking in three places, plus note linking in the chapter dialog:

- **Note view modal**: each linked highlight and chapter in the tabs gets an unlink icon (chapter rows via `ListItem` secondary action, highlight cards via an overlay button).
- **Highlight modal**: each linked note card gets an unlink icon.
- **Chapter dialog**: each linked note card gets an unlink icon, and the notes tab gains the same "Link existing note" button the highlight modal has.

Unlinking is one click with a snackbar — no confirmation dialog, since links are easy to restore.

## Implementation notes

- No backend changes: links are replaced wholesale via `PUT /notes/{id}`, so a new shared `useNoteLinks` hook re-sends the note with the target id added/removed and centralizes query invalidation and snackbars. `HighlightNotesSection`'s local link mutation is replaced by the hook.
- `NoteCard` gains a right-edge `action` slot (and its keydown handler now ignores events bubbling from the action button).
- `NotePickerDialog` moved from the highlight modal folder to shared `Notes/components/` with its title as a prop, so the chapter dialog can reuse it.

## Testing

- `tsc --noEmit` and `eslint --max-warnings 0` pass (no frontend test suite).
- Worth a manual pass: unlink from all three surfaces, confirm lists/tab counts refresh and clicking the icon doesn't open the underlying modal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)