### PR TITLE
Serve the highlight row from one shared projection

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -170,33 +170,19 @@ source_modules = [
     "src.infrastructure.ai.ai_agents",
     "src.infrastructure.ai.ai_model",
     "src.infrastructure.ai.ai_service",
+    "src.infrastructure.*.routers",
+    "src.infrastructure.*.schemas",
+    "src.infrastructure.*.services",
     "src.infrastructure.common.dependencies",
     "src.infrastructure.common.di",
     "src.infrastructure.common.rate_limit",
-    "src.infrastructure.common.routers",
-    "src.infrastructure.common.schemas",
     "src.infrastructure.common.sql",
     "src.infrastructure.identity.dependencies",
-    "src.infrastructure.identity.routers",
-    "src.infrastructure.identity.schemas",
-    "src.infrastructure.identity.services",
-    "src.infrastructure.jobs.routers",
-    "src.infrastructure.jobs.schemas",
     "src.infrastructure.jobs.tasks",
     "src.infrastructure.jobs.saq_job_queue_service",
     "src.infrastructure.jobs.saq_queue",
-    "src.infrastructure.learning.routers",
-    "src.infrastructure.learning.schemas",
-    "src.infrastructure.library.routers",
-    "src.infrastructure.library.schemas",
-    "src.infrastructure.library.services",
-    "src.infrastructure.reading.routers",
-    "src.infrastructure.reading.schemas",
-    "src.infrastructure.reading.services",
-    "src.infrastructure.tagging.routers",
-    "src.infrastructure.tagging.schemas",
 ]
-forbidden_modules = ["src.models", "src.infrastructure.jobs.orm"]
+forbidden_modules = ["src.infrastructure.*.orm"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/backend/src/application/common/queries/highlight_row.py
+++ b/backend/src/application/common/queries/highlight_row.py
@@ -1,0 +1,42 @@
+"""The highlight row shared by the views that render a whole highlight.
+
+The book-details page and the in-book highlight search show the same highlight
+through the same ``Highlight`` response schema, so they read it through one
+shape rather than two identical ones.
+
+These are view DTOs, not domain entities: they exist to be rendered and must
+never be fed back into a command. See ``docs/adr/0001-read-models-and-query-services.md``.
+"""
+
+from dataclasses import dataclass
+from datetime import datetime as dt
+
+from src.application.common.queries.refs import FlashcardRef, TagRef
+
+
+@dataclass(frozen=True)
+class HighlightLabelView:
+    """One highlight's effective label, resolved by the domain rather than by SQL."""
+
+    highlight_style_id: int
+    text: str | None
+    ui_color: str | None
+
+
+@dataclass(frozen=True)
+class HighlightRow:
+    """A highlight with everything a highlight list renders alongside it."""
+
+    id: int
+    book_id: int
+    chapter_id: int | None
+    chapter_name: str | None
+    chapter_number: int | None
+    text: str
+    page: int | None
+    datetime: str
+    label: HighlightLabelView | None
+    tags: tuple[TagRef, ...]
+    flashcards: tuple[FlashcardRef, ...]
+    created_at: dt
+    updated_at: dt

--- a/backend/src/application/common/queries/refs.py
+++ b/backend/src/application/common/queries/refs.py
@@ -1,0 +1,45 @@
+"""View DTOs that several read models embed.
+
+Each is a flat projection of one row, carrying only the fields a view renders.
+They live here rather than in a module's ``queries`` package because more than
+one view needs the identical shape.
+
+These are view DTOs, not domain entities: they exist to be rendered and must
+never be fed back into a command. See ``docs/adr/0001-read-models-and-query-services.md``.
+"""
+
+from dataclasses import dataclass
+from datetime import datetime as dt
+
+
+@dataclass(frozen=True)
+class TagRef:
+    """A tag as a view renders it."""
+
+    id: int
+    name: str
+    tag_group_id: int | None
+
+
+@dataclass(frozen=True)
+class FlashcardRef:
+    """A flashcard as a view renders it."""
+
+    id: int
+    user_id: int
+    book_id: int
+    highlight_id: int | None
+    chapter_id: int | None
+    note_id: int | None
+    question: str
+    answer: str
+
+
+@dataclass(frozen=True)
+class BookmarkView:
+    """A bookmark pinned to one of a book's highlights."""
+
+    id: int
+    book_id: int
+    highlight_id: int
+    created_at: dt

--- a/backend/src/application/learning/queries/book_flashcards.py
+++ b/backend/src/application/learning/queries/book_flashcards.py
@@ -8,25 +8,9 @@ from dataclasses import dataclass
 from datetime import datetime as dt
 from typing import Protocol
 
+from src.application.common.queries.highlight_row import HighlightLabelView
+from src.application.common.queries.refs import TagRef
 from src.domain.common.value_objects.ids import BookId, UserId
-
-
-@dataclass(frozen=True)
-class TagRef:
-    """A tag on a flashcard's highlight, as the list shows it."""
-
-    id: int
-    name: str
-    tag_group_id: int | None
-
-
-@dataclass(frozen=True)
-class HighlightLabelView:
-    """A highlight's effective label, resolved by the domain rather than by SQL."""
-
-    highlight_style_id: int | None
-    text: str | None
-    ui_color: str | None
 
 
 @dataclass(frozen=True)

--- a/backend/src/application/library/queries/book_details.py
+++ b/backend/src/application/library/queries/book_details.py
@@ -8,18 +8,11 @@ from dataclasses import dataclass
 from datetime import datetime as dt
 from typing import Protocol
 
+from src.application.common.queries.highlight_row import HighlightRow
+from src.application.common.queries.refs import BookmarkView, FlashcardRef, TagRef
 from src.domain.common.value_objects.ids import BookId, UserId
 from src.domain.common.value_objects.position import Position
 from src.domain.library.entities.book import ReadingStage
-
-
-@dataclass(frozen=True)
-class TagRef:
-    """A tag as shown inside a book."""
-
-    id: int
-    name: str
-    tag_group_id: int | None
 
 
 @dataclass(frozen=True)
@@ -31,58 +24,6 @@ class TagGroupRef:
 
 
 @dataclass(frozen=True)
-class BookmarkView:
-    """A bookmark pinned to one of the book's highlights."""
-
-    id: int
-    book_id: int
-    highlight_id: int
-    created_at: dt
-
-
-@dataclass(frozen=True)
-class FlashcardRef:
-    """A flashcard as shown in the book-details view."""
-
-    id: int
-    user_id: int
-    book_id: int
-    highlight_id: int | None
-    chapter_id: int | None
-    note_id: int | None
-    question: str
-    answer: str
-
-
-@dataclass(frozen=True)
-class HighlightLabelView:
-    """The label resolved for a highlight's style."""
-
-    highlight_style_id: int
-    text: str | None
-    ui_color: str | None
-
-
-@dataclass(frozen=True)
-class HighlightView:
-    """A highlight with everything the book-details view renders alongside it."""
-
-    id: int
-    book_id: int
-    chapter_id: int | None
-    chapter_name: str | None
-    chapter_number: int | None
-    text: str
-    page: int | None
-    datetime: str
-    label: HighlightLabelView | None
-    tags: tuple[TagRef, ...]
-    flashcards: tuple[FlashcardRef, ...]
-    created_at: dt
-    updated_at: dt
-
-
-@dataclass(frozen=True)
 class ChapterWithHighlightsView:
     """A chapter of the book together with its highlights (possibly none)."""
 
@@ -91,7 +32,7 @@ class ChapterWithHighlightsView:
     chapter_number: int | None
     parent_id: int | None
     start_position: Position | None
-    highlights: tuple[HighlightView, ...]
+    highlights: tuple[HighlightRow, ...]
     created_at: dt
     updated_at: dt
 

--- a/backend/src/application/notes/queries/note_with_links.py
+++ b/backend/src/application/notes/queries/note_with_links.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 from datetime import datetime as dt
 from typing import Protocol
 
+from src.application.common.queries.refs import FlashcardRef
 from src.domain.common.value_objects.ids import (
     BookId,
     ChapterId,
@@ -47,20 +48,6 @@ class LinkedTagView:
 
 
 @dataclass(frozen=True)
-class NoteFlashcardView:
-    """A flashcard generated from a note."""
-
-    id: int
-    user_id: int
-    book_id: int
-    highlight_id: int | None
-    chapter_id: int | None
-    note_id: int | None
-    question: str
-    answer: str
-
-
-@dataclass(frozen=True)
 class NoteWithLinksView:
     """A note together with the entities it links to.
 
@@ -86,7 +73,7 @@ class NoteWithLinksView:
     chapters: tuple[LinkedChapterView, ...]
     highlights: tuple[LinkedHighlightView, ...]
     tags: tuple[LinkedTagView, ...]
-    flashcards: tuple[NoteFlashcardView, ...]
+    flashcards: tuple[FlashcardRef, ...]
     created_at: dt
     updated_at: dt
 

--- a/backend/src/application/reading/queries/bookmarks.py
+++ b/backend/src/application/reading/queries/bookmarks.py
@@ -4,21 +4,10 @@ These are view DTOs, not domain entities: they exist to be rendered and must
 never be fed back into a command. See ``docs/adr/0001-read-models-and-query-services.md``.
 """
 
-from dataclasses import dataclass
-from datetime import datetime as dt
 from typing import Protocol
 
+from src.application.common.queries.refs import BookmarkView
 from src.domain.common.value_objects.ids import BookId, UserId
-
-
-@dataclass(frozen=True)
-class BookmarkView:
-    """A bookmark pinned to one of the book's highlights."""
-
-    id: int
-    book_id: int
-    highlight_id: int
-    created_at: dt
 
 
 class BookmarkQueryProtocol(Protocol):

--- a/backend/src/application/reading/queries/get_bookmarks_use_case.py
+++ b/backend/src/application/reading/queries/get_bookmarks_use_case.py
@@ -1,9 +1,7 @@
 """Read use case for a book's bookmark list."""
 
-from src.application.reading.queries.bookmarks import (
-    BookmarkQueryProtocol,
-    BookmarkView,
-)
+from src.application.common.queries.refs import BookmarkView
+from src.application.reading.queries.bookmarks import BookmarkQueryProtocol
 from src.domain.common.value_objects.ids import BookId, UserId
 from src.domain.reading.exceptions import BookNotFoundError
 

--- a/backend/src/application/reading/queries/highlight_search.py
+++ b/backend/src/application/reading/queries/highlight_search.py
@@ -13,58 +13,8 @@ from dataclasses import dataclass
 from datetime import datetime as dt
 from typing import Protocol
 
+from src.application.common.queries.highlight_row import HighlightRow
 from src.domain.common.value_objects.ids import BookId, UserId
-
-
-@dataclass(frozen=True)
-class TagRef:
-    """A tag on a matched highlight."""
-
-    id: int
-    name: str
-    tag_group_id: int | None
-
-
-@dataclass(frozen=True)
-class FlashcardRef:
-    """A flashcard made from a matched highlight."""
-
-    id: int
-    user_id: int
-    book_id: int
-    highlight_id: int | None
-    chapter_id: int | None
-    note_id: int | None
-    question: str
-    answer: str
-
-
-@dataclass(frozen=True)
-class HighlightLabelView:
-    """A highlight's effective label, resolved by the domain rather than by SQL."""
-
-    highlight_style_id: int
-    text: str | None
-    ui_color: str | None
-
-
-@dataclass(frozen=True)
-class SearchHighlightView:
-    """A highlight that matched the search, with what the result list renders."""
-
-    id: int
-    book_id: int
-    chapter_id: int | None
-    chapter_name: str | None
-    chapter_number: int | None
-    text: str
-    page: int | None
-    datetime: str
-    label: HighlightLabelView | None
-    tags: tuple[TagRef, ...]
-    flashcards: tuple[FlashcardRef, ...]
-    created_at: dt
-    updated_at: dt
 
 
 @dataclass(frozen=True)
@@ -78,7 +28,7 @@ class SearchChapterView:
     id: int
     name: str
     chapter_number: int | None
-    highlights: tuple[SearchHighlightView, ...]
+    highlights: tuple[HighlightRow, ...]
     created_at: dt
     updated_at: dt
 

--- a/backend/src/application/reading/queries/reading_sessions.py
+++ b/backend/src/application/reading/queries/reading_sessions.py
@@ -8,16 +8,8 @@ from dataclasses import dataclass
 from datetime import datetime as dt
 from typing import Protocol
 
+from src.application.common.queries.highlight_row import HighlightLabelView
 from src.domain.common.value_objects.ids import BookId, UserId
-
-
-@dataclass(frozen=True)
-class HighlightLabelView:
-    """A highlight's effective label, resolved by the domain rather than by SQL."""
-
-    highlight_style_id: int
-    text: str | None
-    ui_color: str | None
 
 
 @dataclass(frozen=True)

--- a/backend/src/infrastructure/common/queries/row_mappers.py
+++ b/backend/src/infrastructure/common/queries/row_mappers.py
@@ -1,0 +1,59 @@
+"""ORM-to-DTO mapping for the view DTOs shared across read models.
+
+Nothing here decides anything: a highlight's effective label arrives already
+resolved from the caller's ``LabelResolutionService``, so the rule stays where
+the domain put it (ADR-0001, rule 1).
+"""
+
+from src.application.common.queries.highlight_row import HighlightLabelView, HighlightRow
+from src.application.common.queries.refs import FlashcardRef, TagRef
+from src.domain.reading.services.highlight_style_resolver import ResolvedLabel
+from src.infrastructure.learning.orm.flashcard_model import Flashcard as FlashcardORM
+from src.infrastructure.reading.orm.highlight_model import Highlight as HighlightORM
+from src.infrastructure.tagging.orm.tag_model import Tag as TagORM
+
+
+def tag_ref(row: TagORM) -> TagRef:
+    """Map a tag row to its view DTO."""
+    return TagRef(id=row.id, name=row.name, tag_group_id=row.tag_group_id)
+
+
+def flashcard_ref(row: FlashcardORM) -> FlashcardRef:
+    """Map a flashcard row to its view DTO."""
+    return FlashcardRef(
+        id=row.id,
+        user_id=row.user_id,
+        book_id=row.book_id,
+        highlight_id=row.highlight_id,
+        chapter_id=row.chapter_id,
+        note_id=row.note_id,
+        question=row.question,
+        answer=row.answer,
+    )
+
+
+def highlight_row(row: HighlightORM, labels: dict[int, ResolvedLabel]) -> HighlightRow:
+    """Map a highlight row and its eagerly loaded relations to the view DTO."""
+    style_id = row.highlight_style_id
+    resolved = labels.get(style_id) if style_id is not None else None
+    return HighlightRow(
+        id=row.id,
+        book_id=row.book_id,
+        chapter_id=row.chapter_id,
+        chapter_name=row.chapter.name if row.chapter else None,
+        chapter_number=row.chapter.chapter_number if row.chapter else None,
+        text=row.text,
+        page=row.page,
+        datetime=row.datetime,
+        label=HighlightLabelView(
+            highlight_style_id=style_id,
+            text=resolved.label if resolved else None,
+            ui_color=resolved.ui_color if resolved else None,
+        )
+        if style_id is not None
+        else None,
+        tags=tuple(tag_ref(tag) for tag in row.tags),
+        flashcards=tuple(flashcard_ref(card) for card in row.flashcards),
+        created_at=row.created_at,
+        updated_at=row.updated_at,
+    )

--- a/backend/src/infrastructure/learning/queries/book_flashcard_query.py
+++ b/backend/src/infrastructure/learning/queries/book_flashcard_query.py
@@ -13,15 +13,15 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload, noload
 
+from src.application.common.queries.highlight_row import HighlightLabelView
 from src.application.learning.queries.book_flashcards import (
     FlashcardHighlightView,
     FlashcardWithHighlightView,
-    HighlightLabelView,
-    TagRef,
 )
 from src.application.reading.services.label_resolution_service import LabelResolutionService
 from src.domain.common.value_objects.ids import BookId, UserId
 from src.domain.reading.services.highlight_style_resolver import ResolvedLabel
+from src.infrastructure.common.queries.row_mappers import tag_ref
 from src.infrastructure.learning.orm.flashcard_model import Flashcard as FlashcardORM
 from src.infrastructure.reading.orm.highlight_model import Highlight as HighlightORM
 
@@ -121,9 +121,7 @@ def _highlight_view(row: HighlightORM, labels: dict[int, ResolvedLabel]) -> Flas
         )
         if style_id is not None
         else None,
-        tags=tuple(
-            TagRef(id=tag.id, name=tag.name, tag_group_id=tag.tag_group_id) for tag in row.tags
-        ),
+        tags=tuple(tag_ref(tag) for tag in row.tags),
         created_at=row.created_at,
         updated_at=row.updated_at,
     )

--- a/backend/src/infrastructure/library/queries/book_details_query.py
+++ b/backend/src/infrastructure/library/queries/book_details_query.py
@@ -14,21 +14,18 @@ from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload, noload
 
+from src.application.common.queries.refs import BookmarkView, FlashcardRef, TagRef
 from src.application.library.queries.book_details import (
     BookDetailsView,
-    BookmarkView,
     ChapterWithHighlightsView,
-    FlashcardRef,
-    HighlightLabelView,
-    HighlightView,
     TagGroupRef,
-    TagRef,
 )
 from src.application.reading.services.label_resolution_service import LabelResolutionService
 from src.domain.common.value_objects.ids import BookId, UserId
 from src.domain.common.value_objects.position import Position
 from src.domain.library.entities.book import ReadingStage
 from src.domain.reading.services.highlight_style_resolver import ResolvedLabel
+from src.infrastructure.common.queries.row_mappers import flashcard_ref, highlight_row
 from src.infrastructure.learning.orm.flashcard_model import Flashcard as FlashcardORM
 from src.infrastructure.library.orm.book_model import Book as BookORM
 from src.infrastructure.library.orm.chapter_model import Chapter as ChapterORM
@@ -182,7 +179,7 @@ class BookDetailsQuery:
             .order_by(FlashcardORM.created_at.desc())
         )
         rows = (await self.db.execute(stmt)).scalars().all()
-        return tuple(_flashcard_ref(row) for row in rows)
+        return tuple(flashcard_ref(row) for row in rows)
 
     async def _fetch_chapters(
         self,
@@ -252,49 +249,6 @@ class BookDetailsQuery:
         return (await self.db.execute(stmt)).unique().scalars().all()
 
 
-def _flashcard_ref(row: FlashcardORM) -> FlashcardRef:
-    """Map a flashcard row to its view DTO."""
-    return FlashcardRef(
-        id=row.id,
-        user_id=row.user_id,
-        book_id=row.book_id,
-        highlight_id=row.highlight_id,
-        chapter_id=row.chapter_id,
-        note_id=row.note_id,
-        question=row.question,
-        answer=row.answer,
-    )
-
-
-def _highlight_view(row: HighlightORM, labels: dict[int, ResolvedLabel]) -> HighlightView:
-    """Map a highlight row and its eagerly loaded relations to the view DTO."""
-    style_id = row.highlight_style_id
-    resolved = labels.get(style_id) if style_id is not None else None
-    return HighlightView(
-        id=row.id,
-        book_id=row.book_id,
-        chapter_id=row.chapter_id,
-        chapter_name=row.chapter.name if row.chapter else None,
-        chapter_number=row.chapter.chapter_number if row.chapter else None,
-        text=row.text,
-        page=row.page,
-        datetime=row.datetime,
-        label=HighlightLabelView(
-            highlight_style_id=style_id,
-            text=resolved.label if resolved else None,
-            ui_color=resolved.ui_color if resolved else None,
-        )
-        if style_id is not None
-        else None,
-        tags=tuple(
-            TagRef(id=tag.id, name=tag.name, tag_group_id=tag.tag_group_id) for tag in row.tags
-        ),
-        flashcards=tuple(_flashcard_ref(card) for card in row.flashcards),
-        created_at=row.created_at,
-        updated_at=row.updated_at,
-    )
-
-
 def _chapter_view(
     chapter: ChapterORM,
     highlights: list[HighlightORM],
@@ -308,7 +262,7 @@ def _chapter_view(
         chapter_number=chapter.chapter_number,
         parent_id=chapter.parent_id,
         start_position=_position(chapter.start_position),
-        highlights=tuple(_highlight_view(row, labels) for row in ordered),
+        highlights=tuple(highlight_row(row, labels) for row in ordered),
         created_at=chapter.created_at,
         updated_at=chapter.updated_at,
     )

--- a/backend/src/infrastructure/library/routers/books.py
+++ b/backend/src/infrastructure/library/routers/books.py
@@ -12,7 +12,6 @@ from src.application.library.commands.book_management.update_reading_stage_use_c
 from src.application.library.queries.book_details import (
     BookDetailsView,
     ChapterWithHighlightsView,
-    HighlightView,
 )
 from src.application.library.queries.book_list import BookWithCountsView
 from src.application.library.queries.get_book_details_use_case import GetBookDetailsUseCase
@@ -37,52 +36,11 @@ from src.infrastructure.reading.schemas import (
     BookDetails,
     Bookmark,
     ChapterWithHighlights,
-    Highlight,
-    HighlightLabel,
 )
+from src.infrastructure.reading.schemas.highlight_builders import build_highlight_schema
 from src.infrastructure.tagging.schemas import TagGroupInBook, TagInBook
 
 router = APIRouter(prefix="/books", tags=["books"])
-
-
-def _build_highlight_schema(highlight: HighlightView) -> Highlight:
-    """Build the Highlight schema from a highlight in the book-details read model."""
-    return Highlight(
-        id=highlight.id,
-        book_id=highlight.book_id,
-        chapter_id=highlight.chapter_id,
-        text=highlight.text,
-        chapter=highlight.chapter_name,
-        chapter_number=highlight.chapter_number,
-        page=highlight.page,
-        datetime=highlight.datetime,
-        label=HighlightLabel(
-            highlight_style_id=highlight.label.highlight_style_id,
-            text=highlight.label.text,
-            ui_color=highlight.label.ui_color,
-        )
-        if highlight.label
-        else None,
-        flashcards=[
-            Flashcard(
-                id=card.id,
-                user_id=card.user_id,
-                book_id=card.book_id,
-                highlight_id=card.highlight_id,
-                chapter_id=card.chapter_id,
-                note_id=card.note_id,
-                question=card.question,
-                answer=card.answer,
-            )
-            for card in highlight.flashcards
-        ],
-        tags=[
-            TagInBook(id=tag.id, name=tag.name, tag_group_id=tag.tag_group_id)
-            for tag in highlight.tags
-        ],
-        created_at=highlight.created_at,
-        updated_at=highlight.updated_at,
-    )
 
 
 def _build_chapter_schema(chapter: ChapterWithHighlightsView) -> ChapterWithHighlights:
@@ -98,7 +56,7 @@ def _build_chapter_schema(chapter: ChapterWithHighlightsView) -> ChapterWithHigh
         )
         if chapter.start_position
         else None,
-        highlights=[_build_highlight_schema(highlight) for highlight in chapter.highlights],
+        highlights=[build_highlight_schema(highlight) for highlight in chapter.highlights],
         created_at=chapter.created_at,
         updated_at=chapter.updated_at,
     )

--- a/backend/src/infrastructure/notes/queries/note_query.py
+++ b/backend/src/infrastructure/notes/queries/note_query.py
@@ -17,11 +17,11 @@ from sqlalchemy import ColumnElement, Select, Table, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql import func
 
+from src.application.common.queries.refs import FlashcardRef
 from src.application.notes.queries.note_with_links import (
     LinkedChapterView,
     LinkedHighlightView,
     LinkedTagView,
-    NoteFlashcardView,
     NoteWithLinksView,
 )
 from src.domain.common.value_objects.ids import (
@@ -224,7 +224,7 @@ class NoteQuery:
 
     async def _fetch_flashcards(
         self, note_ids: list[int], user_id: UserId
-    ) -> dict[int, tuple[NoteFlashcardView, ...]]:
+    ) -> dict[int, tuple[FlashcardRef, ...]]:
         """Load every note's flashcards in one pass, newest first within a note."""
         stmt = (
             select(
@@ -244,7 +244,7 @@ class NoteQuery:
             .order_by(FlashcardORM.note_id, FlashcardORM.created_at.desc())
         )
         rows = (await self.db.execute(stmt)).tuples().all()
-        grouped: dict[int | None, list[NoteFlashcardView]] = defaultdict(list)
+        grouped: dict[int | None, list[FlashcardRef]] = defaultdict(list)
         for (
             card_id,
             card_user_id,
@@ -256,7 +256,7 @@ class NoteQuery:
             answer,
         ) in rows:
             grouped[card_note_id].append(
-                NoteFlashcardView(
+                FlashcardRef(
                     id=card_id,
                     user_id=card_user_id,
                     book_id=book_id,

--- a/backend/src/infrastructure/reading/queries/bookmark_query.py
+++ b/backend/src/infrastructure/reading/queries/bookmark_query.py
@@ -9,7 +9,7 @@ question.
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from src.application.reading.queries.bookmarks import BookmarkView
+from src.application.common.queries.refs import BookmarkView
 from src.domain.common.value_objects.ids import BookId, UserId
 from src.infrastructure.library.orm.book_model import Book as BookORM
 from src.infrastructure.reading.orm.bookmark_model import Bookmark as BookmarkORM

--- a/backend/src/infrastructure/reading/queries/highlight_search_query.py
+++ b/backend/src/infrastructure/reading/queries/highlight_search_query.py
@@ -20,21 +20,16 @@ from sqlalchemy.orm import joinedload, noload
 
 from src.application.reading.queries.highlight_search import (
     BookHighlightSearchView,
-    FlashcardRef,
-    HighlightLabelView,
     SearchChapterView,
-    SearchHighlightView,
-    TagRef,
 )
 from src.application.reading.services.label_resolution_service import LabelResolutionService
 from src.domain.common.value_objects.ids import BookId, UserId
 from src.domain.reading.services.highlight_style_resolver import ResolvedLabel
+from src.infrastructure.common.queries.row_mappers import highlight_row
 from src.infrastructure.common.sql import LIKE_ESCAPE_CHAR, escape_like_pattern
-from src.infrastructure.learning.orm.flashcard_model import Flashcard as FlashcardORM
 from src.infrastructure.library.orm.book_model import Book as BookORM
 from src.infrastructure.library.orm.chapter_model import Chapter as ChapterORM
 from src.infrastructure.reading.orm.highlight_model import Highlight as HighlightORM
-from src.infrastructure.tagging.orm.tag_model import Tag as TagORM
 
 
 class HighlightSearchQuery:
@@ -137,53 +132,7 @@ def _chapter_view(
         id=chapter.id,
         name=chapter.name,
         chapter_number=chapter.chapter_number,
-        highlights=tuple(_highlight_view(row, labels) for row in ordered),
+        highlights=tuple(highlight_row(row, labels) for row in ordered),
         created_at=chapter.created_at,
         updated_at=chapter.updated_at,
-    )
-
-
-def _highlight_view(row: HighlightORM, labels: dict[int, ResolvedLabel]) -> SearchHighlightView:
-    """Map a matched highlight and its eagerly loaded relations to the view DTO."""
-    style_id = row.highlight_style_id
-    resolved = labels.get(style_id) if style_id is not None else None
-    return SearchHighlightView(
-        id=row.id,
-        book_id=row.book_id,
-        chapter_id=row.chapter_id,
-        chapter_name=row.chapter.name if row.chapter else None,
-        chapter_number=row.chapter.chapter_number if row.chapter else None,
-        text=row.text,
-        page=row.page,
-        datetime=row.datetime,
-        label=HighlightLabelView(
-            highlight_style_id=style_id,
-            text=resolved.label if resolved else None,
-            ui_color=resolved.ui_color if resolved else None,
-        )
-        if style_id is not None
-        else None,
-        tags=tuple(_tag_ref(tag) for tag in row.tags),
-        flashcards=tuple(_flashcard_ref(card) for card in row.flashcards),
-        created_at=row.created_at,
-        updated_at=row.updated_at,
-    )
-
-
-def _tag_ref(row: TagORM) -> TagRef:
-    """Map a tag row to its view DTO."""
-    return TagRef(id=row.id, name=row.name, tag_group_id=row.tag_group_id)
-
-
-def _flashcard_ref(row: FlashcardORM) -> FlashcardRef:
-    """Map a flashcard row to its view DTO."""
-    return FlashcardRef(
-        id=row.id,
-        user_id=row.user_id,
-        book_id=row.book_id,
-        highlight_id=row.highlight_id,
-        chapter_id=row.chapter_id,
-        note_id=row.note_id,
-        question=row.question,
-        answer=row.answer,
     )

--- a/backend/src/infrastructure/reading/queries/reading_session_query.py
+++ b/backend/src/infrastructure/reading/queries/reading_session_query.py
@@ -16,12 +16,12 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import noload
 
+from src.application.common.queries.highlight_row import HighlightLabelView
 from src.application.library.protocols.file_repository import FileRepositoryProtocol
 from src.application.reading.protocols.ebook_text_extraction_service import (
     EbookTextExtractionServiceProtocol,
 )
 from src.application.reading.queries.reading_sessions import (
-    HighlightLabelView,
     ReadingSessionPageView,
     ReadingSessionView,
     SessionHighlightView,

--- a/backend/src/infrastructure/reading/routers/highlights.py
+++ b/backend/src/infrastructure/reading/routers/highlights.py
@@ -13,7 +13,6 @@ from src.application.reading.commands.highlights.highlight_upload_use_case impor
 )
 from src.application.reading.queries.highlight_search import (
     SearchChapterView,
-    SearchHighlightView,
 )
 from src.application.reading.queries.highlight_search_use_case import (
     HighlightSearchUseCase,
@@ -22,60 +21,17 @@ from src.core import container
 from src.domain.identity.entities.user import User
 from src.infrastructure.common.di import inject_use_case
 from src.infrastructure.identity.dependencies import get_current_user
-from src.infrastructure.learning.schemas import Flashcard
 from src.infrastructure.reading.schemas import (
     BookHighlightSearchResponse,
     ChapterWithHighlights,
-    Highlight,
     HighlightDeleteRequest,
     HighlightDeleteResponse,
-    HighlightLabel,
     HighlightUploadRequest,
     HighlightUploadResponse,
 )
-from src.infrastructure.tagging.schemas import TagInBook
+from src.infrastructure.reading.schemas.highlight_builders import build_highlight_schema
 
 router = APIRouter(prefix="", tags=["highlights"])
-
-
-def _build_highlight_schema(highlight: SearchHighlightView) -> Highlight:
-    """Build the Highlight schema from a match in the search read model."""
-    return Highlight(
-        id=highlight.id,
-        book_id=highlight.book_id,
-        chapter_id=highlight.chapter_id,
-        text=highlight.text,
-        chapter=highlight.chapter_name,
-        chapter_number=highlight.chapter_number,
-        page=highlight.page,
-        datetime=highlight.datetime,
-        label=HighlightLabel(
-            highlight_style_id=highlight.label.highlight_style_id,
-            text=highlight.label.text,
-            ui_color=highlight.label.ui_color,
-        )
-        if highlight.label
-        else None,
-        flashcards=[
-            Flashcard(
-                id=card.id,
-                user_id=card.user_id,
-                book_id=card.book_id,
-                highlight_id=card.highlight_id,
-                chapter_id=card.chapter_id,
-                note_id=card.note_id,
-                question=card.question,
-                answer=card.answer,
-            )
-            for card in highlight.flashcards
-        ],
-        tags=[
-            TagInBook(id=tag.id, name=tag.name, tag_group_id=tag.tag_group_id)
-            for tag in highlight.tags
-        ],
-        created_at=highlight.created_at,
-        updated_at=highlight.updated_at,
-    )
 
 
 def _build_chapter_schema(chapter: SearchChapterView) -> ChapterWithHighlights:
@@ -89,7 +45,7 @@ def _build_chapter_schema(chapter: SearchChapterView) -> ChapterWithHighlights:
         chapter_number=chapter.chapter_number,
         parent_id=None,
         start_position=None,
-        highlights=[_build_highlight_schema(highlight) for highlight in chapter.highlights],
+        highlights=[build_highlight_schema(highlight) for highlight in chapter.highlights],
         created_at=chapter.created_at,
         updated_at=chapter.updated_at,
     )

--- a/backend/src/infrastructure/reading/schemas/highlight_builders.py
+++ b/backend/src/infrastructure/reading/schemas/highlight_builders.py
@@ -1,0 +1,50 @@
+"""Response-schema builders for the shared highlight row.
+
+Lives beside the schema it produces so that every router rendering a highlight
+-- book details, in-book search -- gets the same field mapping.
+"""
+
+from src.application.common.queries.highlight_row import HighlightRow
+from src.infrastructure.learning.schemas.flashcard_schemas import Flashcard
+from src.infrastructure.reading.schemas.highlight_schemas import Highlight, HighlightLabel
+from src.infrastructure.tagging.schemas.tag_schemas import TagInBook
+
+
+def build_highlight_schema(highlight: HighlightRow) -> Highlight:
+    """Build the Highlight schema from a highlight in a read model."""
+    return Highlight(
+        id=highlight.id,
+        book_id=highlight.book_id,
+        chapter_id=highlight.chapter_id,
+        text=highlight.text,
+        chapter=highlight.chapter_name,
+        chapter_number=highlight.chapter_number,
+        page=highlight.page,
+        datetime=highlight.datetime,
+        label=HighlightLabel(
+            highlight_style_id=highlight.label.highlight_style_id,
+            text=highlight.label.text,
+            ui_color=highlight.label.ui_color,
+        )
+        if highlight.label
+        else None,
+        flashcards=[
+            Flashcard(
+                id=card.id,
+                user_id=card.user_id,
+                book_id=card.book_id,
+                highlight_id=card.highlight_id,
+                chapter_id=card.chapter_id,
+                note_id=card.note_id,
+                question=card.question,
+                answer=card.answer,
+            )
+            for card in highlight.flashcards
+        ],
+        tags=[
+            TagInBook(id=tag.id, name=tag.name, tag_group_id=tag.tag_group_id)
+            for tag in highlight.tags
+        ],
+        created_at=highlight.created_at,
+        updated_at=highlight.updated_at,
+    )


### PR DESCRIPTION
Follow-up to the read-model migration (#461–#472). Collapses the duplicated Highlight read-model row onto one projection, then fixes an import contract that turned out not to be enforcing its own name.

## The duplication

The book-details page and the in-book highlight search render the same highlight through the same `Highlight` response schema, but each owned a private copy of the entire path:

| | book details | in-book search |
| --- | --- | --- |
| view DTO | `HighlightView` (13 fields) | `SearchHighlightView` (same 13) |
| ORM → DTO | `_highlight_view` | `_highlight_view` |
| DTO → schema | `_build_highlight_schema` | `_build_highlight_schema` |

The two schema builders were byte-identical apart from their parameter annotation and docstring. `TagRef` was declared 3×, `HighlightLabelView` 3×, `FlashcardRef` and `BookmarkView` 2× each. Adding a field to the row meant writing it out in six places to reach the wire.

## What changed

- `application/common/queries/` — `HighlightRow`, `HighlightLabelView`, `TagRef`, `FlashcardRef`, `BookmarkView`
- `infrastructure/common/queries/row_mappers.py` — one ORM→DTO mapper
- `infrastructure/reading/schemas/highlight_builders.py` — one DTO→schema builder, beside the schema it produces

The `learning` and `notes` views adopt the shared refs too. Commits are split so each stands alone.

### One latent type error fixed

`learning`'s `HighlightLabelView` declared `highlight_style_id: int | None` with a docstring explaining that the flashcard list can render a card whose highlight carries no style. That state is unreachable — the label is built at exactly one site, inside an `if style_id is not None` guard, and a highlight with no style is already represented by `label` itself being `None`. The nullable type described something the code cannot produce, so the shared type uses `int`.

## The contract fix

Separately: `orm-boundary` forbade importing `src.models` — **a package that does not exist** — plus `src.infrastructure.jobs.orm`. Every other module's ORM package was unguarded, so a contract named *"ORM models must only be directly imported in repository and mapper modules"* only ever held for jobs. Its `source_modules` enumeration had also rotted; `notes` and `reflection` were never added.

Now forbids `src.infrastructure.*.orm`, with wildcards for routers/schemas/services. **No production code needed changing** — the codebase already obeyed the rule nobody was checking.

## Verification

`pyright` 0 errors · `ruff` clean · `lint-imports` 5/5 kept · `pytest` 618 passed.

**No API contract change** — the generated OpenAPI document is byte-identical to `main` (`d4c532cd…` both sides).

Both contract halves were verified by breaking them on purpose: an ORM import added to `reading/routers/highlights.py` and to `notes/routers/notes.py` each flip the contract to BROKEN. The same positive test was used to confirm `application/common/queries/` still matches the `queries-are-dead-ends` wildcard, so commands remain unable to import read models.

## Deliberately left alone

`SessionHighlightView` and `FlashcardHighlightView` are *near*-duplicates that drop 4 and 1 fields respectively. Narrowing the 13-field row to serve them would force optional fields and weaken the types — a separate decision.

The 7-field `HighlightLabelView` in `reading/queries/highlight_labels.py` shares only a name; it describes a style on the label-management screen. Not merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)