### PR TITLE
Key rate limiting on the client the trusted proxy reports

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,6 +58,14 @@ TRUSTED_PROXY_HOPS=0
 # proxy connects from (e.g. '["127.0.0.1/32"]'). Empty (default) disables it.
 # TRUSTED_PROXY_CIDRS='[]'
 
+# Log the peer address and every header of each request, so the two settings
+# above can be matched to what your proxy actually sends rather than what it
+# documents. Turn it on, make one request, and find the "proxy_chain" log line:
+# "peer" is what TRUSTED_PROXY_CIDRS must contain, "peer_trusted" says whether
+# it does, and "resolved" is the key the rate limiter would use. Credentials are
+# excluded, but this logs everything else — turn it off once confirmed.
+LOG_PROXY_CHAIN=false
+
 # Admin setup (first-run bootstrap)
 #
 # ADMIN_PASSWORD is REQUIRED — the backend refuses to start if it is empty

--- a/.env.example
+++ b/.env.example
@@ -28,15 +28,35 @@ PORT=8000
 # and empty lists are rejected at startup.
 #CORS_ORIGINS='["https://mydomain.example.com"]'
 
-# Number of reverse proxies in front of the app that append to X-Forwarded-For.
-# This decides which entry of that header the per-IP rate limiter keys on, so
-# getting it wrong either lets callers forge their own bucket (too high) or
-# lumps every request behind the proxy into one bucket (too low).
+# Which entry of X-Forwarded-For the per-IP rate limiter keys on. Getting this
+# wrong either lets callers forge their own bucket or lumps every request behind
+# the proxy into one, so it depends on what your proxy does with the header.
+#
+# Proxies that APPEND to it (nginx, HAProxy, Caddy) keep whatever the caller
+# sent and add their peer on the right, so only the rightmost entries are real:
 #   0 = the app is directly exposed (default). X-Forwarded-For is ignored.
-#   1 = exactly one edge proxy — Railway, Cloudflare, a single nginx.
-#   2 = two chained proxies, e.g. Cloudflare in front of your own nginx.
-# If you deploy on Railway (or any other managed platform), set this to 1.
+#   1 = exactly one appending proxy in front.
+#   2 = two chained appending proxies.
 TRUSTED_PROXY_HOPS=0
+
+# Proxies that REWRITE it discard what the caller sent and start a fresh chain,
+# so no hop count can find the client. Railway does this: a request through
+# Cloudflare arrives as
+#   x-forwarded-for: <cloudflare-egress>, <railway-pop>
+# with the browser's address absent entirely. Railway puts it in x-real-ip
+# instead (substituting cf-connecting-ip when the request came from trusted
+# Cloudflare infrastructure), so the fix is to believe x-real-ip — but only when
+# the request genuinely came through the proxy that sets it.
+#
+# TRUSTED_PROXY_CIDRS is matched against the TCP peer address, which no caller
+# can forge. A match means the proxy wrote the headers, so its x-real-ip is
+# authoritative; no match means every header is caller-supplied and is ignored.
+# On Railway the peer is its internal proxy, so set:
+
+#   TRUSTED_PROXY_CIDRS='["100.64.0.0/10"]'
+# and leave TRUSTED_PROXY_HOPS at 0. Behind your own nginx, use the address the
+# proxy connects from (e.g. '["127.0.0.1/32"]'). Empty (default) disables it.
+# TRUSTED_PROXY_CIDRS='[]'
 
 # Admin setup (first-run bootstrap)
 #

--- a/Dockerfile
+++ b/Dockerfile
@@ -69,8 +69,11 @@ ENV PYTHONUNBUFFERED=1
 ENV PORT=8000
 
 # Run database migrations and start uvicorn.
-# Note: no --forwarded-allow-ips='*'. That makes uvicorn overwrite the peer
-# address with the *leftmost* X-Forwarded-For entry, which the caller controls,
-# so every request could mint its own rate-limit bucket. The app resolves the
-# real client itself from TRUSTED_PROXY_HOPS — set that to 1 behind Railway.
-CMD ["sh", "-c", "alembic upgrade head && uvicorn src.main:app --host 0.0.0.0 --port ${PORT} --proxy-headers"]
+# Note: no --proxy-headers. It makes uvicorn rewrite the peer address from
+# X-Forwarded-For, and the app's own resolution depends on that peer being the
+# real TCP peer to decide whether any header may be believed at all — see
+# src/infrastructure/common/client_ip.py. Nothing else here reads the peer, and
+# the flag would honour FORWARDED_ALLOW_IPS from the environment, so leaving it
+# on means a stray env var can hand callers their own rate-limit bucket.
+# Configure the trusted proxy in .env instead.
+CMD ["sh", "-c", "alembic upgrade head && uvicorn src.main:app --host 0.0.0.0 --port ${PORT}"]

--- a/backend/src/config.py
+++ b/backend/src/config.py
@@ -4,6 +4,7 @@ import logging
 import sys
 from collections.abc import Callable
 from functools import lru_cache
+from ipaddress import IPv4Network, IPv6Network
 from pathlib import Path
 from typing import Any, Literal
 
@@ -48,12 +49,25 @@ class Settings(BaseSettings):
     RATE_LIMIT_ENABLED: bool = True
     RATE_LIMIT_DEFAULT: str = "300/minute"
 
-    # Number of reverse proxies in front of the app that append to
-    # X-Forwarded-For. 0 means the app is directly exposed and the header is
-    # ignored entirely; anything else would let callers pick their own
-    # rate-limit bucket. Set to 1 behind a single edge proxy (Railway,
-    # Cloudflare, nginx), 2 behind two chained proxies, and so on.
+    # Number of reverse proxies in front of the app that APPEND to
+    # X-Forwarded-For, as nginx and friends do. 0 means the header is ignored
+    # entirely; anything else would let callers pick their own rate-limit
+    # bucket. Consulted only after TRUSTED_PROXY_CIDRS fails to name a client —
+    # a proxy that rewrites the header rather than appending to it cannot be
+    # read with a hop count at all.
     TRUSTED_PROXY_HOPS: int = 0
+
+    # CIDRs of the proxy that opens the connection to this app. Matched against
+    # the TCP peer address, which the caller cannot influence — unlike any
+    # header — so a match is proof that the request passed through that proxy
+    # and the client it names in X-Real-IP is the proxy's own statement.
+    #
+    # On Railway the peer is its internal proxy, so set '["100.64.0.0/10"]'.
+    # Railway documents X-Real-IP as the single source of truth for the
+    # connecting IP and substitutes Cf-Connecting-IP when the request came from
+    # trusted Cloudflare infrastructure, so trusting the peer inherits that
+    # validation rather than duplicating it. Empty disables the mechanism.
+    TRUSTED_PROXY_CIDRS: list[IPv4Network | IPv6Network] = []
 
     # Admin setup (for first-time initialization on a fresh deployment)
     ADMIN_USERNAME: str = "admin"

--- a/backend/src/config.py
+++ b/backend/src/config.py
@@ -69,6 +69,11 @@ class Settings(BaseSettings):
     # validation rather than duplicating it. Empty disables the mechanism.
     TRUSTED_PROXY_CIDRS: list[IPv4Network | IPv6Network] = []
 
+    # Log the peer address and headers of every request, so the settings above
+    # can be matched to what a deployment's proxy actually sends rather than
+    # what it documents. Verbose: turn it off once confirmed.
+    LOG_PROXY_CHAIN: bool = False
+
     # Admin setup (for first-time initialization on a fresh deployment)
     ADMIN_USERNAME: str = "admin"
     ADMIN_PASSWORD: str = ""

--- a/backend/src/infrastructure/common/client_ip.py
+++ b/backend/src/infrastructure/common/client_ip.py
@@ -31,6 +31,9 @@ UNKNOWN_CLIENT = "unknown"
 # Cloudflare needs no separate handling here.
 CLIENT_HEADER = "x-real-ip"
 
+# Credential-bearing headers, kept out of the routing diagnostic below.
+_REDACTED_HEADERS = frozenset({"authorization", "cookie", "proxy-authorization"})
+
 
 def _within(address: str, networks: Sequence[IPv4Network | IPv6Network]) -> bool:
     try:
@@ -117,3 +120,29 @@ def client_ip_from_scope(scope: Scope) -> str:
 def client_ip(request: Request) -> str:
     """Resolve the originating client IP for a request (slowapi key function)."""
     return client_ip_from_scope(request.scope)
+
+
+def proxy_chain(scope: Scope, resolved: str) -> dict[str, object]:
+    """Describe how a request was routed, for matching config to a deployment.
+
+    Takes the already-resolved client so the diagnostic cannot disagree with the
+    resolution it exists to explain. Reports headers by exclusion rather than by
+    allowlist: the header that names the client is exactly what an unfamiliar
+    platform has to be inspected for, and an allowlist cannot list it in advance.
+    """
+    peer = _peer(scope)
+    chain: dict[str, object] = {
+        "peer": peer,
+        "peer_trusted": bool(peer and _within(peer, get_settings().TRUSTED_PROXY_CIDRS)),
+        "resolved": resolved,
+    }
+
+    headers = Headers(scope=scope)
+    for name in dict.fromkeys(headers.keys()):
+        if name in _REDACTED_HEADERS:
+            continue
+        # A header sent twice is reported as a list, because resolution refuses
+        # to believe repeated headers and that has to be visible here.
+        values = headers.getlist(name)
+        chain[f"header_{name.replace('-', '_')}"] = values[0] if len(values) == 1 else values
+    return chain

--- a/backend/src/infrastructure/common/client_ip.py
+++ b/backend/src/infrastructure/common/client_ip.py
@@ -1,12 +1,21 @@
 """Resolution of the originating client IP when running behind reverse proxies.
 
-``X-Forwarded-For`` grows left to right: every proxy appends the address of the
-peer it accepted the connection from. Only the rightmost ``TRUSTED_PROXY_HOPS``
-entries were written by infrastructure we control — everything left of them was
-supplied by the client and is forgeable. Picking the leftmost entry (what
-uvicorn's ``--forwarded-allow-ips='*'`` does) therefore hands the rate limiter a
-key the caller chooses freely.
+The only fact about a request the caller cannot influence is the TCP peer
+address, so that is what decides whether any header may be believed: when the
+peer is one of ``TRUSTED_PROXY_CIDRS``, the request demonstrably arrived through
+a proxy we control and the client it names in ``X-Real-IP`` is that proxy's
+statement rather than the caller's.
+
+``X-Forwarded-For`` cannot stand in for that, because it does not mean the same
+thing everywhere. Proxies that *append* add their peer to whatever the caller
+sent, leaving only the rightmost ``TRUSTED_PROXY_HOPS`` entries believable.
+Railway instead *rewrites* the header, so a request arriving through Cloudflare
+reaches the app with the browser's address absent entirely and no hop count can
+find it. ``.env.example`` documents how to configure each.
 """
+
+from collections.abc import Sequence
+from ipaddress import IPv4Network, IPv6Network, ip_address
 
 from starlette.datastructures import Headers
 from starlette.requests import Request
@@ -16,9 +25,52 @@ from src.config import get_settings
 
 UNKNOWN_CLIENT = "unknown"
 
+# Header a trusted proxy reports the originating client in. Railway and nginx
+# both use this one, and Railway substitutes Cf-Connecting-IP into it when the
+# request came from trusted Cloudflare infrastructure, so fronting the app with
+# Cloudflare needs no separate handling here.
+CLIENT_HEADER = "x-real-ip"
+
+
+def _within(address: str, networks: Sequence[IPv4Network | IPv6Network]) -> bool:
+    try:
+        parsed = ip_address(address)
+    except ValueError:
+        return False
+    return any(parsed in network for network in networks)
+
+
+def _address_or_none(value: str | None) -> str | None:
+    """Return ``value`` only when it is a usable IP address.
+
+    Anything else would become a rate-limit key of the caller's choosing, so a
+    malformed header is treated as absent rather than passed through.
+    """
+    if value is None:
+        return None
+    candidate = value.strip()
+    try:
+        ip_address(candidate)
+    except ValueError:
+        return None
+    return candidate
+
+
+def _sole_header(headers: Headers, name: str) -> str | None:
+    """Return a header's value only when it appears exactly once.
+
+    Reading just the first of several occurrences is what lets a caller shadow a
+    value the proxy set, so repetition is treated as untrustworthy rather than
+    resolved to one of the candidates.
+    """
+    values = headers.getlist(name)
+    if len(values) != 1:
+        return None
+    return values[0]
+
 
 def _client_from_forwarded_for(header_value: str, hops: int) -> str | None:
-    """Return the address the outermost trusted proxy observed, if present.
+    """Return the address the outermost appending proxy observed, if present.
 
     Returns ``None`` when the header holds fewer entries than there are trusted
     hops, which means the request did not arrive through the expected proxy
@@ -29,8 +81,12 @@ def _client_from_forwarded_for(header_value: str, hops: int) -> str | None:
 
     if len(entries) < hops:
         return None
-
     return entries[-hops]
+
+
+def _peer(scope: Scope) -> str | None:
+    client = scope.get("client")
+    return client[0] if client else None
 
 
 def client_ip_from_scope(scope: Scope) -> str:
@@ -40,17 +96,21 @@ def client_ip_from_scope(scope: Scope) -> str:
     ``UNKNOWN_CLIENT`` bucket so that unattributable requests are rate limited
     together rather than each getting a fresh allowance.
     """
-    hops = get_settings().TRUSTED_PROXY_HOPS
+    settings = get_settings()
+    peer = _peer(scope)
 
-    if hops > 0:
-        forwarded = Headers(scope=scope).get("x-forwarded-for")
+    if peer and _within(peer, settings.TRUSTED_PROXY_CIDRS):
+        reported = _address_or_none(_sole_header(Headers(scope=scope), CLIENT_HEADER))
+        if reported:
+            return reported
+
+    if settings.TRUSTED_PROXY_HOPS > 0:
+        forwarded = _sole_header(Headers(scope=scope), "x-forwarded-for")
         if forwarded:
-            resolved = _client_from_forwarded_for(forwarded, hops)
+            resolved = _client_from_forwarded_for(forwarded, settings.TRUSTED_PROXY_HOPS)
             if resolved:
                 return resolved
 
-    client = scope.get("client")
-    peer = client[0] if client else None
     return peer or UNKNOWN_CLIENT
 
 

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -30,7 +30,7 @@ from src.domain.common.exceptions import (
     EntityNotFoundError,
     ValidationError,
 )
-from src.infrastructure.common.client_ip import client_ip, client_ip_from_scope
+from src.infrastructure.common.client_ip import client_ip, client_ip_from_scope, proxy_chain
 from src.infrastructure.common.rate_limit import RateLimitMiddleware, limiter
 from src.infrastructure.common.routers import settings as settings_router
 from src.infrastructure.identity.repositories.user_repository import UserRepository
@@ -223,6 +223,9 @@ class RequestIdAndLoggingMiddleware:
             path=path,
             client_host=client_host,
         )
+
+        if settings.LOG_PROXY_CHAIN:
+            logger.info("proxy_chain", path=path, **proxy_chain(scope, resolved=client_host))
 
         start_time = time.time()
         status_code = 500

--- a/backend/tests/unit/infrastructure/common/test_client_ip.py
+++ b/backend/tests/unit/infrastructure/common/test_client_ip.py
@@ -1,19 +1,43 @@
 """Tests for originating-client-IP resolution behind reverse proxies."""
 
+from ipaddress import ip_network
+
 import pytest
 
 from src.config import get_settings
 from src.infrastructure.common.client_ip import UNKNOWN_CLIENT, client_ip_from_scope
+
+# The chain observed in production: Railway's internal proxy is the peer, its
+# Oslo PoP and the Cloudflare egress in front of it fill X-Forwarded-For, and the
+# browser appears only in X-Real-IP.
+RAILWAY_PEER = "100.64.0.6"
+CLOUDFLARE_EGRESS = "104.23.217.156"
+RAILWAY_POP = "79.127.151.146"
+BROWSER = "91.157.105.204"
+RAILWAY_CHAIN = f"{CLOUDFLARE_EGRESS}, {RAILWAY_POP}"
 
 
 def _set_hops(monkeypatch: pytest.MonkeyPatch, hops: int) -> None:
     monkeypatch.setattr(get_settings(), "TRUSTED_PROXY_HOPS", hops)
 
 
-def _scope(forwarded_for: str | None = None, peer: str | None = "10.0.0.1") -> dict[str, object]:
-    headers: list[tuple[bytes, bytes]] = []
-    if forwarded_for is not None:
-        headers.append((b"x-forwarded-for", forwarded_for.encode()))
+def _trust_proxy(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(get_settings(), "TRUSTED_PROXY_CIDRS", [ip_network("100.64.0.0/10")])
+
+
+def _scope(
+    forwarded_for: str | None = None,
+    real_ip: str | None = None,
+    peer: str | None = "10.0.0.1",
+    headers: list[tuple[bytes, bytes]] | None = None,
+) -> dict[str, object]:
+    """Build an ASGI scope. Pass `headers` to control repetition and ordering."""
+    if headers is None:
+        headers = []
+        if forwarded_for is not None:
+            headers.append((b"x-forwarded-for", forwarded_for.encode()))
+        if real_ip is not None:
+            headers.append((b"x-real-ip", real_ip.encode()))
     return {
         "type": "http",
         "headers": headers,
@@ -85,3 +109,93 @@ def test_short_header_is_rejected_rather_than_misindexed(
     scope = _scope(forwarded_for="1.2.3.4")
 
     assert client_ip_from_scope(scope) == "10.0.0.1"
+
+
+@pytest.mark.parametrize("hops", [0, 1])
+def test_trusted_proxy_reports_the_client_it_observed(
+    monkeypatch: pytest.MonkeyPatch, hops: int
+) -> None:
+    """The production chain: the client is only in X-Real-IP, not in the chain.
+
+    Parametrized over the hop count because a rewriting proxy leaves nothing
+    usable in X-Forwarded-For, so the count must not win when both are set.
+    """
+    _set_hops(monkeypatch, hops)
+    _trust_proxy(monkeypatch)
+    scope = _scope(forwarded_for=RAILWAY_CHAIN, real_ip=BROWSER, peer=RAILWAY_PEER)
+
+    assert client_ip_from_scope(scope) == BROWSER
+
+
+def test_rotating_a_forged_client_header_cannot_mint_buckets(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Anyone reaching the app off-proxy can set X-Real-IP to whatever they like.
+
+    One caller must still get one bucket, which is the whole point of the
+    exercise — so the peer is what counts, not what they claim.
+    """
+    _set_hops(monkeypatch, 0)
+    _trust_proxy(monkeypatch)
+
+    keys = {
+        client_ip_from_scope(
+            _scope(forwarded_for=RAILWAY_CHAIN, real_ip=forged, peer="203.0.113.99")
+        )
+        for forged in ("1.2.3.4", "5.6.7.8", "9.10.11.12")
+    }
+
+    assert keys == {"203.0.113.99"}
+
+
+def test_repeated_client_header_is_not_believed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A second X-Real-IP line must not shadow the one the proxy set."""
+    _set_hops(monkeypatch, 0)
+    _trust_proxy(monkeypatch)
+    scope = _scope(
+        peer=RAILWAY_PEER,
+        headers=[
+            (b"x-real-ip", b"203.0.113.99"),
+            (b"x-real-ip", BROWSER.encode()),
+        ],
+    )
+
+    assert client_ip_from_scope(scope) == RAILWAY_PEER
+
+
+def test_unparseable_client_header_falls_back_to_the_peer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_hops(monkeypatch, 0)
+    _trust_proxy(monkeypatch)
+    scope = _scope(forwarded_for=RAILWAY_CHAIN, real_ip="not-an-ip", peer=RAILWAY_PEER)
+
+    assert client_ip_from_scope(scope) == RAILWAY_PEER
+
+
+def test_missing_client_header_falls_back_to_the_peer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Coarse but unforgeable: everyone behind that proxy shares a bucket."""
+    _set_hops(monkeypatch, 0)
+    _trust_proxy(monkeypatch)
+    scope = _scope(forwarded_for=RAILWAY_CHAIN, peer=RAILWAY_PEER)
+
+    assert client_ip_from_scope(scope) == RAILWAY_PEER
+
+
+def test_trusted_proxy_falls_back_to_the_hop_count(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An appending proxy that sets no client header still has a usable chain."""
+    _set_hops(monkeypatch, 1)
+    _trust_proxy(monkeypatch)
+    scope = _scope(forwarded_for=f"1.2.3.4, {BROWSER}", peer=RAILWAY_PEER)
+
+    assert client_ip_from_scope(scope) == BROWSER
+
+
+def test_trusted_proxy_resolves_an_ipv6_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_hops(monkeypatch, 0)
+    _trust_proxy(monkeypatch)
+    scope = _scope(real_ip="2001:14ba:a086:1900::1", peer=RAILWAY_PEER)
+
+    assert client_ip_from_scope(scope) == "2001:14ba:a086:1900::1"

--- a/backend/tests/unit/infrastructure/common/test_client_ip.py
+++ b/backend/tests/unit/infrastructure/common/test_client_ip.py
@@ -5,7 +5,11 @@ from ipaddress import ip_network
 import pytest
 
 from src.config import get_settings
-from src.infrastructure.common.client_ip import UNKNOWN_CLIENT, client_ip_from_scope
+from src.infrastructure.common.client_ip import (
+    UNKNOWN_CLIENT,
+    client_ip_from_scope,
+    proxy_chain,
+)
 
 # The chain observed in production: Railway's internal proxy is the peer, its
 # Oslo PoP and the Cloudflare egress in front of it fill X-Forwarded-For, and the
@@ -199,3 +203,75 @@ def test_trusted_proxy_resolves_an_ipv6_client(monkeypatch: pytest.MonkeyPatch) 
     scope = _scope(real_ip="2001:14ba:a086:1900::1", peer=RAILWAY_PEER)
 
     assert client_ip_from_scope(scope) == "2001:14ba:a086:1900::1"
+
+
+def test_proxy_chain_reports_the_peer_and_every_routing_header(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Reported by exclusion: an unfamiliar platform's header cannot be listed
+    in advance, which is exactly what the diagnostic is for."""
+    _set_hops(monkeypatch, 0)
+    _trust_proxy(monkeypatch)
+    scope = _scope(
+        peer=RAILWAY_PEER,
+        headers=[
+            (b"x-forwarded-for", RAILWAY_CHAIN.encode()),
+            (b"x-real-ip", BROWSER.encode()),
+            (b"x-railway-edge", b"osl1"),
+            (b"cf-ray", b"a209b0ef0b3470d7-ARN"),
+        ],
+    )
+
+    chain = proxy_chain(scope, resolved=BROWSER)
+
+    assert chain["peer"] == RAILWAY_PEER
+    assert chain["peer_trusted"] is True
+    assert chain["resolved"] == BROWSER
+    assert chain["header_x_forwarded_for"] == RAILWAY_CHAIN
+    assert chain["header_x_railway_edge"] == "osl1"
+    assert chain["header_cf_ray"] == "a209b0ef0b3470d7-ARN"
+
+
+def test_proxy_chain_keeps_credentials_out_of_the_log() -> None:
+    scope = _scope(
+        headers=[
+            (b"authorization", b"Bearer sometoken"),
+            (b"cookie", b"session=secret"),
+            (b"x-real-ip", BROWSER.encode()),
+        ]
+    )
+
+    chain = proxy_chain(scope, resolved="10.0.0.1")
+
+    assert "header_authorization" not in chain
+    assert "header_cookie" not in chain
+    assert chain["header_x_real_ip"] == BROWSER
+
+
+def test_proxy_chain_reports_repeated_headers_separately(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Resolution refuses to guess which line came from the proxy, so the
+    diagnostic must not collapse them either."""
+    _set_hops(monkeypatch, 1)
+    scope = _scope(
+        headers=[
+            (b"x-forwarded-for", b"1.2.3.4"),
+            (b"x-forwarded-for", b"203.0.113.9"),
+        ]
+    )
+
+    chain = proxy_chain(scope, resolved=client_ip_from_scope(scope))
+
+    assert chain["header_x_forwarded_for"] == ["1.2.3.4", "203.0.113.9"]
+    assert chain["resolved"] == "10.0.0.1"
+
+
+def test_proxy_chain_marks_an_untrusted_peer(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_hops(monkeypatch, 0)
+    _trust_proxy(monkeypatch)
+    scope = _scope(real_ip=BROWSER, peer="203.0.113.99")
+
+    chain = proxy_chain(scope, resolved="203.0.113.99")
+
+    assert chain["peer_trusted"] is False

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,9 @@ services:
       # TRUSTED_PROXY_CIDRS to the address it connects from — see .env.example.
       TRUSTED_PROXY_HOPS: ${TRUSTED_PROXY_HOPS:-0}
       TRUSTED_PROXY_CIDRS: ${TRUSTED_PROXY_CIDRS:-[]}
+      # Temporarily set true to log each request's peer and headers, to check the
+      # two settings above against what your proxy actually sends.
+      LOG_PROXY_CHAIN: ${LOG_PROXY_CHAIN:-false}
       SECRET_KEY: ${SECRET_KEY}
       ACCESS_TOKEN_EXPIRE_MINUTES: 15
       REFRESH_TOKEN_EXPIRE_DAYS: 30

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,9 +36,13 @@ services:
       ADMIN_USERNAME: ${ADMIN_USERNAME}
       ADMIN_PASSWORD: ${ADMIN_PASSWORD}
       CORS_ORIGINS: '["https://yourdomain.com"]'
-      # Set to 1 if a reverse proxy terminates TLS in front of this container,
-      # so per-IP rate limiting keys on the real client instead of the proxy.
+      # Set to 1 if an *appending* reverse proxy (nginx, Caddy) terminates TLS in
+      # front of this container, so per-IP rate limiting keys on the real client
+      # instead of the proxy. Behind a proxy that rewrites X-Forwarded-For and
+      # reports the client in X-Real-IP (Railway, nginx) leave this at 0 and set
+      # TRUSTED_PROXY_CIDRS to the address it connects from — see .env.example.
       TRUSTED_PROXY_HOPS: ${TRUSTED_PROXY_HOPS:-0}
+      TRUSTED_PROXY_CIDRS: ${TRUSTED_PROXY_CIDRS:-[]}
       SECRET_KEY: ${SECRET_KEY}
       ACCESS_TOKEN_EXPIRE_MINUTES: 15
       REFRESH_TOKEN_EXPIRE_DAYS: 30


### PR DESCRIPTION
## Why

`TRUSTED_PROXY_HOPS` (#447) assumed every proxy *appends* its peer to `X-Forwarded-For`, so the rightmost entries are trustworthy. Railway *rewrites* the header instead, which the deployed logs confirmed:

```
peer              100.64.0.3
hops              1
resolved          79.127.151.146      <- Railway's Oslo PoP, not a visitor
x_forwarded_for   104.23.217.156, 79.127.151.146
x_real_ip         91.157.105.204      <- the actual browser
x_railway_edge    osl1
```

Cloudflare had set `X-Forwarded-For` to the browser's address and Railway's edge discarded it. RDAP confirms the three addresses: `104.23.217.156` is `CLOUDFLARENET`, `79.127.151.146` is `CDN77-OSL` (Railway's Oslo PoP), and only `91.157.105.204` (`ELISA-LAAJAKAISTA`, FI) is a real client.

So `TRUSTED_PROXY_HOPS=1` keyed the limiter on Railway's PoP, putting every visitor routed through `osl1` in one bucket — one caller exhausting the 5/minute login limit would lock out everyone else behind it. Not exploitable (the key is unforgeable), but wrong, and no hop count could fix it because the client is not in the header.

## What

Railway reports the client in `X-Real-IP`, substituting `Cf-Connecting-IP` when the request came from trusted Cloudflare infrastructure. Believing that header requires proof the request came through Railway, and the only fact a caller cannot influence is the **TCP peer address** — so match that against `TRUSTED_PROXY_CIDRS` and read the header only on a match. This inherits Railway's own Cloudflare validation rather than reimplementing a weaker copy against published IP ranges.

Verified against the real chains above:

| Scenario | peer | Keys on |
|---|---|---|
| Browser via Cloudflare | `100.64.0.3` | `91.157.105.204` — the real client |
| Second visitor, same Cloudflare egress | `100.64.0.7` | their own address, no longer lumped together |
| Off-proxy request with forged `X-Real-IP` | `45.155.205.99` | their own peer — header ignored |
| Rotating a forged `X-Real-IP` | `45.155.205.99` | one bucket, not one per request |
| Duplicate `X-Real-IP` lines | `100.64.0.3` | falls back to the peer, refuses to pick |

`TRUSTED_PROXY_HOPS` stays for appending proxies such as nginx, consulted only after the peer check declines to name a client.

## Commits

1. **Stop uvicorn rewriting the peer address** — `--proxy-headers` replaced `scope["client"]` from `X-Forwarded-For` and honoured `FORWARDED_ALLOW_IPS`, an env var this repo does not pin, so a stray value could have turned the trust anchor into a caller-supplied string. Nothing else reads the peer, and no absolute URLs or redirects depend on the flag.
2. **Key rate limiting on the client the trusted proxy reports** — the resolution change above.
3. **Log a request's peer and headers behind `LOG_PROXY_CHAIN`** — off by default; reports headers by exclusion (credentials redacted) because the header that names the client is the one you cannot list in advance.

## Deploying

Railway needs `TRUSTED_PROXY_CIDRS='["100.64.0.0/10"]'` and `TRUSTED_PROXY_HOPS=0`. Because the Dockerfile `CMD` changed, this needs a **rebuilt image**, not just an env update. Set `LOG_PROXY_CHAIN=true` for one request to confirm `peer_trusted: true`, then turn it off.

Pydantic parses `TRUSTED_PROXY_CIDRS` into `IPv4Network`/`IPv6Network` at startup, so a malformed CIDR — including a host-bits typo like `100.64.0.1/10` — fails loudly instead of silently never matching.

## Remaining

Railway's guarantee that it overwrites `X-Real-IP` is confirmed on the Cloudflare path (a forged header arrived replaced). The off-Cloudflare origin path is untested; if it ever passed a caller's `X-Real-IP` through, the peer check would still hold, since such a caller's peer is Railway's proxy either way. Worth a direct check against the `.up.railway.app` hostname at some point.

516 tests pass; pyright and ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)