### PR TITLE
Upgrade FastAPI to 0.139 and starlette to 1.3.1

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -6,7 +6,7 @@ authors = [{ name = "User", email = "user@example.com" }]
 readme = "README.md"
 requires-python = ">=3.11,<4.0"
 dependencies = [
-  "fastapi>=0.121.1,<0.136.0",
+  "fastapi>=0.139.0,<0.140.0",
   "uvicorn[standard]>=0.44.0,<0.45.0",
   "sqlalchemy[asyncio]>=2.0.44,<3.0.0",
   "alembic>=1.17.1,<2.0.0",

--- a/backend/tests/test_bookmarks.py
+++ b/backend/tests/test_bookmarks.py
@@ -1,7 +1,5 @@
 """Tests for bookmarks API endpoints."""
 
-import json
-
 import pytest
 from fastapi import status
 from httpx import AsyncClient
@@ -375,7 +373,7 @@ class TestBookmarkCascadeDelete:
         # Soft delete the highlight
         payload = {"highlight_ids": [test_highlight.id]}
         response = await client.request(
-            "DELETE", f"/api/v1/books/{test_book.id}/highlight", content=json.dumps(payload)
+            "DELETE", f"/api/v1/books/{test_book.id}/highlight", json=payload
         )
         assert response.status_code == status.HTTP_200_OK
 

--- a/backend/tests/test_books.py
+++ b/backend/tests/test_books.py
@@ -1,6 +1,5 @@
 """Tests for books API endpoints."""
 
-import json
 from datetime import UTC, datetime
 from typing import NamedTuple
 
@@ -188,7 +187,7 @@ class TestDeleteHighlights:
 
         payload = {"highlight_ids": [highlight1.id, highlight2.id]}
         response = await client.request(
-            "DELETE", f"/api/v1/books/{book.id}/highlight", content=json.dumps(payload)
+            "DELETE", f"/api/v1/books/{book.id}/highlight", json=payload
         )
 
         assert response.status_code == status.HTTP_200_OK
@@ -215,7 +214,7 @@ class TestDeleteHighlights:
 
         payload = {"highlight_ids": [highlight1.id]}
         response = await client.request(
-            "DELETE", f"/api/v1/books/{book.id}/highlight", content=json.dumps(payload)
+            "DELETE", f"/api/v1/books/{book.id}/highlight", json=payload
         )
 
         assert response.status_code == status.HTTP_200_OK
@@ -239,7 +238,7 @@ class TestDeleteHighlights:
 
         payload = {"highlight_ids": [highlight.id]}
         response = await client.request(
-            "DELETE", f"/api/v1/books/{book.id}/highlight", content=json.dumps(payload)
+            "DELETE", f"/api/v1/books/{book.id}/highlight", json=payload
         )
 
         assert response.status_code == status.HTTP_200_OK
@@ -276,7 +275,7 @@ class TestDeleteHighlights:
         # Try to delete book1's highlight using book2's ID
         payload = {"highlight_ids": [highlight1.id]}
         response = await client.request(
-            "DELETE", f"/api/v1/books/{book2.id}/highlight", content=json.dumps(payload)
+            "DELETE", f"/api/v1/books/{book2.id}/highlight", json=payload
         )
 
         assert response.status_code == status.HTTP_200_OK
@@ -290,9 +289,7 @@ class TestDeleteHighlights:
     async def test_delete_highlights_book_not_found(self, client: AsyncClient) -> None:
         """Test deletion of highlights for non-existent book."""
         payload = {"highlight_ids": [1, 2, 3]}
-        response = await client.request(
-            "DELETE", "/api/v1/books/99999/highlight", content=json.dumps(payload)
-        )
+        response = await client.request("DELETE", "/api/v1/books/99999/highlight", json=payload)
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
         data = response.json()
@@ -304,7 +301,7 @@ class TestDeleteHighlights:
         """Test deletion with empty highlight list."""
         payload = {"highlight_ids": []}
         response = await client.request(
-            "DELETE", f"/api/v1/books/{test_book.id}/highlight", content=json.dumps(payload)
+            "DELETE", f"/api/v1/books/{test_book.id}/highlight", json=payload
         )
 
         # Should fail validation because of min_length=1

--- a/backend/tests/test_ereader_epub_upload.py
+++ b/backend/tests/test_ereader_epub_upload.py
@@ -1,0 +1,135 @@
+"""Tests for the ereader EPUB upload endpoint (multipart form parsing)."""
+
+from pathlib import Path
+
+import pytest
+from ebooklib import epub
+from fastapi import status
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src import models
+from src.infrastructure.library.repositories import file_repository
+from tests.conftest import create_test_book
+
+CLIENT_BOOK_ID = "test-client-book-1"
+
+
+def _build_epub(path: Path) -> bytes:
+    book = epub.EpubBook()
+    book.set_identifier("upload-test-epub")
+    book.set_title("Uploaded Book")
+    book.set_language("en")
+
+    chapter = epub.EpubHtml(title="Chapter 1", file_name="chap01.xhtml", lang="en")
+    chapter.content = "<h1>Chapter 1</h1><p>Some content.</p>"
+    book.add_item(chapter)
+    book.toc = [epub.Link("chap01.xhtml", "Chapter 1", "chap01")]
+    book.add_item(epub.EpubNcx())
+    book.add_item(epub.EpubNav())
+    book.spine = ["nav", chapter]
+
+    epub.write_epub(str(path), book)
+    return path.read_bytes()
+
+
+@pytest.fixture
+def epub_bytes(tmp_path: Path) -> bytes:
+    return _build_epub(tmp_path / "upload.epub")
+
+
+@pytest.fixture
+def storage_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    epubs_dir = tmp_path / "epubs"
+    monkeypatch.setattr(file_repository, "EPUBS_DIR", epubs_dir)
+    monkeypatch.setattr(file_repository, "BOOK_COVERS_DIR", tmp_path / "covers")
+    return epubs_dir
+
+
+@pytest.fixture
+async def ereader_book(db_session: AsyncSession, test_user: models.User) -> models.Book:
+    return await create_test_book(
+        db_session=db_session,
+        user_id=test_user.id,
+        title="Ereader Book",
+        client_book_id=CLIENT_BOOK_ID,
+    )
+
+
+class TestEpubUpload:
+    async def test_upload_success_stores_file(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        ereader_book: models.Book,
+        epub_bytes: bytes,
+        storage_dir: Path,
+    ) -> None:
+        response = await client.post(
+            f"/api/v1/ereader/books/{CLIENT_BOOK_ID}/epub",
+            files={"epub": ("book.epub", epub_bytes, "application/epub+zip")},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["success"] is True
+
+        await db_session.refresh(ereader_book)
+        assert ereader_book.ebook_file is not None
+        assert (storage_dir / ereader_book.ebook_file).read_bytes() == epub_bytes
+
+    async def test_upload_creates_chapters_from_toc(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        ereader_book: models.Book,
+        epub_bytes: bytes,
+        storage_dir: Path,
+    ) -> None:
+        response = await client.post(
+            f"/api/v1/ereader/books/{CLIENT_BOOK_ID}/epub",
+            files={"epub": ("book.epub", epub_bytes, "application/epub+zip")},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        result = await db_session.execute(select(models.Chapter).filter_by(book_id=ereader_book.id))
+        chapter_names = [chapter.name for chapter in result.scalars().all()]
+        assert "Chapter 1" in chapter_names
+
+    async def test_upload_rejects_wrong_content_type(
+        self,
+        client: AsyncClient,
+        ereader_book: models.Book,
+    ) -> None:
+        response = await client.post(
+            f"/api/v1/ereader/books/{CLIENT_BOOK_ID}/epub",
+            files={"epub": ("book.txt", b"not an epub", "text/plain")},
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    async def test_upload_rejects_invalid_epub_content(
+        self,
+        client: AsyncClient,
+        ereader_book: models.Book,
+        storage_dir: Path,
+    ) -> None:
+        response = await client.post(
+            f"/api/v1/ereader/books/{CLIENT_BOOK_ID}/epub",
+            files={"epub": ("book.epub", b"garbage bytes", "application/epub+zip")},
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    async def test_upload_unknown_client_book_id_returns_404(
+        self,
+        client: AsyncClient,
+        epub_bytes: bytes,
+        storage_dir: Path,
+    ) -> None:
+        response = await client.post(
+            "/api/v1/ereader/books/no-such-book/epub",
+            files={"epub": ("book.epub", epub_bytes, "application/epub+zip")},
+        )
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND

--- a/backend/tests/test_flashcards.py
+++ b/backend/tests/test_flashcards.py
@@ -1,7 +1,5 @@
 """Tests for flashcards API endpoints."""
 
-import json
-
 from fastapi import status
 from httpx import AsyncClient
 from sqlalchemy import select
@@ -427,7 +425,7 @@ class TestFlashcardCascadeDelete:
         # Soft delete the highlight
         payload = {"highlight_ids": [test_highlight.id]}
         response = await client.request(
-            "DELETE", f"/api/v1/books/{test_book.id}/highlight", content=json.dumps(payload)
+            "DELETE", f"/api/v1/books/{test_book.id}/highlight", json=payload
         )
         assert response.status_code == status.HTTP_200_OK
 

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -664,7 +664,7 @@ requires-dist = [
     { name = "boto3", specifier = ">=1.38.0,<2.0.0" },
     { name = "dependency-injector", specifier = ">=4.49.0,<5.0.0" },
     { name = "ebooklib", specifier = ">=0.20,<1.0" },
-    { name = "fastapi", specifier = ">=0.121.1,<0.136.0" },
+    { name = "fastapi", specifier = ">=0.139.0,<0.140.0" },
     { name = "httpx", specifier = ">=0.28.1,<0.29.0" },
     { name = "pillow", specifier = ">=11.0.0" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.2.12,<4.0.0" },
@@ -892,7 +892,7 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.129.2"
+version = "0.139.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -901,9 +901,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fd/cc/1b0d90ed759ff8c9dbc4800de7475d4e9256a81b97b45bd05a1affcb350a/fastapi-0.129.2.tar.gz", hash = "sha256:e2b3637a2b47856e704dbd9a3a09393f6df48e8b9cb6c7a3e26ba44d2053f9ab", size = 368211, upload-time = "2026-02-21T17:25:49.198Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/95/d3f0ae10836324a2eab98a52b61210ac609f08200bf4bb0dc8132d32f78a/fastapi-0.139.2.tar.gz", hash = "sha256:333145a6891e9b5b3cfceb69baf817e8240cde4d4588ae5a10bf56ffacb6255e", size = 423428, upload-time = "2026-07-16T15:06:17.912Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/18/d0/a89a640308016c7fff8d2a47b86cc03ee7cca780b5079d0b69f466f9e1a9/fastapi-0.129.2-py3-none-any.whl", hash = "sha256:e21d9f6e8db376655187905ad0145edd6f6a4e5f2bff241c4efb8a0bffd6a540", size = 103227, upload-time = "2026-02-21T17:25:47.745Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/c7/cb03251d9dfb177246a9809a76f189d21df32dbd4a845951881d11323b7f/fastapi-0.139.2-py3-none-any.whl", hash = "sha256:b9ad015a835173d59865e2f5d8296fbc2b317bf56a2ba1a5bfbdd03de2fd4b1c", size = 130234, upload-time = "2026-07-16T15:06:19.557Z" },
 ]
 
 [[package]]
@@ -3823,15 +3823,15 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "0.52.1"
+version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c4/68/79977123bb7be889ad680d79a40f339082c1978b5cfcf62c2d8d196873ac/starlette-0.52.1.tar.gz", hash = "sha256:834edd1b0a23167694292e94f597773bc3f89f362be6effee198165a35d62933", size = 2653702, upload-time = "2026-01-18T13:34:11.062Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/0d/13d1d239a25cbfb19e740db83143e95c772a1fe10202dda4b76792b114dd/starlette-0.52.1-py3-none-any.whl", hash = "sha256:0029d43eb3d273bc4f83a08720b4912ea4b071087a3b48db01b7c839f7954d74", size = 74272, upload-time = "2026-01-18T13:34:09.188Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Fixes #435. Raises the FastAPI cap to `>=0.139.0,<0.140.0`; FastAPI 0.139 declares `starlette>=0.46.0` with no upper bound, so the resolver takes starlette from 0.52.1 to **1.3.1**, clearing the five remaining Dependabot alerts (form-limit DoS, StaticFiles UNC-path SSRF, HTTPEndpoint getattr dispatch, host/path poisoning of `request.url`).

**One behavior change surfaced**: the delete-highlights tests sent JSON bodies as raw `content=` without a Content-Type header. The old stack parsed them anyway; the new stack correctly returns 422 for an untyped body. The tests now use httpx's `json=` parameter — real clients were never affected (the axios-generated client and KOReader both send `application/json`).

**New coverage**: the ereader EPUB upload endpoint (KOReader book upload) had zero tests despite being exactly the multipart form-parsing path these advisories touch. Added five tests: happy path (file stored, TOC chapters synced), wrong content type, invalid EPUB bytes, and unknown `client_book_id`.

Direct starlette usage in the codebase is limited to stable surfaces (`status` constants, `MutableHeaders`, raw-ASGI middleware types) — no source changes were needed.

## Test plan

- [x] `uv run pytest` — 433 passed (428 existing + 5 new multipart tests)
- [x] `uv run pyright src tests` — 0 errors
- [x] `uv run ruff check` / `ruff format --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)