### PR TITLE
Simplify Argon2 cost containment and drop the legacy non-peppered fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -93,7 +93,9 @@ COOKIE_SECURE=true
 
 # Password pepper - Secret value added to all passwords before hashing
 # Generate with: openssl rand -hex 32
-# IMPORTANT: Once set, do not change this value or existing passwords will stop working
+# IMPORTANT: Decide this before the first account exists. Changing the value, or
+# introducing one on an install that already has users, makes every existing
+# password stop working; recovery is a password reset per account.
 # NOTE: Can be left empty or undefined if password peppering is not desired
 PASSWORD_PEPPER=your_secret_pepper_here
 

--- a/backend/src/config.py
+++ b/backend/src/config.py
@@ -85,10 +85,10 @@ class Settings(BaseSettings):
     COOKIE_SECURE: bool = True
     PASSWORD_PEPPER: str = ""
 
-    # How many Argon2id hashes may run concurrently. Each costs ~64 MiB, so this
-    # is the ceiling on memory an unauthenticated flood of logins can pin down.
-    # Raise it only if the host has memory and cores to spare.
-    PASSWORD_HASH_CONCURRENCY: int = 2
+    # Size of the thread pool that runs Argon2id. Each hash costs ~64 MiB and
+    # ~100 ms of CPU, so this is the ceiling on what a burst of logins can pin
+    # down. Raise it only if the host has memory and cores to spare.
+    PASSWORD_HASH_CONCURRENCY: int = Field(default=2, ge=1)
 
     # Registration. Defaults to closed: a deployment that never sets this is
     # almost always a single-user install on the public internet, and the wrong
@@ -166,15 +166,6 @@ class Settings(BaseSettings):
         """Reject a negative proxy-hop count, which would index the wrong entry."""
         if value < 0:
             msg = "TRUSTED_PROXY_HOPS must be 0 or greater"
-            raise ValueError(msg)
-        return value
-
-    @field_validator("PASSWORD_HASH_CONCURRENCY", mode="after")
-    @classmethod
-    def validate_password_hash_concurrency(cls, value: int) -> int:
-        """Require at least one hashing slot, or no login could ever complete."""
-        if value < 1:
-            msg = "PASSWORD_HASH_CONCURRENCY must be at least 1"
             raise ValueError(msg)
         return value
 

--- a/backend/src/infrastructure/identity/services/password_service.py
+++ b/backend/src/infrastructure/identity/services/password_service.py
@@ -39,23 +39,9 @@ def _hash_sync(plain_password: str) -> str:
 
 def _verify_sync(plain_password: str, hashed_password: str) -> bool:
     try:
-        peppered_matches = password_hash.verify(plain_password + PASSWORD_PEPPER, hashed_password)
-
-        if not PASSWORD_PEPPER:
-            # With no pepper configured the legacy attempt below is byte-for-byte
-            # the one just made; repeating it would only double the cost.
-            return peppered_matches
-
-        # Fallback to non-peppered for backward compatibility (DEPRECATED).
-        # This allows existing users to login and change their password.
-        #
-        # Deliberately not short-circuited on peppered_matches: returning early
-        # would make a peppered hash cost one verification and a legacy hash two,
-        # and that ~30ms gap is measurable from outside. Cost per call is
-        # therefore constant, and bounded by the hashing pool in the callers below.
-        legacy_matches = password_hash.verify(plain_password, hashed_password)
-        return peppered_matches or legacy_matches
+        return password_hash.verify(plain_password + PASSWORD_PEPPER, hashed_password)
     except UnknownHashError:
+        # A stored hash we cannot parse is a failed login, not a 500.
         return False
 
 
@@ -66,13 +52,10 @@ async def hash_password(plain_password: str) -> str:
 
 
 async def verify_password(plain_password: str, hashed_password: str) -> bool:
-    """Verify a plain password against a hashed password.
+    """Verify a plain password against a peppered hash.
 
-    Tries with pepper first (current standard), then falls back to non-peppered
-    for backward compatibility with existing passwords.
-
-    DEPRECATED: Non-peppered password verification will be removed in a future release.
-    Users should change their passwords to migrate to peppered hashes.
+    Exactly one verification runs, so the cost is the same whether the password
+    matches or not.
     """
     loop = asyncio.get_running_loop()
     return await loop.run_in_executor(_hash_pool, _verify_sync, plain_password, hashed_password)

--- a/backend/src/infrastructure/identity/services/password_service.py
+++ b/backend/src/infrastructure/identity/services/password_service.py
@@ -1,15 +1,15 @@
 """Password hashing and verification service.
 
 Argon2id is deliberately expensive: the recommended parameters allocate 64 MiB
-and burn tens of milliseconds per call. Running that inline on the event loop
-stalls every other request for the duration, so an unauthenticated caller could
-wedge the whole app with a trickle of bad logins. Hashing therefore happens on a
-worker thread, and a semaphore caps how many run at once so the memory cost
-stays bounded no matter how many requests arrive together.
+and burn ~100 ms of CPU per call. Running that inline on the event loop stalls
+every other request for the duration, so hashing runs on its own small thread
+pool instead. The pool size is the ceiling on how much memory and CPU a burst of
+logins can pin down at once, and keeping the pool separate from asyncio's default
+executor means bulk file work cannot crowd out a login, or the reverse.
 """
 
 import asyncio
-from weakref import WeakKeyDictionary
+from concurrent.futures import ThreadPoolExecutor
 
 from pwdlib import PasswordHash
 from pwdlib.exceptions import UnknownHashError
@@ -25,21 +25,12 @@ password_hash = PasswordHash.recommended()
 # A fake string like "abc123" would cause pwdlib to raise UnknownHashError.
 DUMMY_HASH = password_hash.hash("dummy_password_for_timing_attack_prevention")
 
-# Keyed by event loop: asyncio primitives bind to the first loop that uses them,
-# and the test suite runs each case on a fresh loop.
-_concurrency_guards: WeakKeyDictionary[asyncio.AbstractEventLoop, asyncio.Semaphore] = (
-    WeakKeyDictionary()
+# Threads are created on demand, so an idle pool costs nothing. Unlike an asyncio
+# semaphore, the pool is not bound to an event loop, so the same one serves the
+# app, the worker and every test case.
+_hash_pool = ThreadPoolExecutor(
+    max_workers=settings.PASSWORD_HASH_CONCURRENCY, thread_name_prefix="argon2"
 )
-
-
-def _concurrency_guard() -> asyncio.Semaphore:
-    """Get the hashing semaphore for the running event loop."""
-    loop = asyncio.get_running_loop()
-    guard = _concurrency_guards.get(loop)
-    if guard is None:
-        guard = asyncio.Semaphore(settings.PASSWORD_HASH_CONCURRENCY)
-        _concurrency_guards[loop] = guard
-    return guard
 
 
 def _hash_sync(plain_password: str) -> str:
@@ -61,7 +52,7 @@ def _verify_sync(plain_password: str, hashed_password: str) -> bool:
         # Deliberately not short-circuited on peppered_matches: returning early
         # would make a peppered hash cost one verification and a legacy hash two,
         # and that ~30ms gap is measurable from outside. Cost per call is
-        # therefore constant, and bounded by the semaphore in the callers below.
+        # therefore constant, and bounded by the hashing pool in the callers below.
         legacy_matches = password_hash.verify(plain_password, hashed_password)
         return peppered_matches or legacy_matches
     except UnknownHashError:
@@ -70,8 +61,8 @@ def _verify_sync(plain_password: str, hashed_password: str) -> bool:
 
 async def hash_password(plain_password: str) -> str:
     """Hash a plain password for storage with pepper."""
-    async with _concurrency_guard():
-        return await asyncio.to_thread(_hash_sync, plain_password)
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(_hash_pool, _hash_sync, plain_password)
 
 
 async def verify_password(plain_password: str, hashed_password: str) -> bool:
@@ -83,8 +74,8 @@ async def verify_password(plain_password: str, hashed_password: str) -> bool:
     DEPRECATED: Non-peppered password verification will be removed in a future release.
     Users should change their passwords to migrate to peppered hashes.
     """
-    async with _concurrency_guard():
-        return await asyncio.to_thread(_verify_sync, plain_password, hashed_password)
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(_hash_pool, _verify_sync, plain_password, hashed_password)
 
 
 def get_dummy_hash() -> str:

--- a/backend/tests/unit/infrastructure/identity/test_password_service.py
+++ b/backend/tests/unit/infrastructure/identity/test_password_service.py
@@ -59,64 +59,30 @@ async def test_concurrent_hashing_is_capped(monkeypatch: pytest.MonkeyPatch) -> 
     assert peak <= get_settings().PASSWORD_HASH_CONCURRENCY
 
 
-def _count_verify_calls(monkeypatch: pytest.MonkeyPatch) -> list[int]:
-    """Replace the underlying hash comparison with an always-failing counter."""
-    calls = [0]
+@pytest.fixture
+def recorded_verifies(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Record the passwords handed to the hash comparison, which always fails."""
+    seen: list[str] = []
 
-    def counting_verify(_password: str, _hash: str) -> bool:
-        calls[0] += 1
+    def recording_verify(password: str, _hash: str) -> bool:
+        seen.append(password)
         return False
 
-    monkeypatch.setattr(password_service.password_hash, "verify", counting_verify)
-    return calls
+    monkeypatch.setattr(password_service.password_hash, "verify", recording_verify)
+    return seen
 
 
-async def test_failed_verification_hashes_once_when_no_pepper_is_set(
-    monkeypatch: pytest.MonkeyPatch,
+@pytest.mark.parametrize("pepper", ["", "pepper"])
+async def test_verification_costs_exactly_one_hash(
+    monkeypatch: pytest.MonkeyPatch, recorded_verifies: list[str], pepper: str
 ) -> None:
-    """Without a pepper the legacy fallback is identical to the first attempt."""
-    monkeypatch.setattr(password_service, "PASSWORD_PEPPER", "")
-    calls = _count_verify_calls(monkeypatch)
+    """Every login pays one Argon2 verification, peppered or not."""
+    monkeypatch.setattr(password_service, "PASSWORD_PEPPER", pepper)
 
     assert not await password_service.verify_password("password", "hash")
-    assert calls[0] == 1
+    assert recorded_verifies == ["password" + pepper]
 
 
-async def test_failed_verification_still_tries_legacy_hash_when_peppered(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setattr(password_service, "PASSWORD_PEPPER", "pepper")
-    calls = _count_verify_calls(monkeypatch)
-
-    assert not await password_service.verify_password("password", "hash")
-    assert calls[0] == 2
-
-
-async def test_peppered_success_costs_the_same_as_failure(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """A short circuit on the peppered hit would leak which hashes are legacy."""
-    monkeypatch.setattr(password_service, "PASSWORD_PEPPER", "pepper")
-    calls = [0]
-
-    def verify_peppered_only(password: str, _hash: str) -> bool:
-        calls[0] += 1
-        return password == "passwordpepper"
-
-    monkeypatch.setattr(password_service.password_hash, "verify", verify_peppered_only)
-
-    assert await password_service.verify_password("password", "hash")
-    assert calls[0] == 2
-
-
-async def test_legacy_hash_still_verifies_when_peppered(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setattr(password_service, "PASSWORD_PEPPER", "pepper")
-
-    def verify_unpeppered_only(password: str, _hash: str) -> bool:
-        return password == "password"
-
-    monkeypatch.setattr(password_service.password_hash, "verify", verify_unpeppered_only)
-
-    assert await password_service.verify_password("password", "hash")
+async def test_unparseable_stored_hash_is_a_failed_login() -> None:
+    """A hash pwdlib cannot read must not turn a login into a 500."""
+    assert not await password_service.verify_password("password", "not-a-hash")


### PR DESCRIPTION
Follow-up to the Argon2 work in #447, in two parts.

## Cap hashing with a thread pool instead of a per-loop semaphore (f6cdf996)

Hashing needed two properties — run off the event loop, and be capped so a burst of logins cannot pin 64 MiB and ~100 ms of CPU per call. A dedicated `ThreadPoolExecutor` is both at once, since `max_workers` *is* the cap. That removes the semaphore, the `WeakKeyDictionary` keying it by event loop, and the accessor that lazily built one per loop; executors are not loop-bound, so one pool serves the app, the worker and every test case.

It also stops hashing sharing asyncio's default executor with the S3 and file-repository `to_thread` calls, where a bulk upload could occupy every thread and delay a login, or the reverse.

`PASSWORD_HASH_CONCURRENCY`'s hand-written validator becomes `Field(ge=1)`.

One behavioural difference: work queued behind a full pool now runs even if the requester disconnects first, where cancellation used to release the semaphore before the hash started. Under a flood that work was going to run regardless, so the ceiling is unchanged.

## Drop the deprecated non-peppered fallback (58d933ff)

With `PASSWORD_PEPPER` set, every login ran two Argon2 verifications: one peppered, one through the fallback kept for hashes predating peppering. It was the dominant cost on the login path.

| | wall | CPU |
|---|---|---|
| before (pepper set) | ~60 ms | ~200 ms |
| after | 26.4 ms | 88.6 ms |

Removing it also retires the reason the earlier commit could not short-circuit a peppered hit: with a single attempt, a match and a miss cost the same by construction, so constant verification cost no longer needs a comment defending it.

## Two things to know before merging

- **An account whose stored hash never had the pepper applied can no longer log in**, and those accounts cannot be identified from the database — a peppered hash is indistinguishable from a legacy one until a verification succeeds. Recovery is a password reset. Worth a test login after deploy.
- **The boot-time `ADMIN_PASSWORD` path is not an escape hatch for that**: `_initialize_admin_password` returns early when `has_password()` is true, so it will not re-hash an existing password. Recovery means clearing `hashed_password` for the user first. The pepper note in `.env.example` now says that introducing a pepper on an install that already has users invalidates their passwords.

## Verification

- 517 tests pass; `pyright` and `ruff check`/`format` clean on the touched files.
- Four tests covering fallback permutations collapse into one parametrized case asserting a single verification with the pepper applied, plus a guard that an unreadable stored hash is a failed login rather than a 500. The thread-pool change needed no test edits.
- Measured on a 12-core dev box: Argon2's total work is ~95 ms of CPU regardless of `parallelism`, which only spreads it across cores (`p=1`: 96 ms wall; `p=4`: 25 ms wall / 88 ms CPU). Worth noting for a 1-vCPU host, where `PASSWORD_HASH_CONCURRENCY=1` buys the same throughput as `2` while pinning half the memory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)