### PR TITLE
Dedupe mapper to_orm create/update field copies (#420)

### DIFF
--- a/backend/src/infrastructure/ai/mappers/ai_usage_mapper.py
+++ b/backend/src/infrastructure/ai/mappers/ai_usage_mapper.py
@@ -1,12 +1,13 @@
 from src.domain.ai.entities.ai_usage_record import AIUsageRecord
 from src.domain.common.value_objects.ids import AIUsageRecordId, UserId
+from src.infrastructure.common.mappers import orm_id
 from src.models import AIUsageRecord as AIUsageRecordORM
 
 
 class AIUsageMapper:
     def to_orm(self, entity: AIUsageRecord) -> AIUsageRecordORM:
         return AIUsageRecordORM(
-            id=entity.id.value if entity.id.value != 0 else None,
+            id=orm_id(entity.id),
             user_id=entity.user_id.value,
             task_type=entity.task_type,
             entity_type=entity.entity_type,

--- a/backend/src/infrastructure/common/mappers.py
+++ b/backend/src/infrastructure/common/mappers.py
@@ -1,0 +1,18 @@
+"""Shared helpers for ORM ↔ domain mappers."""
+
+from uuid import UUID
+
+from src.domain.common.entity import EntityId
+
+
+def orm_id(entity_id: EntityId) -> int | UUID | None:
+    """Map a domain ``EntityId`` to an ORM primary key.
+
+    New entities carry the integer sentinel ``0`` until the database assigns a
+    real id; returning ``None`` in that case lets the ORM generate the key on
+    insert. UUID-based ids are always passed through unchanged.
+    """
+    value = entity_id.value
+    if isinstance(value, int) and value == 0:
+        return None
+    return value

--- a/backend/src/infrastructure/identity/mappers/refresh_token_mapper.py
+++ b/backend/src/infrastructure/identity/mappers/refresh_token_mapper.py
@@ -2,6 +2,7 @@
 
 from src.domain.common.value_objects.ids import RefreshTokenId, UserId
 from src.domain.identity.entities.refresh_token import RefreshToken
+from src.infrastructure.common.mappers import orm_id
 from src.models import RefreshToken as RefreshTokenORM
 
 
@@ -21,7 +22,7 @@ class RefreshTokenMapper:
 
     def to_orm(self, domain_entity: RefreshToken) -> RefreshTokenORM:
         return RefreshTokenORM(
-            id=domain_entity.id.value if domain_entity.id.value != 0 else None,
+            id=orm_id(domain_entity.id),
             jti=domain_entity.jti,
             user_id=domain_entity.user_id.value,
             family_id=domain_entity.family_id,

--- a/backend/src/infrastructure/identity/mappers/user_mapper.py
+++ b/backend/src/infrastructure/identity/mappers/user_mapper.py
@@ -2,6 +2,7 @@
 
 from src.domain.common.value_objects.ids import UserId
 from src.domain.identity.entities.user import User
+from src.infrastructure.common.mappers import orm_id
 from src.models import User as UserORM
 
 
@@ -20,15 +21,10 @@ class UserMapper:
 
     def to_orm(self, domain_entity: User, orm_model: UserORM | None = None) -> UserORM:
         """Convert domain entity to ORM model."""
-        if orm_model:
-            # Update existing
-            orm_model.email = domain_entity.email
-            orm_model.hashed_password = domain_entity.hashed_password
-            return orm_model
-
-        # Create new
-        return UserORM(
-            id=domain_entity.id.value if domain_entity.id.value != 0 else None,
-            email=domain_entity.email,
-            hashed_password=domain_entity.hashed_password,
-        )
+        if orm_model is None:
+            orm_model = UserORM(
+                id=orm_id(domain_entity.id),
+            )
+        orm_model.email = domain_entity.email
+        orm_model.hashed_password = domain_entity.hashed_password
+        return orm_model

--- a/backend/src/infrastructure/learning/mappers/ai_chat_session_mapper.py
+++ b/backend/src/infrastructure/learning/mappers/ai_chat_session_mapper.py
@@ -2,6 +2,7 @@
 
 from src.domain.common.value_objects.ids import AIChatSessionId, ChapterId, UserId
 from src.domain.learning.entities.ai_chat_session import AIChatSession
+from src.infrastructure.common.mappers import orm_id
 from src.models import AIChatSession as AIChatSessionModel
 
 
@@ -21,13 +22,11 @@ class AIChatSessionMapper:
 
     def to_orm(self, entity: AIChatSession) -> AIChatSessionModel:
         """Convert domain entity to ORM model."""
-        model = AIChatSessionModel(
+        return AIChatSessionModel(
+            id=orm_id(entity.id),
             user_id=entity.user_id.value,
             chapter_id=entity.chapter_id.value,
             session_type=entity.session_type,
             message_history=entity.message_history,
             created_at=entity.created_at,
         )
-        if entity.id.value != 0:
-            model.id = entity.id.value
-        return model

--- a/backend/src/infrastructure/learning/mappers/flashcard_mapper.py
+++ b/backend/src/infrastructure/learning/mappers/flashcard_mapper.py
@@ -9,6 +9,7 @@ from src.domain.common.value_objects import (
     UserId,
 )
 from src.domain.learning.entities.flashcard import Flashcard
+from src.infrastructure.common.mappers import orm_id
 from src.models import Flashcard as FlashcardORM
 
 
@@ -34,29 +35,17 @@ class FlashcardMapper:
         self, domain_entity: Flashcard, orm_model: FlashcardORM | None = None
     ) -> FlashcardORM:
         """Convert domain entity to ORM model."""
-        if orm_model:
-            # Update existing
-            orm_model.user_id = domain_entity.user_id.value
-            orm_model.book_id = domain_entity.book_id.value
-            orm_model.question = domain_entity.question
-            orm_model.answer = domain_entity.answer
-            orm_model.highlight_id = (
-                domain_entity.highlight_id.value if domain_entity.highlight_id else None
+        if orm_model is None:
+            orm_model = FlashcardORM(
+                id=orm_id(domain_entity.id),
             )
-            orm_model.chapter_id = (
-                domain_entity.chapter_id.value if domain_entity.chapter_id else None
-            )
-            orm_model.note_id = domain_entity.note_id.value if domain_entity.note_id else None
-            return orm_model
-
-        # Create new
-        return FlashcardORM(
-            id=domain_entity.id.value if domain_entity.id.value != 0 else None,
-            user_id=domain_entity.user_id.value,
-            book_id=domain_entity.book_id.value,
-            question=domain_entity.question,
-            answer=domain_entity.answer,
-            highlight_id=domain_entity.highlight_id.value if domain_entity.highlight_id else None,
-            chapter_id=domain_entity.chapter_id.value if domain_entity.chapter_id else None,
-            note_id=domain_entity.note_id.value if domain_entity.note_id else None,
+        orm_model.user_id = domain_entity.user_id.value
+        orm_model.book_id = domain_entity.book_id.value
+        orm_model.question = domain_entity.question
+        orm_model.answer = domain_entity.answer
+        orm_model.highlight_id = (
+            domain_entity.highlight_id.value if domain_entity.highlight_id else None
         )
+        orm_model.chapter_id = domain_entity.chapter_id.value if domain_entity.chapter_id else None
+        orm_model.note_id = domain_entity.note_id.value if domain_entity.note_id else None
+        return orm_model

--- a/backend/src/infrastructure/library/mappers/book_mapper.py
+++ b/backend/src/infrastructure/library/mappers/book_mapper.py
@@ -1,6 +1,7 @@
 from src.domain.common.value_objects.ids import BookId, UserId
 from src.domain.common.value_objects.position import Position
 from src.domain.library.entities.book import Book
+from src.infrastructure.common.mappers import orm_id
 from src.models import Book as BookORM
 
 
@@ -33,44 +34,25 @@ class BookMapper:
 
     def to_orm(self, domain_entity: Book, orm_model: BookORM | None = None) -> BookORM:
         """Convert domain entity to ORM model."""
-        if orm_model:
-            # Update existing
-            orm_model.user_id = domain_entity.user_id.value
-            orm_model.title = domain_entity.title
-            orm_model.client_book_id = domain_entity.client_book_id
-            orm_model.author = domain_entity.author
-            orm_model.isbn = domain_entity.isbn
-            orm_model.description = domain_entity.description
-            orm_model.language = domain_entity.language
-            orm_model.page_count = domain_entity.page_count
-            orm_model.ebook_file = domain_entity.ebook_file
-            orm_model.file_type = domain_entity.file_type
-            orm_model.cover_file = domain_entity.cover_file
-            orm_model.cover_blurhash = domain_entity.cover_blurhash
-            orm_model.last_viewed = domain_entity.last_viewed
-            orm_model.end_position = (
-                domain_entity.end_position.to_json() if domain_entity.end_position else None
+        if orm_model is None:
+            orm_model = BookORM(
+                id=orm_id(domain_entity.id),
+                created_at=domain_entity.created_at,
             )
-            return orm_model
-
-        # Create new
-        return BookORM(
-            id=domain_entity.id.value if domain_entity.id.value != 0 else None,
-            user_id=domain_entity.user_id.value,
-            title=domain_entity.title,
-            client_book_id=domain_entity.client_book_id,
-            author=domain_entity.author,
-            isbn=domain_entity.isbn,
-            description=domain_entity.description,
-            language=domain_entity.language,
-            page_count=domain_entity.page_count,
-            ebook_file=domain_entity.ebook_file,
-            file_type=domain_entity.file_type,
-            cover_file=domain_entity.cover_file,
-            cover_blurhash=domain_entity.cover_blurhash,
-            created_at=domain_entity.created_at,
-            last_viewed=domain_entity.last_viewed,
-            end_position=domain_entity.end_position.to_json()
-            if domain_entity.end_position
-            else None,
+        orm_model.user_id = domain_entity.user_id.value
+        orm_model.title = domain_entity.title
+        orm_model.client_book_id = domain_entity.client_book_id
+        orm_model.author = domain_entity.author
+        orm_model.isbn = domain_entity.isbn
+        orm_model.description = domain_entity.description
+        orm_model.language = domain_entity.language
+        orm_model.page_count = domain_entity.page_count
+        orm_model.ebook_file = domain_entity.ebook_file
+        orm_model.file_type = domain_entity.file_type
+        orm_model.cover_file = domain_entity.cover_file
+        orm_model.cover_blurhash = domain_entity.cover_blurhash
+        orm_model.last_viewed = domain_entity.last_viewed
+        orm_model.end_position = (
+            domain_entity.end_position.to_json() if domain_entity.end_position else None
         )
+        return orm_model

--- a/backend/src/infrastructure/library/mappers/chapter_mapper.py
+++ b/backend/src/infrastructure/library/mappers/chapter_mapper.py
@@ -1,6 +1,7 @@
 from src.domain.common.value_objects.ids import BookId, ChapterId
 from src.domain.common.value_objects.position import Position
 from src.domain.library.entities.chapter import Chapter
+from src.infrastructure.common.mappers import orm_id
 from src.models import Chapter as ChapterORM
 
 
@@ -31,36 +32,21 @@ class ChapterMapper:
 
     def to_orm(self, domain_entity: Chapter, orm_model: ChapterORM | None = None) -> ChapterORM:
         """Convert domain entity to ORM model."""
-        if orm_model:
-            # Update existing
-            orm_model.book_id = domain_entity.book_id.value
-            orm_model.parent_id = domain_entity.parent_id.value if domain_entity.parent_id else None
-            orm_model.name = domain_entity.name
-            orm_model.chapter_number = domain_entity.chapter_number
-            orm_model.start_xpoint = domain_entity.start_xpoint
-            orm_model.end_xpoint = domain_entity.end_xpoint
-            orm_model.start_position = (
-                domain_entity.start_position.to_json() if domain_entity.start_position else None
+        if orm_model is None:
+            orm_model = ChapterORM(
+                id=orm_id(domain_entity.id),
+                created_at=domain_entity.created_at,
             )
-            orm_model.end_position = (
-                domain_entity.end_position.to_json() if domain_entity.end_position else None
-            )
-            return orm_model
-
-        # Create new
-        return ChapterORM(
-            id=domain_entity.id.value if domain_entity.id.value != 0 else None,
-            book_id=domain_entity.book_id.value,
-            parent_id=domain_entity.parent_id.value if domain_entity.parent_id else None,
-            name=domain_entity.name,
-            chapter_number=domain_entity.chapter_number,
-            start_xpoint=domain_entity.start_xpoint,
-            end_xpoint=domain_entity.end_xpoint,
-            start_position=domain_entity.start_position.to_json()
-            if domain_entity.start_position
-            else None,
-            end_position=domain_entity.end_position.to_json()
-            if domain_entity.end_position
-            else None,
-            created_at=domain_entity.created_at,
+        orm_model.book_id = domain_entity.book_id.value
+        orm_model.parent_id = domain_entity.parent_id.value if domain_entity.parent_id else None
+        orm_model.name = domain_entity.name
+        orm_model.chapter_number = domain_entity.chapter_number
+        orm_model.start_xpoint = domain_entity.start_xpoint
+        orm_model.end_xpoint = domain_entity.end_xpoint
+        orm_model.start_position = (
+            domain_entity.start_position.to_json() if domain_entity.start_position else None
         )
+        orm_model.end_position = (
+            domain_entity.end_position.to_json() if domain_entity.end_position else None
+        )
+        return orm_model

--- a/backend/src/infrastructure/notes/mappers/note_mapper.py
+++ b/backend/src/infrastructure/notes/mappers/note_mapper.py
@@ -2,6 +2,7 @@
 
 from src.domain.common.value_objects import NoteId, UserId
 from src.domain.notes.entities.note import Note, NoteKind
+from src.infrastructure.common.mappers import orm_id
 from src.models import Note as NoteORM
 
 
@@ -30,17 +31,12 @@ class NoteMapper:
         Association collections are synced separately by the repository,
         which loads the referenced ORM rows.
         """
-        if orm_model:
-            orm_model.user_id = domain_entity.user_id.value
-            orm_model.title = domain_entity.title
-            orm_model.body = domain_entity.body
-            orm_model.kind = domain_entity.kind.value if domain_entity.kind else None
-            return orm_model
-
-        return NoteORM(
-            id=domain_entity.id.value if domain_entity.id.value != 0 else None,
-            user_id=domain_entity.user_id.value,
-            title=domain_entity.title,
-            body=domain_entity.body,
-            kind=domain_entity.kind.value if domain_entity.kind else None,
-        )
+        if orm_model is None:
+            orm_model = NoteORM(
+                id=orm_id(domain_entity.id),
+            )
+        orm_model.user_id = domain_entity.user_id.value
+        orm_model.title = domain_entity.title
+        orm_model.body = domain_entity.body
+        orm_model.kind = domain_entity.kind.value if domain_entity.kind else None
+        return orm_model

--- a/backend/src/infrastructure/reading/mappers/bookmark_mapper.py
+++ b/backend/src/infrastructure/reading/mappers/bookmark_mapper.py
@@ -2,6 +2,7 @@
 
 from src.domain.common.value_objects.ids import BookId, BookmarkId, HighlightId
 from src.domain.reading.entities.bookmark import Bookmark
+from src.infrastructure.common.mappers import orm_id
 from src.models import Bookmark as BookmarkORM
 
 
@@ -19,14 +20,11 @@ class BookmarkMapper:
 
     def to_orm(self, domain_entity: Bookmark, orm_model: BookmarkORM | None = None) -> BookmarkORM:
         """Convert domain entity to ORM model."""
-        if orm_model:
-            # Update existing (bookmarks are immutable except cascade deletes)
-            # No fields to update for bookmarks
-            return orm_model
-
-        # Create new
-        return BookmarkORM(
-            id=domain_entity.id.value if domain_entity.id.value != 0 else None,
-            book_id=domain_entity.book_id.value,
-            highlight_id=domain_entity.highlight_id.value,
-        )
+        # Bookmarks are immutable except cascade deletes — no mutable fields.
+        if orm_model is None:
+            orm_model = BookmarkORM(
+                id=orm_id(domain_entity.id),
+                book_id=domain_entity.book_id.value,
+                highlight_id=domain_entity.highlight_id.value,
+            )
+        return orm_model

--- a/backend/src/infrastructure/reading/mappers/chapter_prereading_mapper.py
+++ b/backend/src/infrastructure/reading/mappers/chapter_prereading_mapper.py
@@ -5,6 +5,7 @@ from src.domain.reading.entities.chapter_prereading_content import (
     ChapterPrereadingContent,
     PrereadingQuestion,
 )
+from src.infrastructure.common.mappers import orm_id
 from src.models import ChapterPrereadingContent as PrereadingContentORM
 
 
@@ -39,21 +40,14 @@ class ChapterPrereadingMapper:
             for q in entity.questions
         ]
 
-        if orm:
-            orm.chapter_id = entity.chapter_id.value
-            orm.summary = entity.summary
-            orm.keypoints = entity.keypoints
-            orm.questions = questions
-            orm.generated_at = entity.generated_at
-            orm.ai_model = entity.ai_model
-            return orm
-
-        return PrereadingContentORM(
-            id=entity.id.value if entity.id.value != 0 else None,
-            chapter_id=entity.chapter_id.value,
-            summary=entity.summary,
-            keypoints=entity.keypoints,
-            questions=questions,
-            generated_at=entity.generated_at,
-            ai_model=entity.ai_model,
-        )
+        if orm is None:
+            orm = PrereadingContentORM(
+                id=orm_id(entity.id),
+            )
+        orm.chapter_id = entity.chapter_id.value
+        orm.summary = entity.summary
+        orm.keypoints = entity.keypoints
+        orm.questions = questions
+        orm.generated_at = entity.generated_at
+        orm.ai_model = entity.ai_model
+        return orm

--- a/backend/src/infrastructure/reading/mappers/highlight_mapper.py
+++ b/backend/src/infrastructure/reading/mappers/highlight_mapper.py
@@ -16,6 +16,7 @@ from src.domain.common.value_objects import (
 )
 from src.domain.common.value_objects.position import Position
 from src.domain.reading.entities.highlight import Highlight
+from src.infrastructure.common.mappers import orm_id
 from src.models import Highlight as HighlightORM
 
 
@@ -86,42 +87,27 @@ class HighlightMapper:
         datetime_str = domain_entity.datetime
 
         # Update existing ORM model or create new one
-        if orm_model:
-            # Update existing model
-            orm_model.user_id = domain_entity.user_id.value
-            orm_model.book_id = domain_entity.book_id.value
-            orm_model.chapter_id = (
-                domain_entity.chapter_id.value if domain_entity.chapter_id else None
+        if orm_model is None:
+            orm_model = HighlightORM(
+                id=orm_id(domain_entity.id),
+                datetime=datetime_str,
+                created_at=domain_entity.created_at,
             )
-            orm_model.text = domain_entity.text
-            orm_model.content_hash = domain_entity.content_hash.value
-            orm_model.page = domain_entity.page
-            orm_model.start_xpoint = start_xpoint
-            orm_model.end_xpoint = end_xpoint
-            orm_model.position = (
-                domain_entity.position.to_json() if domain_entity.position else None
-            )
-            orm_model.highlight_style_id = (
-                domain_entity.highlight_style_id.value if domain_entity.highlight_style_id else None
-            )
-            orm_model.deleted_at = domain_entity.deleted_at
-            return orm_model
-        # Create new model
-        return HighlightORM(
-            id=domain_entity.id.value if domain_entity.id.value != 0 else None,
-            user_id=domain_entity.user_id.value,
-            book_id=domain_entity.book_id.value,
-            chapter_id=domain_entity.chapter_id.value if domain_entity.chapter_id else None,
-            text=domain_entity.text,
-            content_hash=domain_entity.content_hash.value,
-            page=domain_entity.page,
-            position=domain_entity.position.to_json() if domain_entity.position else None,
-            highlight_style_id=domain_entity.highlight_style_id.value
-            if domain_entity.highlight_style_id
-            else None,
-            start_xpoint=start_xpoint,
-            end_xpoint=end_xpoint,
-            datetime=datetime_str,
-            created_at=domain_entity.created_at,
-            deleted_at=domain_entity.deleted_at,
+        orm_model.user_id = domain_entity.user_id.value
+        orm_model.book_id = domain_entity.book_id.value
+        orm_model.chapter_id = (
+            domain_entity.chapter_id.value if domain_entity.chapter_id else None
         )
+        orm_model.text = domain_entity.text
+        orm_model.content_hash = domain_entity.content_hash.value
+        orm_model.page = domain_entity.page
+        orm_model.start_xpoint = start_xpoint
+        orm_model.end_xpoint = end_xpoint
+        orm_model.position = (
+            domain_entity.position.to_json() if domain_entity.position else None
+        )
+        orm_model.highlight_style_id = (
+            domain_entity.highlight_style_id.value if domain_entity.highlight_style_id else None
+        )
+        orm_model.deleted_at = domain_entity.deleted_at
+        return orm_model

--- a/backend/src/infrastructure/reading/mappers/highlight_mapper.py
+++ b/backend/src/infrastructure/reading/mappers/highlight_mapper.py
@@ -95,17 +95,13 @@ class HighlightMapper:
             )
         orm_model.user_id = domain_entity.user_id.value
         orm_model.book_id = domain_entity.book_id.value
-        orm_model.chapter_id = (
-            domain_entity.chapter_id.value if domain_entity.chapter_id else None
-        )
+        orm_model.chapter_id = domain_entity.chapter_id.value if domain_entity.chapter_id else None
         orm_model.text = domain_entity.text
         orm_model.content_hash = domain_entity.content_hash.value
         orm_model.page = domain_entity.page
         orm_model.start_xpoint = start_xpoint
         orm_model.end_xpoint = end_xpoint
-        orm_model.position = (
-            domain_entity.position.to_json() if domain_entity.position else None
-        )
+        orm_model.position = domain_entity.position.to_json() if domain_entity.position else None
         orm_model.highlight_style_id = (
             domain_entity.highlight_style_id.value if domain_entity.highlight_style_id else None
         )

--- a/backend/src/infrastructure/reading/mappers/highlight_style_mapper.py
+++ b/backend/src/infrastructure/reading/mappers/highlight_style_mapper.py
@@ -2,6 +2,7 @@
 
 from src.domain.common.value_objects import BookId, HighlightStyleId, UserId
 from src.domain.reading.entities.highlight_style import HighlightStyle
+from src.infrastructure.common.mappers import orm_id
 from src.models import HighlightStyle as HighlightStyleORM
 
 
@@ -28,19 +29,17 @@ class HighlightStyleMapper:
         orm_model: HighlightStyleORM | None = None,
     ) -> HighlightStyleORM:
         """Convert domain entity to ORM model."""
-        if orm_model:
-            orm_model.label = domain_entity.label
-            orm_model.ui_color = domain_entity.ui_color
+        if orm_model is None:
+            orm_model = HighlightStyleORM(
+                id=orm_id(domain_entity.id),
+                user_id=domain_entity.user_id.value,
+                book_id=domain_entity.book_id.value if domain_entity.book_id else None,
+                device_color=domain_entity.device_color,
+                device_style=domain_entity.device_style,
+                created_at=domain_entity.created_at,
+            )
+        else:
             orm_model.updated_at = domain_entity.updated_at
-            return orm_model
-
-        return HighlightStyleORM(
-            id=domain_entity.id.value if domain_entity.id.value != 0 else None,
-            user_id=domain_entity.user_id.value,
-            book_id=domain_entity.book_id.value if domain_entity.book_id else None,
-            device_color=domain_entity.device_color,
-            device_style=domain_entity.device_style,
-            label=domain_entity.label,
-            ui_color=domain_entity.ui_color,
-            created_at=domain_entity.created_at,
-        )
+        orm_model.label = domain_entity.label
+        orm_model.ui_color = domain_entity.ui_color
+        return orm_model

--- a/backend/src/infrastructure/reading/mappers/reading_session_mapper.py
+++ b/backend/src/infrastructure/reading/mappers/reading_session_mapper.py
@@ -8,6 +8,7 @@ from src.domain.common.value_objects import (
 )
 from src.domain.common.value_objects.position import Position
 from src.domain.reading.entities.reading_session import ReadingSession
+from src.infrastructure.common.mappers import orm_id
 from src.models import ReadingSession as ReadingSessionORM
 
 
@@ -65,45 +66,25 @@ class ReadingSessionMapper:
             start_xpoint_str = domain_entity.start_xpoint.start.to_string()
             end_xpoint_str = domain_entity.start_xpoint.end.to_string()
 
-        if orm_model:
-            # Update existing
-            orm_model.user_id = domain_entity.user_id.value
-            orm_model.book_id = domain_entity.book_id.value
-            orm_model.start_time = domain_entity.start_time
-            orm_model.end_time = domain_entity.end_time
-            orm_model.content_hash = domain_entity.content_hash.value
-            orm_model.start_xpoint = start_xpoint_str
-            orm_model.end_xpoint = end_xpoint_str
-            orm_model.start_page = domain_entity.start_page
-            orm_model.end_page = domain_entity.end_page
-            orm_model.start_position = (
-                domain_entity.start_position.to_json() if domain_entity.start_position else None
+        if orm_model is None:
+            orm_model = ReadingSessionORM(
+                id=orm_id(domain_entity.id),
             )
-            orm_model.end_position = (
-                domain_entity.end_position.to_json() if domain_entity.end_position else None
-            )
-            orm_model.device_id = domain_entity.device_id
-            orm_model.ai_summary = domain_entity.ai_summary
-            return orm_model
-
-        # Create new
-        return ReadingSessionORM(
-            id=domain_entity.id.value if domain_entity.id.value != 0 else None,
-            user_id=domain_entity.user_id.value,
-            book_id=domain_entity.book_id.value,
-            start_time=domain_entity.start_time,
-            end_time=domain_entity.end_time,
-            content_hash=domain_entity.content_hash.value,
-            start_xpoint=start_xpoint_str,
-            end_xpoint=end_xpoint_str,
-            start_page=domain_entity.start_page,
-            end_page=domain_entity.end_page,
-            start_position=domain_entity.start_position.to_json()
-            if domain_entity.start_position
-            else None,
-            end_position=domain_entity.end_position.to_json()
-            if domain_entity.end_position
-            else None,
-            device_id=domain_entity.device_id,
-            ai_summary=domain_entity.ai_summary,
+        orm_model.user_id = domain_entity.user_id.value
+        orm_model.book_id = domain_entity.book_id.value
+        orm_model.start_time = domain_entity.start_time
+        orm_model.end_time = domain_entity.end_time
+        orm_model.content_hash = domain_entity.content_hash.value
+        orm_model.start_xpoint = start_xpoint_str
+        orm_model.end_xpoint = end_xpoint_str
+        orm_model.start_page = domain_entity.start_page
+        orm_model.end_page = domain_entity.end_page
+        orm_model.start_position = (
+            domain_entity.start_position.to_json() if domain_entity.start_position else None
         )
+        orm_model.end_position = (
+            domain_entity.end_position.to_json() if domain_entity.end_position else None
+        )
+        orm_model.device_id = domain_entity.device_id
+        orm_model.ai_summary = domain_entity.ai_summary
+        return orm_model

--- a/backend/src/infrastructure/reading/mappers/tag_group_mapper.py
+++ b/backend/src/infrastructure/reading/mappers/tag_group_mapper.py
@@ -2,6 +2,7 @@
 
 from src.domain.common.value_objects.ids import BookId, TagGroupId
 from src.domain.reading.entities.tag_group import TagGroup
+from src.infrastructure.common.mappers import orm_id
 from src.models import TagGroup as TagGroupORM
 
 
@@ -22,14 +23,10 @@ class TagGroupMapper:
         orm_model: TagGroupORM | None = None,
     ) -> TagGroupORM:
         """Convert domain entity to ORM model."""
-        if orm_model:
-            # Update existing
-            orm_model.name = entity.name
-            return orm_model
-
-        # Create new
-        return TagGroupORM(
-            id=entity.id.value if entity.id.value != 0 else None,
-            book_id=entity.book_id.value,
-            name=entity.name,
-        )
+        if orm_model is None:
+            orm_model = TagGroupORM(
+                id=orm_id(entity.id),
+                book_id=entity.book_id.value,
+            )
+        orm_model.name = entity.name
+        return orm_model

--- a/backend/src/infrastructure/reading/mappers/tag_mapper.py
+++ b/backend/src/infrastructure/reading/mappers/tag_mapper.py
@@ -4,6 +4,7 @@ from sqlalchemy import inspect
 
 from src.domain.common.value_objects.ids import BookId, TagId, UserId
 from src.domain.reading.entities.tag import Tag
+from src.infrastructure.common.mappers import orm_id
 from src.models import Tag as TagORM
 
 
@@ -32,19 +33,12 @@ class TagMapper:
 
     def to_orm(self, domain_entity: Tag, orm_model: TagORM | None = None) -> TagORM:
         """Convert domain entity to ORM model."""
-        if orm_model:
-            # Update existing
-            orm_model.user_id = domain_entity.user_id.value
-            orm_model.book_id = domain_entity.book_id.value
-            orm_model.name = domain_entity.name
-            orm_model.tag_group_id = domain_entity.tag_group_id
-            return orm_model
-
-        # Create new
-        return TagORM(
-            id=domain_entity.id.value if domain_entity.id.value != 0 else None,
-            user_id=domain_entity.user_id.value,
-            book_id=domain_entity.book_id.value,
-            name=domain_entity.name,
-            tag_group_id=domain_entity.tag_group_id,
-        )
+        if orm_model is None:
+            orm_model = TagORM(
+                id=orm_id(domain_entity.id),
+            )
+        orm_model.user_id = domain_entity.user_id.value
+        orm_model.book_id = domain_entity.book_id.value
+        orm_model.name = domain_entity.name
+        orm_model.tag_group_id = domain_entity.tag_group_id
+        return orm_model


### PR DESCRIPTION
## Summary

Addresses the mapper half of #420. Every ORM↔domain mapper repeated its scalar field copies twice in `to_orm` — once in the `if orm_model:` update branch and again in the create-branch constructor — plus the `id.value if != 0 else None` sentinel in each of the 14 that had it.

- Adds a shared `orm_id()` helper (`infrastructure/common/mappers.py`) mapping the `0` id sentinel to `None`.
- Collapses each `to_orm` to a single path: create-only fields (`id`, `created_at`, immutable fields) in the constructor, mutable fields assigned once for both create and update.
- Net **−83 lines** across 16 files.

## Behaviour preservation

Every diff was reviewed to keep create/update behaviour identical:
- `highlight_mapper`: `datetime` kept **create-only** (never written on update).
- `highlight_style_mapper`: `updated_at` is **update-only** — preserved via an `else` branch.
- Create-only mappers (`ai_usage`, `refresh_token`, `ai_chat_session`) fold `id` into the constructor.
- `job_batch_mapper` was already in this shape — left untouched.

## Not included

The second half of #420 (slimming `containers/reading.py`) is intentionally left out: it's idiomatic `dependency_injector` wiring with no clean mechanical win short of an architecture change. Happy to revisit separately.

## Verification

- `uv run pyright src/infrastructure` — 0 errors
- `uv run ruff check src/infrastructure` — clean
- `uv run pytest` — 428 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)