### PR TITLE
Add ruff format to pre-commit and editor hooks

### DIFF
--- a/.claude/check-files.sh
+++ b/.claude/check-files.sh
@@ -14,6 +14,9 @@ for file in $CLAUDE_FILE_PATHS; do
         *.py)
             echo "━━━ Checking Python: $file ━━━"
 
+            # Run ruff (formatter) - keeps files matching CI's `ruff format --check`
+            cd "$PROJECT_ROOT/backend" && uv run ruff format "$file" 2>&1 | head -5
+
             # Run ruff (linter)
             if cd "$PROJECT_ROOT/backend" && uv run ruff check "$file" 2>&1 | head -20; then
                 echo "✓ Ruff: no issues"

--- a/.claude/hooks/format-all.sh
+++ b/.claude/hooks/format-all.sh
@@ -1,18 +1,23 @@
 #!/bin/bash
+# PostToolUse hook: auto-format and check files after Edit/Write.
+# Backend uses ruff (via uv) + pyright; frontend uses the workspace scripts.
+# Must run tools through `uv run` / `npm` with the correct working directory —
+# bare `ruff`/`pyright` are not on PATH, which previously made this a silent no-op.
 
 file_path=$(jq -r '.tool_input.file_path' 2>/dev/null)
+[[ -z "$file_path" || "$file_path" == "null" ]] && exit 0
+
+root="${CLAUDE_PROJECT_DIR:-$(git -C "$(dirname "$file_path")" rev-parse --show-toplevel 2>/dev/null)}"
+[[ -z "$root" ]] && exit 0
 
 # Backend Python files
 if [[ "$file_path" == *.py ]]; then
-  ruff format "$file_path" 2>/dev/null
-  ruff check "$file_path" 2>/dev/null
-  pyright "$file_path" 2>/dev/null
+  (cd "$root/backend" && uv run ruff format "$file_path" && uv run ruff check --fix "$file_path" && uv run pyright "$file_path")
 fi
 
 # Frontend files
 if [[ "$file_path" =~ \.(ts|tsx|js|jsx)$ ]]; then
-  npm run format -- "$file_path" 2>/dev/null
-  npm run lint -- "$file_path" 2>/dev/null
+  (cd "$root/frontend" && npm run format -- "$file_path" && npm run lint -- "$file_path")
 fi
 
 exit 0

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
       "bash -c 'cd frontend && prettier --write \"$0\"'"
     ],
     "backend/**/*.py": [
+      "bash -c 'cd backend && uv run ruff format \"$0\"'",
       "bash -c 'cd backend && uv run ruff check --fix \"$0\"'",
       "bash -c 'cd backend && uv run pyright \"$0\"'"
     ]


### PR DESCRIPTION
## Problem

CI fails intermittently on backend formatting even though local commits pass. Root cause: our gates run `ruff check` but not `ruff format`, while CI runs **both** (`ruff format --check .` *and* `ruff check .`). `ruff check --fix` fixes lint rules, not code layout (e.g. line wrapping) — so unformatted-but-lint-clean Python commits fine and only fails in CI.

A second, quieter cause: the Claude editor hook `.claude/hooks/format-all.sh` was a **silent no-op** — it invoked bare `ruff`/`pyright` (not on PATH) with `2>/dev/null` + `exit 0`, so it never formatted anything.

## Fix — three layers, all now mirror CI

1. **`lint-staged` (`backend/**/*.py`)** — run `uv run ruff format` before `ruff check --fix`. This is the real guarantee: **every commit** is formatted at pre-commit time regardless of editor.
2. **`.claude/hooks/format-all.sh`** — run tools via `uv run` from the `backend`/`frontend` dirs (and stop swallowing failures) so in-session edits are formatted immediately.
3. **`.claude/check-files.sh`** — add a `ruff format` pass alongside the existing lint check.

## Verification

- `jq empty package.json` — valid.
- Confirmed `uv run ruff format` reformats a deliberately mis-indented file (layout `ruff check --fix` leaves untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)