### PR TITLE
User-written chapter gist notes shown in structure view and chapter dialog (#413)

### DIFF
--- a/backend/src/domain/notes/entities/note.py
+++ b/backend/src/domain/notes/entities/note.py
@@ -17,6 +17,7 @@ class NoteKind(StrEnum):
     CHARACTER = "character"
     TERM = "term"
     CONCEPT = "concept"
+    GIST = "gist"
     OTHER = "other"
 
 

--- a/backend/src/infrastructure/notes/schemas/note_schemas.py
+++ b/backend/src/infrastructure/notes/schemas/note_schemas.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel, Field, StringConstraints
 
 from src.infrastructure.learning.schemas import Flashcard
 
-NoteKindLiteral = Literal["character", "term", "concept", "other"]
+NoteKindLiteral = Literal["character", "term", "concept", "gist", "other"]
 
 NoteTitle = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
 

--- a/backend/tests/test_notes.py
+++ b/backend/tests/test_notes.py
@@ -389,6 +389,32 @@ class TestGetNotesForBook:
         assert len(notes) == 1
         assert notes[0]["title"] == "Raskolnikov"
 
+    async def test_list_notes_filter_by_gist_kind(
+        self,
+        client: AsyncClient,
+        test_book: models.Book,
+        test_chapter: models.Chapter,
+    ) -> None:
+        await client.post(
+            "/api/v1/notes",
+            json={
+                "title": test_chapter.name,
+                "body": "This chapter is about the crime.",
+                "kind": "gist",
+                "book_id": test_book.id,
+                "chapter_ids": [test_chapter.id],
+            },
+        )
+
+        gist_resp = await client.get(f"/api/v1/books/{test_book.id}/notes?kind=gist")
+        gists = gist_resp.json()["items"]
+        assert len(gists) == 1
+        assert gists[0]["kind"] == "gist"
+        assert gists[0]["chapter_ids"] == [test_chapter.id]
+
+        concept_resp = await client.get(f"/api/v1/books/{test_book.id}/notes?kind=concept")
+        assert concept_resp.json()["items"] == []
+
     async def test_list_notes_filter_by_chapter(
         self,
         client: AsyncClient,

--- a/backend/tests/unit/domain/notes/entities/test_note.py
+++ b/backend/tests/unit/domain/notes/entities/test_note.py
@@ -40,6 +40,11 @@ class TestNoteInvariants:
         with pytest.raises(DomainError, match="at least one book"):
             make_note(book_ids=[])
 
+    def test_gist_kind(self) -> None:
+        note = make_note(kind=NoteKind.GIST)
+        assert note.kind == NoteKind.GIST
+        assert NoteKind("gist") == NoteKind.GIST
+
 
 class TestNoteUpdate:
     def test_update_content(self) -> None:

--- a/frontend/src/api/generated/model/getNotesForBookApiV1BooksBookIdNotesGetParams.ts
+++ b/frontend/src/api/generated/model/getNotesForBookApiV1BooksBookIdNotesGetParams.ts
@@ -6,7 +6,7 @@
  */
 
 export type GetNotesForBookApiV1BooksBookIdNotesGetParams = {
-  kind?: 'character' | 'term' | 'concept' | 'other' | null;
+  kind?: 'character' | 'term' | 'concept' | 'gist' | 'other' | null;
   chapter_id?: number | null;
   highlight_id?: number | null;
   tag_id?: number | null;

--- a/frontend/src/api/generated/model/noteCreateRequest.ts
+++ b/frontend/src/api/generated/model/noteCreateRequest.ts
@@ -17,7 +17,7 @@ export interface NoteCreateRequest {
   /** Markdown body */
   body?: string;
   /** Optional note kind */
-  kind?: 'character' | 'term' | 'concept' | 'other' | null;
+  kind?: 'character' | 'term' | 'concept' | 'gist' | 'other' | null;
   /** Book this note is created in */
   book_id: number;
   chapter_ids?: number[];

--- a/frontend/src/api/generated/model/noteUpdateRequest.ts
+++ b/frontend/src/api/generated/model/noteUpdateRequest.ts
@@ -17,7 +17,7 @@ export interface NoteUpdateRequest {
   /** Markdown body */
   body?: string;
   /** Optional note kind */
-  kind?: 'character' | 'term' | 'concept' | 'other' | null;
+  kind?: 'character' | 'term' | 'concept' | 'gist' | 'other' | null;
   chapter_ids?: number[];
   highlight_ids?: number[];
   tag_ids?: number[];

--- a/frontend/src/pages/BookPage/Notes/NoteEditorDialog.tsx
+++ b/frontend/src/pages/BookPage/Notes/NoteEditorDialog.tsx
@@ -4,6 +4,7 @@ import { Box, Button } from '@mui/material';
 import { useRef, useState } from 'react';
 
 import { NoteEditorForm, type NoteEditorFormHandle } from './NoteEditorForm';
+import type { NoteKindValue } from './noteKinds';
 
 interface NoteEditorDialogProps {
   open: boolean;
@@ -13,6 +14,8 @@ interface NoteEditorDialogProps {
   initialChapterIds?: number[];
   initialHighlightIds?: number[];
   initialBody?: string;
+  initialKind?: NoteKindValue;
+  initialTitle?: string;
 }
 
 export const NoteEditorDialog = ({
@@ -22,6 +25,8 @@ export const NoteEditorDialog = ({
   initialChapterIds,
   initialHighlightIds,
   initialBody,
+  initialKind,
+  initialTitle,
 }: NoteEditorDialogProps) => {
   const formRef = useRef<NoteEditorFormHandle>(null);
   const [status, setStatus] = useState({ isSaving: false, canSave: false });
@@ -55,6 +60,8 @@ export const NoteEditorDialog = ({
         initialChapterIds={initialChapterIds}
         initialHighlightIds={initialHighlightIds}
         initialBody={initialBody}
+        initialKind={initialKind}
+        initialTitle={initialTitle}
         onSaved={onClose}
         onStatusChange={setStatus}
       />

--- a/frontend/src/pages/BookPage/Notes/NoteEditorForm.tsx
+++ b/frontend/src/pages/BookPage/Notes/NoteEditorForm.tsx
@@ -11,7 +11,7 @@ import { useBookMutationHelpers } from '@/hooks/useBookMutationHelpers.ts';
 import { useBookPage } from '@/pages/BookPage/BookPageContext';
 import { Autocomplete, Box, MenuItem, TextField } from '@mui/material';
 import { useQueryClient } from '@tanstack/react-query';
-import { forwardRef, useEffect, useImperativeHandle } from 'react';
+import { forwardRef, useEffect, useImperativeHandle, type ReactNode } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 
 import { useNoteTagField } from './hooks/useNoteTagField';
@@ -29,6 +29,8 @@ interface NoteEditorFormProps {
   initialChapterIds?: number[];
   initialHighlightIds?: number[];
   initialBody?: string;
+  initialKind?: NoteKindValue;
+  initialTitle?: string;
   /** Called after a successful create/update. */
   onSaved: () => void;
   /** Reports save-ability so the hosting dialog can render its footer buttons. */
@@ -50,6 +52,8 @@ interface NoteFormValues {
 
 const EMPTY_FORM: NoteFormValues = { title: '', body: '', kind: '', chapters: [], tags: [] };
 
+const GIST_LENGTH_GUIDE = 200;
+
 /**
  * The note create/edit form fields plus mutations, without a dialog shell.
  * Shared by `NoteEditorDialog` (create + standalone edit) and `NoteViewModal`'s
@@ -58,7 +62,17 @@ const EMPTY_FORM: NoteFormValues = { title: '', body: '', kind: '', chapters: []
  */
 export const NoteEditorForm = forwardRef<NoteEditorFormHandle, NoteEditorFormProps>(
   function NoteEditorForm(
-    { open, note, initialChapterIds, initialHighlightIds, initialBody, onSaved, onStatusChange },
+    {
+      open,
+      note,
+      initialChapterIds,
+      initialHighlightIds,
+      initialBody,
+      initialKind,
+      initialTitle,
+      onSaved,
+      onStatusChange,
+    },
     ref
   ) {
     const { book } = useBookPage();
@@ -87,7 +101,9 @@ export const NoteEditorForm = forwardRef<NoteEditorFormHandle, NoteEditorFormPro
       } else {
         reset({
           ...EMPTY_FORM,
+          title: initialTitle ?? '',
           body: initialBody ?? '',
+          kind: initialKind ?? '',
           chapters: chapterOptions.filter((option) =>
             (initialChapterIds ?? []).includes(option.id)
           ),
@@ -132,6 +148,20 @@ export const NoteEditorForm = forwardRef<NoteEditorFormHandle, NoteEditorFormPro
     const isSaving = createMutation.isPending || updateMutation.isPending;
     const canSave = watch('title').trim().length > 0 && !isSaving;
 
+    const isGist = watch('kind') === 'gist';
+    const bodyLength = watch('body').length;
+    const gistHelperText: ReactNode = isGist ? (
+      <Box component="span" sx={{ display: 'flex', justifyContent: 'space-between', gap: 1 }}>
+        <span>1–2 sentences: what was this chapter about, in your words?</span>
+        <Box
+          component="span"
+          sx={{ flexShrink: 0, color: bodyLength > GIST_LENGTH_GUIDE ? 'warning.main' : 'inherit' }}
+        >
+          {bodyLength}/{GIST_LENGTH_GUIDE}
+        </Box>
+      </Box>
+    ) : undefined;
+
     useEffect(() => {
       onStatusChange?.({ isSaving, canSave });
     }, [isSaving, canSave, onStatusChange]);
@@ -174,6 +204,7 @@ export const NoteEditorForm = forwardRef<NoteEditorFormHandle, NoteEditorFormPro
           fullWidth
           multiline
           minRows={5}
+          helperText={gistHelperText}
         />
         <Controller
           name="chapters"

--- a/frontend/src/pages/BookPage/Notes/noteKinds.ts
+++ b/frontend/src/pages/BookPage/Notes/noteKinds.ts
@@ -1,4 +1,4 @@
-export const NOTE_KINDS = ['character', 'term', 'concept', 'other'] as const;
+export const NOTE_KINDS = ['character', 'term', 'concept', 'gist', 'other'] as const;
 
 export type NoteKindValue = (typeof NOTE_KINDS)[number];
 
@@ -6,5 +6,6 @@ export const NOTE_KIND_LABELS: Record<NoteKindValue, string> = {
   character: 'Character',
   term: 'Term',
   concept: 'Concept',
+  gist: 'Gist',
   other: 'Other',
 };

--- a/frontend/src/pages/BookPage/Structure/ChapterAccordion.tsx
+++ b/frontend/src/pages/BookPage/Structure/ChapterAccordion.tsx
@@ -18,6 +18,7 @@ type ReadStatus = 'read' | 'current' | 'unread';
 interface ChapterAccordionProps {
   chapter: ChapterWithHighlights;
   childrenByParentId: Map<number | null, ChapterWithHighlights[]>;
+  gistByChapterId: Map<number, string>;
   bookId: number;
   depth?: number;
   isRead?: boolean;
@@ -42,8 +43,24 @@ const accordionSx = (depth: number) => (theme: { spacing: (n: number) => string 
   },
 });
 
+const GistLine = ({ gist }: { gist: string }) => (
+  <Typography
+    variant="body2"
+    color="text.secondary"
+    sx={{
+      display: '-webkit-box',
+      WebkitLineClamp: 2,
+      WebkitBoxOrient: 'vertical',
+      overflow: 'hidden',
+    }}
+  >
+    {gist}
+  </Typography>
+);
+
 const ExpandableChapter = ({
   name,
+  gist,
   depth,
   expanded,
   onToggle,
@@ -51,6 +68,7 @@ const ExpandableChapter = ({
   children,
 }: {
   name: string;
+  gist?: string;
   depth: number;
   expanded: boolean;
   onToggle: () => void;
@@ -66,11 +84,14 @@ const ExpandableChapter = ({
         '& .MuiAccordionSummary-content.Mui-expanded': { my: '12px' },
       }}
     >
-      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+      <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1 }}>
         {readStatus && <ChapterReadIndicator status={readStatus} />}
-        <Typography variant="body1" sx={{ fontWeight: 600 }}>
-          {name}
-        </Typography>
+        <Box>
+          <Typography variant="body1" sx={{ fontWeight: 600 }}>
+            {name}
+          </Typography>
+          {gist && <GistLine gist={gist} />}
+        </Box>
       </Box>
     </AccordionSummary>
     <AccordionDetails sx={{ pt: 0 }}>{children}</AccordionDetails>
@@ -79,11 +100,13 @@ const ExpandableChapter = ({
 
 const LeafChapterRow = ({
   chapter,
+  gist,
   depth,
   readStatus,
   onClick,
 }: {
   chapter: ChapterWithHighlights;
+  gist?: string;
   depth: number;
   readStatus?: ReadStatus;
   onClick?: () => void;
@@ -118,11 +141,14 @@ const LeafChapterRow = ({
         },
       })}
     >
-      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+      <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1 }}>
         {readStatus && <ChapterReadIndicator status={readStatus} />}
-        <Typography variant="body1" sx={{ fontWeight: 600 }}>
-          {chapter.name}
-        </Typography>
+        <Box>
+          <Typography variant="body1" sx={{ fontWeight: 600 }}>
+            {chapter.name}
+          </Typography>
+          {gist && <GistLine gist={gist} />}
+        </Box>
       </Box>
       <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, color: 'text.secondary' }}>
         {highlightCount > 0 && (
@@ -145,6 +171,7 @@ const LeafChapterRow = ({
 export const ChapterAccordion = ({
   chapter,
   childrenByParentId,
+  gistByChapterId,
   bookId,
   depth = 0,
   isRead,
@@ -159,12 +186,14 @@ export const ChapterAccordion = ({
 
   const childChapters = childrenByParentId.get(chapter.id) ?? [];
   const isLeaf = childChapters.length === 0;
+  const gist = gistByChapterId.get(chapter.id);
 
   let content: ReactNode;
   if (!isLeaf) {
     content = (
       <ExpandableChapter
         name={chapter.name}
+        gist={gist}
         depth={depth}
         expanded={expanded}
         onToggle={() => setExpanded(!expanded)}
@@ -190,6 +219,7 @@ export const ChapterAccordion = ({
                 key={child.id}
                 chapter={child}
                 childrenByParentId={childrenByParentId}
+                gistByChapterId={gistByChapterId}
                 bookId={bookId}
                 depth={depth + 1}
                 isRead={childIsRead}
@@ -206,6 +236,7 @@ export const ChapterAccordion = ({
     content = (
       <LeafChapterRow
         chapter={chapter}
+        gist={gist}
         depth={depth}
         readStatus={readStatus}
         onClick={() => onChapterClick?.(chapter.id)}

--- a/frontend/src/pages/BookPage/Structure/ChapterDetailDialog/ChapterDetailDialog.tsx
+++ b/frontend/src/pages/BookPage/Structure/ChapterDetailDialog/ChapterDetailDialog.tsx
@@ -21,6 +21,7 @@ import { NoteEditorDialog } from '@/pages/BookPage/Notes/NoteEditorDialog';
 import { Box, Button } from '@mui/material';
 import { sumBy } from 'lodash';
 import { useMemo, useState } from 'react';
+import { ChapterGistSection } from './ChapterGistSection.tsx';
 import { ChapterReviewSection } from './ChapterReviewSection.tsx';
 import { ChapterToolbar } from './ChapterToolbar.tsx';
 import { ChatDialog } from './ChatDialog.tsx';
@@ -159,6 +160,8 @@ export const ChapterDetailDialog = ({
 
   const renderContent = () => (
     <Box>
+      <ChapterGistSection chapterId={chapter.id} chapterName={chapter.name} notes={notes} />
+
       <Box {...summarySwipeHandlers}>
         <PrereadingSummarySection prereadingSummary={prereadingSummary} defaultExpanded={true} />
       </Box>

--- a/frontend/src/pages/BookPage/Structure/ChapterDetailDialog/ChapterGistSection.tsx
+++ b/frontend/src/pages/BookPage/Structure/ChapterDetailDialog/ChapterGistSection.tsx
@@ -5,6 +5,7 @@ import { EditIcon } from '@/theme/Icons.tsx';
 import { Box, Button, Typography } from '@mui/material';
 import { find } from 'lodash';
 import { useState } from 'react';
+import { CollapsibleSection } from './CollapsibleSection';
 
 interface ChapterGistSectionProps {
   chapterId: number;
@@ -18,42 +19,39 @@ export const ChapterGistSection = ({ chapterId, chapterName, notes }: ChapterGis
   const gist = find(notes, (note) => note.kind === 'gist') ?? null;
 
   return (
-    <Box sx={{ mb: 2 }}>
-      {gist ? (
-        <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1 }}>
-          <Box sx={{ flexGrow: 1 }}>
-            <Typography variant="caption" color="text.secondary">
-              Your gist
-            </Typography>
-            <Typography variant="body1">{gist.body}</Typography>
+    <CollapsibleSection title="Gist" defaultExpanded>
+      <Box sx={{ mb: 2 }}>
+        {gist ? (
+          <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1 }}>
+            <Box sx={{ flexGrow: 1 }}>
+              <Typography sx={{ fontStyle: 'italic' }} variant="body1">
+                {gist.body}
+              </Typography>
+            </Box>
+            <IconButtonWithTooltip
+              title="Edit gist"
+              ariaLabel="Edit gist"
+              icon={<EditIcon fontSize="small" />}
+              onClick={() => setEditorOpen(true)}
+            />
           </Box>
-          <IconButtonWithTooltip
-            title="Edit gist"
-            ariaLabel="Edit gist"
-            icon={<EditIcon fontSize="small" />}
-            onClick={() => setEditorOpen(true)}
-          />
-        </Box>
-      ) : (
-        <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-start', gap: 1 }}>
-          <Typography variant="body2" color="text.secondary">
-            What was this chapter about, in your words? Capturing it in a sentence or two is the
-            best way to make it stick.
-          </Typography>
-          <Button variant="outlined" size="small" onClick={() => setEditorOpen(true)}>
-            Write gist
-          </Button>
-        </Box>
-      )}
-      <NoteEditorDialog
-        open={editorOpen}
-        onClose={() => setEditorOpen(false)}
-        note={gist}
-        initialKind="gist"
-        initialBody={gist ? undefined : ''}
-        initialChapterIds={[chapterId]}
-        initialTitle={chapterName}
-      />
-    </Box>
+        ) : (
+          <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-start', gap: 1 }}>
+            <Button variant="outlined" size="small" onClick={() => setEditorOpen(true)}>
+              Write gist
+            </Button>
+          </Box>
+        )}
+        <NoteEditorDialog
+          open={editorOpen}
+          onClose={() => setEditorOpen(false)}
+          note={gist}
+          initialKind="gist"
+          initialBody={gist ? undefined : ''}
+          initialChapterIds={[chapterId]}
+          initialTitle={chapterName}
+        />
+      </Box>
+    </CollapsibleSection>
   );
 };

--- a/frontend/src/pages/BookPage/Structure/ChapterDetailDialog/ChapterGistSection.tsx
+++ b/frontend/src/pages/BookPage/Structure/ChapterDetailDialog/ChapterGistSection.tsx
@@ -1,0 +1,59 @@
+import type { NoteWithLinks } from '@/api/generated/model';
+import { IconButtonWithTooltip } from '@/components/buttons/IconButtonWithTooltip.tsx';
+import { NoteEditorDialog } from '@/pages/BookPage/Notes/NoteEditorDialog';
+import { EditIcon } from '@/theme/Icons.tsx';
+import { Box, Button, Typography } from '@mui/material';
+import { find } from 'lodash';
+import { useState } from 'react';
+
+interface ChapterGistSectionProps {
+  chapterId: number;
+  chapterName: string;
+  notes: NoteWithLinks[];
+}
+
+export const ChapterGistSection = ({ chapterId, chapterName, notes }: ChapterGistSectionProps) => {
+  const [editorOpen, setEditorOpen] = useState(false);
+
+  const gist = find(notes, (note) => note.kind === 'gist') ?? null;
+
+  return (
+    <Box sx={{ mb: 2 }}>
+      {gist ? (
+        <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1 }}>
+          <Box sx={{ flexGrow: 1 }}>
+            <Typography variant="caption" color="text.secondary">
+              Your gist
+            </Typography>
+            <Typography variant="body1">{gist.body}</Typography>
+          </Box>
+          <IconButtonWithTooltip
+            title="Edit gist"
+            ariaLabel="Edit gist"
+            icon={<EditIcon fontSize="small" />}
+            onClick={() => setEditorOpen(true)}
+          />
+        </Box>
+      ) : (
+        <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-start', gap: 1 }}>
+          <Typography variant="body2" color="text.secondary">
+            What was this chapter about, in your words? Capturing it in a sentence or two is the
+            best way to make it stick.
+          </Typography>
+          <Button variant="outlined" size="small" onClick={() => setEditorOpen(true)}>
+            Write gist
+          </Button>
+        </Box>
+      )}
+      <NoteEditorDialog
+        open={editorOpen}
+        onClose={() => setEditorOpen(false)}
+        note={gist}
+        initialKind="gist"
+        initialBody={gist ? undefined : ''}
+        initialChapterIds={[chapterId]}
+        initialTitle={chapterName}
+      />
+    </Box>
+  );
+};

--- a/frontend/src/pages/BookPage/Structure/StructurePage.tsx
+++ b/frontend/src/pages/BookPage/Structure/StructurePage.tsx
@@ -1,4 +1,5 @@
 import type { ChapterPrereadingResponse, ChapterWithHighlights } from '@/api/generated/model';
+import { useGetNotesForBookApiV1BooksBookIdNotesGet } from '@/api/generated/notes/notes.ts';
 import { useGetBookPrereadingApiV1BooksBookIdPrereadingGet } from '@/api/generated/prereading/prereading';
 import { useBookPage } from '@/pages/BookPage/BookPageContext';
 import { Box, Typography } from '@mui/material';
@@ -23,6 +24,21 @@ export const StructurePage = () => {
     }
     return map;
   }, [bookPrereading]);
+
+  const { data: gistNotes } = useGetNotesForBookApiV1BooksBookIdNotesGet(book.id, {
+    kind: 'gist',
+  });
+
+  const gistByChapterId = useMemo(() => {
+    const map = new Map<number, string>();
+    for (const note of gistNotes?.items ?? []) {
+      const chapterId = note.chapter_ids.at(0);
+      if (chapterId != null && !map.has(chapterId)) {
+        map.set(chapterId, note.body);
+      }
+    }
+    return map;
+  }, [gistNotes]);
 
   const childrenByParentId = useMemo(() => {
     const map = new Map<number | null, ChapterWithHighlights[]>();
@@ -104,6 +120,7 @@ export const StructurePage = () => {
             key={chapter.id}
             chapter={chapter}
             childrenByParentId={childrenByParentId}
+            gistByChapterId={gistByChapterId}
             bookId={book.id}
             isRead={chapterIsRead}
             isCurrent={chapterIsCurrent}

--- a/frontend/src/pages/BookPage/Structure/StructurePage.tsx
+++ b/frontend/src/pages/BookPage/Structure/StructurePage.tsx
@@ -32,8 +32,9 @@ export const StructurePage = () => {
   const gistByChapterId = useMemo(() => {
     const map = new Map<number, string>();
     for (const note of gistNotes?.items ?? []) {
-      const chapterId = note.chapter_ids.at(0);
-      if (chapterId != null && !map.has(chapterId)) {
+      if (note.chapter_ids.length === 0) continue;
+      const chapterId = note.chapter_ids[0];
+      if (!map.has(chapterId)) {
         map.set(chapterId, note.body);
       }
     }


### PR DESCRIPTION
Closes #413

## Summary

- New `gist` note kind: user-written 1–2 sentence chapter summaries, stored as ordinary notes linked to their chapter (so the existing note→flashcard flow applies for free).
- **Chapter detail dialog**: new collapsible `ChapterGistSection` as the first element above the prereading summary — shows your gist (italic, edit-in-place) or a "Write gist" button when missing.
- **Structure tree**: gists render as secondary text under chapter names (2-line clamp), making the whole book's skeleton visible at a glance.
- Note editor: `initialKind`/`initialTitle` props, gist helper text with a soft ~200-char counter (warns, never blocks).

## Decisions (from issue discussion)

- One gist per chapter, edit-in-place — UI-enforced, no DB constraint.
- Soft length guidance only; user-initiated (no proactive prompts).

## Notes

- No DB migration: the `kind` column is a free `String(20)`.
- Orval client regenerated with `orval@8.2.0` to match the checked-in output; the lockfile has 8.22.0, which regenerates ~110 files of unrelated churn — version drift left for a separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)