### PR TITLE
Use the shared flashcard mutations hook for chapter cards

### DIFF
--- a/frontend/src/pages/BookPage/Structure/ChapterDetailDialog/FlashcardsSection.tsx
+++ b/frontend/src/pages/BookPage/Structure/ChapterDetailDialog/FlashcardsSection.tsx
@@ -12,8 +12,6 @@ import { CardList } from '@/components/CardList.tsx';
 import { AIFeature } from '@/components/features/AIFeature.tsx';
 import type { FlashcardWithContext } from '@/components/features/flashcards/FlashcardChapterList.tsx';
 import { useSnackbar } from '@/context/SnackbarContext.tsx';
-import { useMutationErrorHandler } from '@/hooks/useMutationErrorHandler.ts';
-import { useCacheEvents } from '@/lib/cacheEvents.ts';
 import {
   CreateFlashcardForm,
   type FlashcardFormValues,
@@ -21,6 +19,7 @@ import {
 import { FlashcardEditDialog } from '@/pages/BookPage/Flashcards/FlashcardEditDialog.tsx';
 import { FlashcardListCard } from '@/pages/BookPage/Flashcards/FlashcardListCard.tsx';
 import { FlashcardSuggestions } from '@/pages/BookPage/Flashcards/FlashcardSuggestions.tsx';
+import { useFlashcardMutations } from '@/pages/BookPage/Flashcards/hooks/useFlashcardMutations.ts';
 import { flatMap } from 'lodash';
 import { useCallback, useMemo, useState } from 'react';
 
@@ -30,41 +29,6 @@ interface FlashcardsSectionProps {
   prereadingSummary?: ChapterPrereadingResponse;
   bookFlashcards?: Flashcard[];
 }
-
-const useFlashcardMutations = (bookId: number, chapterId: number) => {
-  const mutationErrorHandler = useMutationErrorHandler();
-  const cache = useCacheEvents();
-  const [isProcessing, setIsProcessing] = useState(false);
-
-  const createFlashcardMutation = useCreateFlashcardForBook({
-    mutation: {
-      onSuccess: () => cache.flashcardsChanged(bookId),
-      onError: mutationErrorHandler('create flashcard'),
-    },
-  });
-
-  const saveFlashcard = async (question: string, answer: string): Promise<boolean> => {
-    if (!question.trim() || !answer.trim()) return false;
-
-    setIsProcessing(true);
-    try {
-      await createFlashcardMutation.mutateAsync({
-        bookId,
-        data: { question: question.trim(), answer: answer.trim(), chapter_id: chapterId },
-      });
-      return true;
-    } catch {
-      return false;
-    } finally {
-      setIsProcessing(false);
-    }
-  };
-
-  return {
-    isProcessing,
-    saveFlashcard,
-  };
-};
 
 const useAIFlashcardSuggestions = (
   chapterId: number,
@@ -109,7 +73,15 @@ export const FlashcardsSection = ({
 }: FlashcardsSectionProps) => {
   const [editingFlashcard, setEditingFlashcard] = useState<FlashcardWithContext | null>(null);
   const { showSnackbar } = useSnackbar();
-  const { isProcessing, saveFlashcard } = useFlashcardMutations(bookId, chapter.id);
+  const createFlashcardMutation = useCreateFlashcardForBook();
+  const { isProcessing, saveFlashcard } = useFlashcardMutations({
+    bookId,
+    createFlashcard: (question, answer) =>
+      createFlashcardMutation.mutateAsync({
+        bookId,
+        data: { question, answer, chapter_id: chapter.id },
+      }),
+  });
   const { isLoading, suggestions, fetchSuggestions, removeSuggestion } = useAIFlashcardSuggestions(
     chapter.id,
     showSnackbar


### PR DESCRIPTION
Follow-up to #454, noticed while converting cache invalidation and deliberately
left out of that PR to keep its diff checkable.

`FlashcardsSection` defined its own module-scope `useFlashcardMutations`, with the
same name as the shared hook two sibling components already use. Not a shadowing
conflict — the file never imported the shared one — but a reader moving between
`NoteFlashcardSection`, `HighlightFlashcardSection` and this file meets the same
name with a different signature in each place.

It was also a reimplementation. Both versions validate that question and answer
are non-empty, trim them, hold an `isProcessing` flag around the call, report
failures through `mutationErrorHandler('create flashcard')`, invalidate via
`flashcardsChanged`, and return a boolean. The only real difference was the create
endpoint — which is exactly the part the shared hook takes as a parameter, because
creates are source-specific:

```ts
const createFlashcardMutation = useCreateFlashcardForBook();
const { isProcessing, saveFlashcard } = useFlashcardMutations({
  bookId,
  createFlashcard: (question, answer) =>
    createFlashcardMutation.mutateAsync({
      bookId,
      data: { question, answer, chapter_id: chapter.id },
    }),
});
```

The note and highlight sections already pass theirs the same way. This call site
simply predates that.

## Behaviour is unchanged

- Trimming and validation move into the shared hook, which does both.
- Invalidation is `flashcardsChanged(bookId)` either way — `noteId` is undefined
  for a chapter card.
- A failed create still produces one snackbar with the same message, raised from
  the shared hook's `catch` rather than the mutation's `onError`.
- The `updateFlashcard` the shared hook also returns is simply not destructured.

**−38 / +10.** One definition of the hook now, three call sites, all on it.
`tsc --noEmit` and `eslint --max-warnings 0` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)