### PR TITLE
Bind the request session in one place instead of two

### DIFF
--- a/backend/src/database.py
+++ b/backend/src/database.py
@@ -105,8 +105,7 @@ async def get_db(
 # The session the DI container should build repositories against. A ContextVar
 # rather than a module global: every request runs in its own asyncio task, which
 # carries its own copy of the context, so concurrent requests cannot see each
-# other's binding. Sync dependencies dispatched to the threadpool inherit a copy
-# of the caller's context, so they are covered too.
+# other's binding.
 _request_db_session: ContextVar[AsyncSession] = ContextVar("request_db_session")
 
 

--- a/backend/src/infrastructure/common/di.py
+++ b/backend/src/infrastructure/common/di.py
@@ -1,4 +1,4 @@
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from typing import TypeVar
 
 from dependency_injector.providers import Provider
@@ -8,16 +8,16 @@ from src.database import DatabaseSession, bind_db_session
 T = TypeVar("T")
 
 
-def inject_use_case(provider: Provider[T]) -> Callable[[DatabaseSession], T]:
+def inject_use_case(provider: Provider[T]) -> Callable[[DatabaseSession], Awaitable[T]]:
     """
     Create a FastAPI dependency for a container provider.
 
     Binds the request-scoped database session for as long as it takes to build
-    the use case, which is where the container reads it. The binding is
-    context-local, so concurrent requests cannot observe each other's session.
+    the use case, which is where the container reads it. Async so it runs in the
+    request's own task, whose context no other request can see.
     """
 
-    def dependency(db: DatabaseSession) -> T:
+    async def dependency(db: DatabaseSession) -> T:
         with bind_db_session(db):
             return provider()
 

--- a/backend/src/infrastructure/identity/dependencies.py
+++ b/backend/src/infrastructure/identity/dependencies.py
@@ -1,32 +1,36 @@
 """FastAPI dependencies for identity and authentication."""
 
-from typing import TYPE_CHECKING, Annotated
+from typing import Annotated
 
 from fastapi import Depends
 from fastapi.security import OAuth2PasswordBearer
 
+from src.application.identity.use_cases.authentication.get_user_by_id_use_case import (
+    GetUserByIdUseCase,
+)
 from src.core import container
-from src.database import DatabaseSession, bind_db_session
 from src.domain.common.exceptions import AuthenticationError
 from src.domain.identity.entities.user import User
 from src.domain.identity.exceptions import UserNotFoundError
+from src.infrastructure.common.di import inject_use_case
 from src.infrastructure.identity.services.token_service import verify_access_token
-
-if TYPE_CHECKING:
-    pass
 
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="auth/login")
 
 
 async def get_current_user(
-    token: Annotated[str, Depends(oauth2_scheme)], db: DatabaseSession
+    token: Annotated[str, Depends(oauth2_scheme)],
+    use_case: Annotated[
+        GetUserByIdUseCase,
+        Depends(inject_use_case(container.identity.get_user_by_id_use_case)),
+    ],
 ) -> User:
     """
     Get the current authenticated user from the access token.
 
     Args:
         token: JWT access token from Authorization header
-        db: Database session
+        use_case: Use case built against the request-scoped database session
 
     Returns:
         User domain entity
@@ -37,11 +41,6 @@ async def get_current_user(
     user_id = verify_access_token(token)
     if user_id is None:
         raise AuthenticationError("Could not validate credentials")
-
-    # The binding only has to cover construction — the use case captures the
-    # session then — so it is released before the await rather than held across it.
-    with bind_db_session(db):
-        use_case = container.identity.get_user_by_id_use_case()
 
     try:
         return await use_case.get_user(user_id)

--- a/backend/tests/test_auth_dependency.py
+++ b/backend/tests/test_auth_dependency.py
@@ -1,0 +1,45 @@
+"""Tests for get_current_user, which the shared ``client`` fixture overrides away."""
+
+from collections.abc import AsyncGenerator
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.database import get_db
+from src.infrastructure.identity.services.token_service import create_access_token
+from src.main import app
+from src.models import User
+
+
+@pytest.fixture
+async def real_auth_client(
+    db_session: AsyncSession, test_user: User
+) -> AsyncGenerator[AsyncClient, None]:
+    async def override_get_db() -> AsyncGenerator[AsyncSession, None]:
+        yield db_session
+
+    app.dependency_overrides[get_db] = override_get_db
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        yield client
+    app.dependency_overrides.clear()
+
+
+async def test_real_get_current_user(real_auth_client: AsyncClient, test_user: User) -> None:
+    token = create_access_token(test_user.id)
+    response = await real_auth_client.get(
+        "/api/v1/users/me", headers={"Authorization": f"Bearer {token}"}
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["email"] == test_user.email
+
+
+async def test_real_get_current_user_rejects_unknown_user(
+    real_auth_client: AsyncClient,
+) -> None:
+    token = create_access_token(9999)
+    response = await real_auth_client.get(
+        "/api/v1/users/me", headers={"Authorization": f"Bearer {token}"}
+    )
+    assert response.status_code == 401, response.text


### PR DESCRIPTION
Follow-up to a10090c8, which moved the request DB session off the process-wide container override and onto a `ContextVar`. The fix was right; the wiring around it was heavier than it needed to be.

## Changes

**`get_current_user` reuses `inject_use_case`.** It took the session, opened its own `bind_db_session` block and built the use case by hand — exactly what `inject_use_case` does. Declaring the use case as a dependency leaves `bind_db_session` with a single call site. The comment about releasing the binding before the `await` goes too: a `ContextVar` binding is confined to the task holding it, so holding it across an `await` was never a hazard.

**`inject_use_case`'s dependency is now `async`.** As a sync dependency FastAPI dispatched every use-case injection to the anyio threadpool, and endpoints take several. Running it in the request's own task also removes the one strand of the contextvar reasoning that rested on threadpool context copying — that comment in `database.py` and the docstring in `di.py` are gone.

Also drops a stale `if TYPE_CHECKING: pass` block left behind by the earlier commit.

Binding inside `get_db` itself would remove call-site binding entirely, but `tests/conftest.py` replaces `get_db` via `app.dependency_overrides`, so the override would never bind and every container resolution would raise. Binding at the injection site survives that.

## Test coverage

The shared `client` fixture overrides `get_current_user`, so nothing exercised the real dependency — the one this PR rewires. `backend/tests/test_auth_dependency.py` adds two tests against the real path: a valid token resolving a user, and an unknown user id giving 401.

## Verification

`uv run pytest` — 518 passed. `pyright` and `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)