### PR TITLE
Fix note-editor tag failures for existing and note-only tags

### DIFF
--- a/backend/src/application/reading/use_cases/tags/create_tag_use_case.py
+++ b/backend/src/application/reading/use_cases/tags/create_tag_use_case.py
@@ -9,7 +9,6 @@ from src.application.reading.protocols.tag_repository import (
 )
 from src.domain.common.value_objects.ids import BookId, UserId
 from src.domain.reading.entities.tag import Tag
-from src.domain.reading.exceptions import DuplicateTagNameError
 
 logger = structlog.get_logger(__name__)
 
@@ -27,7 +26,7 @@ class CreateTagUseCase:
 
     async def create_tag(self, book_id: int, name: str, user_id: int) -> Tag:
         """
-        Create a new tag for a book.
+        Get or create a tag for a book.
 
         Args:
             book_id: ID of the book
@@ -35,11 +34,10 @@ class CreateTagUseCase:
             user_id: ID of the user creating the tag
 
         Returns:
-            Created tag entity
+            The existing or newly created tag entity
 
         Raises:
             BookNotFoundError: If book not found
-            DuplicateTagNameError: If tag with same name already exists
         """
         book_id_vo = BookId(book_id)
         user_id_vo = UserId(user_id)
@@ -50,7 +48,7 @@ class CreateTagUseCase:
             book_id_vo, name.strip(), user_id_vo
         )
         if existing_tag:
-            raise DuplicateTagNameError(name)
+            return existing_tag
 
         tag = Tag.create(
             user_id=user_id_vo,

--- a/backend/src/infrastructure/reading/repositories/tag_repository.py
+++ b/backend/src/infrastructure/reading/repositories/tag_repository.py
@@ -1,6 +1,6 @@
 """Repository for Tag and TagGroup domain entities."""
 
-from sqlalchemy import select
+from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -21,7 +21,7 @@ from src.infrastructure.reading.mappers.tag_mapper import TagMapper
 from src.models import Highlight as HighlightORM
 from src.models import Tag as TagORM
 from src.models import TagGroup as TagGroupORM
-from src.models import highlight_tags
+from src.models import highlight_tags, note_tags
 
 
 class TagRepository(BaseRepository[Tag, TagORM]):
@@ -64,9 +64,12 @@ class TagRepository(BaseRepository[Tag, TagORM]):
 
     async def find_by_book(self, book_id: BookId, user_id: UserId) -> list[Tag]:
         """
-        Get all tags for a book that have active highlight associations.
+        Get all tags for a book that are in active use.
 
-        This filters out tags that only have soft-deleted highlights.
+        A tag is "in use" when it is linked to a non-deleted highlight or to a
+        note. This filters out tags that only have soft-deleted highlights and
+        no note association. Notes have no soft-delete: deleting a note cascades
+        away its ``note_tags`` rows, so any surviving note association is active.
 
         Args:
             book_id: The book ID
@@ -75,16 +78,23 @@ class TagRepository(BaseRepository[Tag, TagORM]):
         Returns:
             List of tag entities
         """
+        has_active_highlight = (
+            select(highlight_tags.c.tag_id)
+            .join(HighlightORM, HighlightORM.id == highlight_tags.c.highlight_id)
+            .where(
+                highlight_tags.c.tag_id == TagORM.id,
+                HighlightORM.deleted_at.is_(None),
+            )
+            .exists()
+        )
+        has_note = select(note_tags.c.tag_id).where(note_tags.c.tag_id == TagORM.id).exists()
         stmt = (
             select(TagORM)
-            .join(highlight_tags)
-            .join(HighlightORM)
             .where(
                 TagORM.book_id == book_id.value,
                 TagORM.user_id == user_id.value,
-                HighlightORM.deleted_at.is_(None),
+                or_(has_active_highlight, has_note),
             )
-            .distinct()
             .order_by(TagORM.name)
         )
         result = await self.db.execute(stmt)

--- a/backend/tests/test_books.py
+++ b/backend/tests/test_books.py
@@ -517,6 +517,29 @@ class TestGetBookDetails:
         assert "Important" in tag_names
         assert "Review" in tag_names
 
+    async def test_get_book_details_includes_note_only_tag(
+        self,
+        client: AsyncClient,
+        test_book: models.Book,
+    ) -> None:
+        """A tag linked only to a note (never to a highlight) must still appear
+        in the book-level tag list that feeds the tag-input dropdown."""
+        tag_resp = await client.post(
+            f"/api/v1/books/{test_book.id}/tag",
+            json={"name": "note-only"},
+        )
+        assert tag_resp.status_code in (200, 201), tag_resp.text
+        tag_id = tag_resp.json()["id"]
+
+        await client.post(
+            "/api/v1/notes",
+            json={"title": "Concept", "book_id": test_book.id, "tag_ids": [tag_id]},
+        )
+
+        response = await client.get(f"/api/v1/books/{test_book.id}")
+        assert response.status_code == status.HTTP_200_OK
+        assert tag_id in [tag["id"] for tag in response.json()["tags"]]
+
     async def test_get_book_details_includes_reading_position(
         self,
         client: AsyncClient,

--- a/backend/tests/test_notes.py
+++ b/backend/tests/test_notes.py
@@ -167,6 +167,20 @@ class TestCreateNote:
         )
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
+    async def test_create_tag_is_idempotent_for_existing_name(
+        self, client: AsyncClient, test_tag: models.Tag
+    ) -> None:
+        # The note editor resolves a typed tag name by POSTing to /tag. A tag
+        # may already exist for the book without any highlight association (so
+        # it is hidden from the dropdown); re-creating it must return the
+        # existing tag rather than a 409 conflict.
+        response = await client.post(
+            f"/api/v1/books/{test_tag.book_id}/tag",
+            json={"name": test_tag.name},
+        )
+        assert response.status_code in (200, 201), response.text
+        assert response.json()["id"] == test_tag.id
+
 
 class TestGetNote:
     """Test suite for GET /notes/{note_id} endpoint."""


### PR DESCRIPTION
Adding a tag to a note failed in two ways that the highlight editor did not share:

- Typing a tag that already exists in the DB but is linked to no highlight returned a 409. CreateTagUseCase now returns the existing tag instead of raising DuplicateTagNameError, matching the get-or-create pattern already used when adding a tag to a highlight by name.

- A tag linked only to a note never appeared in the tag dropdown, because find_by_book only surfaced tags with an active highlight association. It now also includes tags linked to a note via a correlated EXISTS.

Add regression tests for both paths.