### PR TITLE
Refetch a note's detail after seeding it from a list row

### DIFF
--- a/frontend/src/pages/BookPage/Notes/hooks/useNoteDialogs.ts
+++ b/frontend/src/pages/BookPage/Notes/hooks/useNoteDialogs.ts
@@ -38,24 +38,33 @@ export const useNoteDialogs = (options: UseNoteDialogsOptions = {}): NoteDialogs
 
   const { open, navigateToIndex, ...rest } = dialog;
 
-  const openView = useCallback(
+  // A list row is a placeholder for the detail, not a substitute: the list
+  // response leaves `flashcards` empty by design. Seed it so the dialog paints
+  // instantly, but backdate the entry so it counts as stale and `useGetNote`
+  // still fetches the real detail on mount.
+  const seedDetail = useCallback(
     (note: NoteWithLinks) => {
-      queryClient.setQueryData(getGetNoteQueryKey(note.id), note);
-      open(note.id);
+      queryClient.setQueryData(getGetNoteQueryKey(note.id), note, { updatedAt: 0 });
     },
-    [open, queryClient]
+    [queryClient]
   );
 
-  // Seed the detail cache like openView so navigation renders instantly; the
-  // underlying navigation replaces the history entry so Back closes the dialog
-  // instead of stepping through every viewed note.
+  const openView = useCallback(
+    (note: NoteWithLinks) => {
+      seedDetail(note);
+      open(note.id);
+    },
+    [open, seedDetail]
+  );
+
+  // The underlying navigation replaces the history entry so Back closes the
+  // dialog instead of stepping through every viewed note.
   const handleNavigate = useCallback(
     (newIndex: number) => {
-      const note = allNotes[newIndex];
-      queryClient.setQueryData(getGetNoteQueryKey(note.id), note);
+      seedDetail(allNotes[newIndex]);
       navigateToIndex(newIndex);
     },
-    [allNotes, navigateToIndex, queryClient]
+    [allNotes, navigateToIndex, seedDetail]
   );
 
   return {


### PR DESCRIPTION
The note dialog's Flashcards tab showed a count of zero and no cards when the dialog was opened from the notes list. Reloading the page with the dialog open fixed it until the next navigation.

## Cause

`useNoteDialogs.openView` writes the list row into the detail query's cache so the dialog paints without a spinner:

```ts
queryClient.setQueryData(getGetNoteQueryKey(note.id), note);
```

`GET /books/{book_id}/notes` leaves `flashcards` empty by design — only the detail endpoint populates them. `setQueryData` stamps `dataUpdatedAt = now`, and the global `staleTime` is 5 minutes, so `useGetNote` considered the cache fresh and never issued the request. No network call, so the tab rendered the list row's empty array. A reload cleared the cache and the real detail came back with the cards.

Cards created while the dialog was open did appear, because that path invalidates the detail key explicitly (`cache.flashcardsChanged(bookId, noteId)`) — which is why this only showed up on open.

`handleNavigate` (prev/next inside the dialog) had the same line.

Both shapes are typed `NoteWithLinks`, so nothing flagged that a list row was standing in for a detail row.

Not a regression from the read-model migration: the seeding landed in db209732 (2026-07-13) and note flashcards in f50807fb (2026-07-16), which silently made the seed incomplete. Verified against the API that the detail endpoint returns the cards — including on a note with chapter/highlight/tag links and after an update that replaces the link rows.

## Fix

Seed with a backdated timestamp, via one `seedDetail` helper used by both call sites:

```ts
queryClient.setQueryData(getGetNoteQueryKey(note.id), note, { updatedAt: 0 });
```

The instant first paint is kept, and the entry counts as stale so `useGetNote` fetches the real detail on mount and it lands over the placeholder. Confirmed in the installed `query-core` that `updatedAt: 0` survives the reducer (`dataUpdatedAt ?? Date.now()` — `??` does not fall back on `0`) and that `isStaleByTime` then returns true.

The blunter alternative is to drop the seeding and accept a spinner; the instant paint was the point of the seed, so it stays.

## Verification

- `npm run type-check` and `npm run lint` — clean
- No regression test: the frontend has no test framework configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)