### PR TITLE
Add ereader endpoint for book prereading content

### DIFF
--- a/backend/src/application/reading/use_cases/chapter_prereading/get_ereader_book_prereading_use_case.py
+++ b/backend/src/application/reading/use_cases/chapter_prereading/get_ereader_book_prereading_use_case.py
@@ -1,0 +1,116 @@
+"""Use case for retrieving ereader-friendly prereading content for a book."""
+
+from dataclasses import dataclass
+from datetime import datetime
+
+from src.application.library.protocols.book_repository import BookRepositoryProtocol
+from src.application.library.protocols.chapter_repository import (
+    ChapterRepositoryProtocol,
+)
+from src.application.reading.protocols.chapter_prereading_repository import (
+    ChapterPrereadingRepositoryProtocol,
+)
+from src.domain.common.value_objects.ids import BookId, UserId
+from src.domain.library.entities.book import Book
+from src.domain.library.entities.chapter import Chapter
+from src.domain.reading.entities.chapter_prereading_content import (
+    ChapterPrereadingContent,
+)
+from src.domain.reading.exceptions import BookNotFoundError
+
+
+@dataclass
+class EreaderChapterPrereading:
+    """Ereader-friendly prereading content for a single chapter.
+
+    Only exposes question text (no AI or user answers) to keep the payload
+    small and preserve the active-recall value on the device.
+    """
+
+    chapter_id: int
+    chapter_name: str
+    chapter_number: int | None
+    parent_chapter_name: str | None
+    summary: str
+    keypoints: list[str]
+    questions: list[str]
+    generated_at: datetime
+
+
+class GetEreaderBookPrereadingUseCase:
+    """Retrieve all chapter prereading content for a book by client_book_id."""
+
+    def __init__(
+        self,
+        book_repo: BookRepositoryProtocol,
+        chapter_repo: ChapterRepositoryProtocol,
+        prereading_repo: ChapterPrereadingRepositoryProtocol,
+    ) -> None:
+        self.book_repo = book_repo
+        self.chapter_repo = chapter_repo
+        self.prereading_repo = prereading_repo
+
+    async def get_prereading_for_client_book(
+        self, client_book_id: str, user_id: UserId
+    ) -> list[EreaderChapterPrereading]:
+        """Get ereader-friendly prereading for every chapter that has it.
+
+        Chapters are returned in the order provided by ``find_all_by_book``
+        (chapter_number ascending, nulls last), and chapters without prereading
+        content are omitted.
+
+        Raises:
+            BookNotFoundError: If no book matches client_book_id for the user.
+        """
+        book = await self._resolve_book(client_book_id, user_id)
+        chapters = await self.chapter_repo.find_all_by_book(book.id, user_id)
+        prereading_by_chapter = await self._build_prereading_lookup(book.id)
+        parent_name_by_id = self._build_parent_name_lookup(chapters)
+        return self._join_chapters_with_prereading(
+            chapters, prereading_by_chapter, parent_name_by_id
+        )
+
+    async def _resolve_book(self, client_book_id: str, user_id: UserId) -> Book:
+        book = await self.book_repo.find_by_client_book_id(client_book_id, user_id)
+        if not book:
+            raise BookNotFoundError(client_book_id)
+        return book
+
+    async def _build_prereading_lookup(
+        self, book_id: BookId
+    ) -> dict[int, ChapterPrereadingContent]:
+        contents = await self.prereading_repo.find_all_by_book_id(book_id)
+        return {content.chapter_id.value: content for content in contents}
+
+    def _build_parent_name_lookup(self, chapters: list[Chapter]) -> dict[int, str]:
+        return {chapter.id.value: chapter.name for chapter in chapters}
+
+    def _join_chapters_with_prereading(
+        self,
+        chapters: list[Chapter],
+        prereading_by_chapter: dict[int, ChapterPrereadingContent],
+        parent_name_by_id: dict[int, str],
+    ) -> list[EreaderChapterPrereading]:
+        items: list[EreaderChapterPrereading] = []
+        for chapter in chapters:
+            content = prereading_by_chapter.get(chapter.id.value)
+            if content is None:
+                continue
+            parent_name = (
+                parent_name_by_id.get(chapter.parent_id.value)
+                if chapter.parent_id is not None
+                else None
+            )
+            items.append(
+                EreaderChapterPrereading(
+                    chapter_id=chapter.id.value,
+                    chapter_name=chapter.name,
+                    chapter_number=chapter.chapter_number,
+                    parent_chapter_name=parent_name,
+                    summary=content.summary,
+                    keypoints=content.keypoints,
+                    questions=[q.question for q in content.questions],
+                    generated_at=content.generated_at,
+                )
+            )
+        return items

--- a/backend/src/containers/reading.py
+++ b/backend/src/containers/reading.py
@@ -21,6 +21,9 @@ from src.application.reading.use_cases.chapter_prereading.get_book_prereading_us
 from src.application.reading.use_cases.chapter_prereading.get_chapter_prereading_use_case import (
     GetChapterPrereadingUseCase,
 )
+from src.application.reading.use_cases.chapter_prereading.get_ereader_book_prereading_use_case import (
+    GetEreaderBookPrereadingUseCase,
+)
 from src.application.reading.use_cases.chapter_prereading.update_prereading_answers_use_case import (
     UpdatePrereadingAnswersUseCase,
 )
@@ -271,6 +274,12 @@ class ReadingContainer(containers.DeclarativeContainer):
         GetBookPrereadingUseCase,
         prereading_repo=chapter_prereading_repository,
         chapter_repo=chapter_repository,
+    )
+    get_ereader_book_prereading_use_case = providers.Factory(
+        GetEreaderBookPrereadingUseCase,
+        book_repo=book_repository,
+        chapter_repo=chapter_repository,
+        prereading_repo=chapter_prereading_repository,
     )
     generate_chapter_prereading_use_case = providers.Factory(
         GenerateChapterPrereadingUseCase,

--- a/backend/src/infrastructure/library/routers/ereader.py
+++ b/backend/src/infrastructure/library/routers/ereader.py
@@ -12,7 +12,11 @@ from src.application.library.use_cases.book_management.create_book_use_case impo
 from src.application.library.use_cases.book_queries.get_ereader_metadata_use_case import (
     GetEreaderMetadataUseCase,
 )
+from src.application.reading.use_cases.chapter_prereading.get_ereader_book_prereading_use_case import (
+    GetEreaderBookPrereadingUseCase,
+)
 from src.core import container
+from src.domain.common.value_objects.ids import UserId
 from src.domain.identity.entities.user import User
 from src.infrastructure.common.di import inject_use_case
 from src.infrastructure.identity.dependencies import get_current_user
@@ -20,6 +24,10 @@ from src.infrastructure.library.schemas import (
     BookCreate,
     EpubUploadResponse,
     EreaderBookMetadata,
+)
+from src.infrastructure.reading.schemas.chapter_prereading_schemas import (
+    EreaderBookPrereadingResponse,
+    EreaderChapterPrereadingItem,
 )
 
 router = APIRouter(prefix="/ereader", tags=["ereader"])
@@ -174,4 +182,53 @@ async def upload_book_epub(
     return EpubUploadResponse(
         success=True,
         message="Ebook uploaded successfully",
+    )
+
+
+@router.get(
+    "/books/{client_book_id}/prereading",
+    response_model=EreaderBookPrereadingResponse,
+    status_code=status.HTTP_200_OK,
+)
+async def get_book_prereading(
+    client_book_id: str,
+    current_user: Annotated[User, Depends(get_current_user)],
+    use_case: GetEreaderBookPrereadingUseCase = Depends(
+        inject_use_case(container.reading.get_ereader_book_prereading_use_case)
+    ),
+) -> EreaderBookPrereadingResponse:
+    """
+    Get all chapter prereading content for a book by client_book_id.
+
+    Returns one item per chapter that has generated prereading content, ordered
+    by the server-side chapter number. Questions are exposed as plain strings
+    only (no AI or user answers). A book with no prereading yields an empty list.
+
+    Args:
+        client_book_id: The client-provided stable book identifier
+        current_user: Authenticated user
+
+    Returns:
+        EreaderBookPrereadingResponse with one item per chapter that has prereading
+
+    Raises:
+        HTTPException: 404 if the book is not found for the given client_book_id
+    """
+    items = await use_case.get_prereading_for_client_book(
+        client_book_id, UserId(current_user.id.value)
+    )
+    return EreaderBookPrereadingResponse(
+        items=[
+            EreaderChapterPrereadingItem(
+                chapter_id=item.chapter_id,
+                chapter_name=item.chapter_name,
+                chapter_number=item.chapter_number,
+                parent_chapter_name=item.parent_chapter_name,
+                summary=item.summary,
+                keypoints=item.keypoints,
+                questions=item.questions,
+                generated_at=item.generated_at,
+            )
+            for item in items
+        ]
     )

--- a/backend/src/infrastructure/reading/schemas/chapter_prereading_schemas.py
+++ b/backend/src/infrastructure/reading/schemas/chapter_prereading_schemas.py
@@ -43,3 +43,26 @@ class BookPrereadingResponse(BaseModel):
     """Response schema for batch prereading content for a book."""
 
     items: list[ChapterPrereadingResponse]
+
+
+class EreaderChapterPrereadingItem(BaseModel):
+    """Ereader-friendly prereading content for a single chapter.
+
+    Questions are exposed as plain strings only (no AI or user answers) to keep
+    the device payload small and preserve active-recall value.
+    """
+
+    chapter_id: int
+    chapter_name: str
+    chapter_number: int | None
+    parent_chapter_name: str | None
+    summary: str
+    keypoints: list[str]
+    questions: list[str]
+    generated_at: datetime
+
+
+class EreaderBookPrereadingResponse(BaseModel):
+    """Response schema for ereader book prereading content."""
+
+    items: list[EreaderChapterPrereadingItem]

--- a/backend/tests/test_ereader_prereading.py
+++ b/backend/tests/test_ereader_prereading.py
@@ -1,0 +1,184 @@
+"""Tests for the ereader book prereading endpoint."""
+
+from datetime import UTC, datetime
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.models import Book, Chapter
+from src.models import ChapterPrereadingContent as PrereadingContentORM
+from tests.conftest import create_test_book
+
+
+async def _add_chapter(
+    db_session: AsyncSession,
+    book: Book,
+    name: str,
+    chapter_number: int | None = None,
+    parent_id: int | None = None,
+) -> Chapter:
+    chapter = Chapter(
+        book_id=book.id,
+        name=name,
+        chapter_number=chapter_number,
+        parent_id=parent_id,
+    )
+    db_session.add(chapter)
+    await db_session.commit()
+    await db_session.refresh(chapter)
+    return chapter
+
+
+async def _add_prereading(
+    db_session: AsyncSession,
+    chapter: Chapter,
+    summary: str = "A summary",
+    keypoints: list[str] | None = None,
+    questions: list[dict[str, str]] | None = None,
+) -> PrereadingContentORM:
+    content = PrereadingContentORM(
+        chapter_id=chapter.id,
+        summary=summary,
+        keypoints=keypoints or ["Keypoint 1"],
+        questions=questions
+        or [{"question": "What is X?", "answer": "It is Y.", "user_answer": "My guess"}],
+        generated_at=datetime(2026, 7, 1, tzinfo=UTC),
+        ai_model="test-model",
+    )
+    db_session.add(content)
+    await db_session.commit()
+    await db_session.refresh(content)
+    return content
+
+
+@pytest.fixture
+async def prereading_book(db_session: AsyncSession, test_user: Book) -> Book:
+    """A book identified by client_book_id."""
+    return await create_test_book(
+        db_session=db_session,
+        user_id=test_user.id,
+        title="Prereading Book",
+        client_book_id="client-abc",
+    )
+
+
+async def test_returns_items_ordered_by_chapter_number(
+    client: AsyncClient, db_session: AsyncSession, prereading_book: Book
+) -> None:
+    parent = await _add_chapter(db_session, prereading_book, "Topic 1", chapter_number=1)
+    ch_a = await _add_chapter(
+        db_session, prereading_book, "Exercises", chapter_number=7, parent_id=parent.id
+    )
+    ch_b = await _add_chapter(
+        db_session, prereading_book, "Intro", chapter_number=2, parent_id=parent.id
+    )
+    await _add_prereading(db_session, ch_a, summary="Exercises summary")
+    await _add_prereading(db_session, ch_b, summary="Intro summary")
+
+    response = await client.get("/api/v1/ereader/books/client-abc/prereading")
+
+    assert response.status_code == 200
+    items = response.json()["items"]
+    # Ordered by chapter_number ascending: Intro (2) before Exercises (7).
+    assert [i["chapter_number"] for i in items] == [2, 7]
+    assert items[0]["chapter_name"] == "Intro"
+    assert items[0]["parent_chapter_name"] == "Topic 1"
+    assert items[1]["chapter_name"] == "Exercises"
+    assert items[1]["summary"] == "Exercises summary"
+
+
+async def test_duplicate_chapter_names_disambiguated_by_parent(
+    client: AsyncClient, db_session: AsyncSession, prereading_book: Book
+) -> None:
+    topic1 = await _add_chapter(db_session, prereading_book, "Topic 1", chapter_number=1)
+    topic2 = await _add_chapter(db_session, prereading_book, "Topic 2", chapter_number=2)
+    ex1 = await _add_chapter(
+        db_session, prereading_book, "Exercises", chapter_number=3, parent_id=topic1.id
+    )
+    ex2 = await _add_chapter(
+        db_session, prereading_book, "Exercises", chapter_number=4, parent_id=topic2.id
+    )
+    await _add_prereading(db_session, ex1)
+    await _add_prereading(db_session, ex2)
+
+    response = await client.get("/api/v1/ereader/books/client-abc/prereading")
+
+    assert response.status_code == 200
+    items = response.json()["items"]
+    exercise_items = [i for i in items if i["chapter_name"] == "Exercises"]
+    assert len(exercise_items) == 2
+    parent_names = {i["parent_chapter_name"] for i in exercise_items}
+    assert parent_names == {"Topic 1", "Topic 2"}
+
+
+async def test_root_chapter_has_null_parent_name(
+    client: AsyncClient, db_session: AsyncSession, prereading_book: Book
+) -> None:
+    root = await _add_chapter(db_session, prereading_book, "Root Chapter", chapter_number=1)
+    await _add_prereading(db_session, root)
+
+    response = await client.get("/api/v1/ereader/books/client-abc/prereading")
+
+    assert response.status_code == 200
+    items = response.json()["items"]
+    assert len(items) == 1
+    assert items[0]["parent_chapter_name"] is None
+
+
+async def test_chapters_without_prereading_are_omitted(
+    client: AsyncClient, db_session: AsyncSession, prereading_book: Book
+) -> None:
+    ch_with = await _add_chapter(db_session, prereading_book, "Has prereading", chapter_number=1)
+    await _add_chapter(db_session, prereading_book, "No prereading", chapter_number=2)
+    await _add_prereading(db_session, ch_with)
+
+    response = await client.get("/api/v1/ereader/books/client-abc/prereading")
+
+    assert response.status_code == 200
+    items = response.json()["items"]
+    assert len(items) == 1
+    assert items[0]["chapter_name"] == "Has prereading"
+
+
+async def test_book_with_zero_prereading_returns_empty_list(
+    client: AsyncClient, db_session: AsyncSession, prereading_book: Book
+) -> None:
+    await _add_chapter(db_session, prereading_book, "Lonely chapter", chapter_number=1)
+
+    response = await client.get("/api/v1/ereader/books/client-abc/prereading")
+
+    assert response.status_code == 200
+    assert response.json()["items"] == []
+
+
+async def test_unknown_client_book_id_returns_404(client: AsyncClient) -> None:
+    response = await client.get("/api/v1/ereader/books/does-not-exist/prereading")
+
+    assert response.status_code == 404
+
+
+async def test_questions_contain_only_question_strings(
+    client: AsyncClient, db_session: AsyncSession, prereading_book: Book
+) -> None:
+    chapter = await _add_chapter(db_session, prereading_book, "Chapter", chapter_number=1)
+    await _add_prereading(
+        db_session,
+        chapter,
+        questions=[
+            {
+                "question": "What is the capital?",
+                "answer": "Secret AI answer",
+                "user_answer": "Secret user answer",
+            }
+        ],
+    )
+
+    response = await client.get("/api/v1/ereader/books/client-abc/prereading")
+
+    assert response.status_code == 200
+    questions = response.json()["items"][0]["questions"]
+    assert questions == ["What is the capital?"]
+    body = response.text
+    assert "Secret AI answer" not in body
+    assert "Secret user answer" not in body


### PR DESCRIPTION
New GET /api/v1/ereader/books/{client_book_id}/prereading endpoint so the KOReader plugin can fetch and cache all chapter prereading for a book. Returns one item per chapter that has prereading (summary, keypoints, question text only — no answers), with chapter_number and parent_chapter_name included so the device can disambiguate duplicate chapter titles under different parent chapters.