### PR TITLE
Add an OpenAPI contract gate between backend and frontend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,13 @@ jobs:
         working-directory: frontend
         run: npm run lint
 
+      - name: Check generated API client is current
+        working-directory: frontend
+        run: |
+          npm run api:generate
+          git add -N src/api/generated
+          git diff --exit-code -- src/api/generated
+
       - name: Type check with TypeScript
         working-directory: frontend
         run: npm run type-check
@@ -84,6 +91,11 @@ jobs:
 
       - name: Check architecture with import-linter
         run: uv run lint-imports
+
+      - name: Check committed OpenAPI schema is current
+        run: |
+          uv run python scripts/export_openapi.py
+          git diff --exit-code openapi.json
 
       - name: Run tests with pytest
         env:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help test mutation-test dev-app dev-worker migrate migrate-new lint format release-nightly deploy empty-s3-bucket reset-db
+.PHONY: help test mutation-test dev-app dev-worker migrate migrate-new lint format api-client release-nightly deploy empty-s3-bucket reset-db
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}'
@@ -12,6 +12,10 @@ mutation-test: ## Run mutation-testing audit on the backend domain layer (slow, 
 	cd backend && ./scripts/patch-mutmut.sh
 	cd backend && rm -rf mutants && uv run mutmut run
 	cd backend && uv run mutmut results
+
+api-client: ## Export the OpenAPI schema and regenerate the frontend API client (no running backend needed)
+	cd backend && uv run python scripts/export_openapi.py
+	cd frontend && npm run api:generate
 
 dev-app: ## Run the backend dev server
 	cd backend && uv run uvicorn src.main:app --reload --host 0.0.0.0 --port 8000

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -1,0 +1,7194 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "crossbill API",
+    "version": "0.1.0"
+  },
+  "paths": {
+    "/api/v1/books/": {
+      "get": {
+        "tags": [
+          "books"
+        ],
+        "summary": "Get Books",
+        "description": "Get all books with their highlight counts, sorted alphabetically by title.\n\nArgs:\n    offset: Number of books to skip (for pagination)\n    limit: Maximum number of books to return (for pagination)\n    search: Optional search text to filter books by title or author\n\nReturns:\n    PaginatedResponse with list of books and pagination info\n\nRaises:\n    HTTPException: If fetching books fails due to server error",
+        "operationId": "get_books",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Number of books to skip",
+              "default": 0,
+              "title": "Offset"
+            },
+            "description": "Number of books to skip"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 1000,
+              "minimum": 1,
+              "description": "Maximum number of books to return",
+              "default": 100,
+              "title": "Limit"
+            },
+            "description": "Maximum number of books to return"
+          },
+          {
+            "name": "only_with_flashcards",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "Return only books with flashcards",
+              "default": false,
+              "title": "Only With Flashcards"
+            },
+            "description": "Return only books with flashcards"
+          },
+          {
+            "name": "search",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Search text to filter books by title or author",
+              "title": "Search"
+            },
+            "description": "Search text to filter books by title or author"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedResponse_BookWithHighlightCount_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/books/recently-viewed": {
+      "get": {
+        "tags": [
+          "books"
+        ],
+        "summary": "Get Recently Viewed Books",
+        "description": "Get recently viewed books with their highlight counts.\n\nReturns books that have been viewed at least once, ordered by most recently viewed.\n\nArgs:\n    limit: Maximum number of books to return (default: 10, max: 50)\n\nReturns:\n    CollectionResponse with list of recently viewed books\n\nRaises:\n    HTTPException: If fetching books fails due to server error",
+        "operationId": "get_recently_viewed_books",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 50,
+              "minimum": 1,
+              "description": "Maximum number of books to return",
+              "default": 10,
+              "title": "Limit"
+            },
+            "description": "Maximum number of books to return"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CollectionResponse_BookWithHighlightCount_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/books/{book_id}": {
+      "get": {
+        "tags": [
+          "books"
+        ],
+        "summary": "Get Book Details",
+        "description": "Get detailed information about a book including its chapters and highlights.\n\nArgs:\n    book_id: ID of the book to retrieve\n\nReturns:\n    BookDetails with chapters and their highlights\n\nRaises:\n    HTTPException: If book is not found or fetching fails",
+        "operationId": "get_book_details",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "book_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Book Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BookDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "books"
+        ],
+        "summary": "Delete Book",
+        "description": "Delete a book and all its contents (hard delete).\n\nThis will permanently delete the book, all its chapters, and all its highlights.\nIf the user syncs highlights from the book again, it will recreate the book,\nchapters, and highlights.\n\nArgs:\n    book_id: ID of the book to delete\n\nRaises:\n    HTTPException: If book is not found or deletion fails",
+        "operationId": "delete_book",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "book_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Book Id"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/books/{book_id}/reading-stage": {
+      "put": {
+        "tags": [
+          "books"
+        ],
+        "summary": "Update Reading Stage",
+        "description": "Set or clear the manual reading stage on a book.",
+        "operationId": "update_reading_stage",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "book_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Book Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BookReadingStageUpdateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/ereader/books": {
+      "post": {
+        "tags": [
+          "ereader"
+        ],
+        "summary": "Create Book",
+        "description": "Create or get a book by client_book_id.\n\nThis endpoint creates a new book if it doesn't exist, or returns the existing\nbook's metadata if it does. Used by KOReader to ensure a book exists before\nuploading highlights, covers, or EPUB files.\n\nArgs:\n    book_data: Book creation data (same format as highlight upload)\n    current_user: Authenticated user\n\nReturns:\n    EreaderBookMetadata with book_id, bookname, author, cover_file, has_epub",
+        "operationId": "create_book",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BookCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EreaderBookMetadata"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/ereader/books/{client_book_id}": {
+      "get": {
+        "tags": [
+          "ereader"
+        ],
+        "summary": "Get Book Metadata",
+        "description": "Get basic book metadata by client_book_id for ereader operations.\n\nThis endpoint returns lightweight book information that KOReader uses to\ndecide whether it needs to upload cover images, epub files, etc.\n\nArgs:\n    client_book_id: The client-provided stable book identifier\n    current_user: Authenticated user\n\nReturns:\n    EreaderBookMetadata with book_id, bookname, author, coverFile, hasEpub\n\nRaises:\n    HTTPException: 404 if book is not found",
+        "operationId": "get_book_metadata",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "client_book_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Client Book Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EreaderBookMetadata"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/ereader/books/{client_book_id}/epub": {
+      "post": {
+        "tags": [
+          "ereader"
+        ],
+        "summary": "Upload Book Epub",
+        "description": "Upload an ebook file (EPUB) for a book using client_book_id.\n\nThis endpoint accepts an uploaded ebook file and saves it for the book.\nUsed by KOReader which identifies books by client_book_id.\n\nArgs:\n    client_book_id: The client-provided stable book identifier\n    epub: Uploaded ebook file (EPUB or PDF)\n    current_user: Authenticated user\n\nReturns:\n    SuccessResponse with success status\n\nRaises:\n    HTTPException: 400 for invalid file, 404 if book is not found",
+        "operationId": "upload_book_epub",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "client_book_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Client Book Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_upload_book_epub"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuccessResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/ereader/books/{client_book_id}/prereading": {
+      "get": {
+        "tags": [
+          "ereader"
+        ],
+        "summary": "Get Ereader Book Prereading",
+        "description": "Get all chapter prereading content for a book by client_book_id.\n\nReturns one item per chapter that has generated prereading content, ordered\nby the server-side chapter number. Questions are exposed as plain strings\nonly (no AI or user answers). A book with no prereading yields an empty list.\n\nArgs:\n    client_book_id: The client-provided stable book identifier\n    current_user: Authenticated user\n\nReturns:\n    CollectionResponse with one item per chapter that has prereading\n\nRaises:\n    HTTPException: 404 if the book is not found for the given client_book_id",
+        "operationId": "get_ereader_book_prereading",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "client_book_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Client Book Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CollectionResponse_EreaderChapterPrereadingItem_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/covers/{filename}": {
+      "get": {
+        "tags": [
+          "covers"
+        ],
+        "summary": "Get Cover",
+        "description": "Get a book cover image by filename.\n\nThis is a public endpoint - no authentication required.\nCover filenames are UUIDs, making enumeration infeasible.",
+        "operationId": "get_cover",
+        "parameters": [
+          {
+            "name": "filename",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Filename"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/highlights/upload": {
+      "post": {
+        "tags": [
+          "highlights"
+        ],
+        "summary": "Upload Highlights",
+        "description": "Upload highlights from KOReader.\n\nCreates or updates book record and adds highlights with automatic deduplication.\nDuplicates are identified by the combination of book, text, and datetime.\n\nArgs:\n    request: Highlight upload request containing book metadata and highlights\n\nReturns:\n    HighlightUploadResponse with upload statistics\n\nRaises:\n    HTTPException: If upload fails due to server error",
+        "operationId": "upload_highlights",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HighlightUploadRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HighlightUploadResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/books/{book_id}/highlights": {
+      "get": {
+        "tags": [
+          "highlights"
+        ],
+        "summary": "Search Book Highlights",
+        "description": "Search for highlights in book using full-text search.\n\nSearches across all highlight text using PostgreSQL full-text search.\nResults are ranked by relevance and excludes soft-deleted highlights.",
+        "operationId": "search_book_highlights",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "book_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Book Id"
+            }
+          },
+          {
+            "name": "searchText",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Text to search for in highlights",
+              "title": "Searchtext"
+            },
+            "description": "Text to search for in highlights"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BookHighlightSearchResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/books/{book_id}/highlight": {
+      "delete": {
+        "tags": [
+          "highlights"
+        ],
+        "summary": "Delete Highlights",
+        "description": "Soft delete highlights from a book.\n\nThis performs a soft delete by marking the highlights as deleted.\nWhen syncing highlights, deleted highlights will not be recreated,\nensuring that user deletions persist across syncs.\n\nArgs:\n    book_id: ID of the book\n    request: Request containing list of highlight IDs to delete\n\nReturns:\n    HighlightDeleteResponse with deletion status and count\n\nRaises:\n    HTTPException: If book is not found or deletion fails\n    :param use_case:",
+        "operationId": "delete_highlights",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "book_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Book Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HighlightDeleteRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HighlightDeleteResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/tag-groups": {
+      "post": {
+        "tags": [
+          "tags"
+        ],
+        "summary": "Create Or Update Tag Group",
+        "description": "Create a new tag group or update an existing one.\n\nArgs:\n    request: Tag group creation/update request\n\nReturns:\n    Created or updated TagGroup\n\nRaises:\n    HTTPException: If creation/update fails",
+        "operationId": "create_or_update_tag_group",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TagGroupCreateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TagGroup"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/tag-groups/{tag_group_id}": {
+      "delete": {
+        "tags": [
+          "tags"
+        ],
+        "summary": "Delete Tag Group",
+        "description": "Delete a tag group.\n\nArgs:\n    tag_group_id: ID of the tag group to delete\n\nRaises:\n    HTTPException: If tag group not found or deletion fails",
+        "operationId": "delete_tag_group",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "tag_group_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Tag Group Id"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/books/{book_id}/tags": {
+      "get": {
+        "tags": [
+          "tags"
+        ],
+        "summary": "Get Tags",
+        "description": "Get all tags for a book.\n\nArgs:\n    book_id: ID of the book\n\nReturns:\n    List of Tags for the book\n\nRaises:\n    HTTPException: If book is not found",
+        "operationId": "get_tags",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "book_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Book Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CollectionResponse_Tag_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/books/{book_id}/tag": {
+      "post": {
+        "tags": [
+          "tags"
+        ],
+        "summary": "Create Tag",
+        "description": "Create a new tag for a book.\n\nArgs:\n    book_id: ID of the book\n    request: Request containing tag name\n\nReturns:\n    Created Tag\n\nRaises:\n    HTTPException: If book is not found, tag already exists, or creation fails",
+        "operationId": "create_tag",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "book_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Book Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TagCreateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Tag"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/books/{book_id}/tag/{tag_id}": {
+      "delete": {
+        "tags": [
+          "tags"
+        ],
+        "summary": "Delete Tag",
+        "description": "Delete a tag from a book.\n\nThis will also remove the tag from all highlights it was associated with.\n\nArgs:\n    book_id: ID of the book\n    tag_id: ID of the tag to delete\n\nRaises:\n    HTTPException: If tag is not found, doesn't belong to book, or deletion fails",
+        "operationId": "delete_tag",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "book_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Book Id"
+            }
+          },
+          {
+            "name": "tag_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Tag Id"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "tags"
+        ],
+        "summary": "Update Tag",
+        "description": "Update a tag's name and/or tag group association.\n\nArgs:\n    book_id: ID of the book\n    tag_id: ID of the tag to update\n    request: Request containing updated tag information\n\nReturns:\n    Updated Tag\n\nRaises:\n    HTTPException: If tag not found, doesn't belong to book, or update fails",
+        "operationId": "update_tag",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "book_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Book Id"
+            }
+          },
+          {
+            "name": "tag_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Tag Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TagUpdateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Tag"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/books/{book_id}/highlight/{highlight_id}/tag": {
+      "post": {
+        "tags": [
+          "tags"
+        ],
+        "summary": "Add Tag To Highlight",
+        "description": "Add a tag to a highlight.\n\nIf a tag name is provided and doesn't exist, it will be created first.\nIf a tag_id is provided, it will be used directly.\n\nArgs:\n    book_id: ID of the book\n    highlight_id: ID of the highlight\n    request: Request containing either tag name or tag_id\n\nReturns:\n    Updated Highlight with tags\n\nRaises:\n    HTTPException: If highlight or tag not found, or association fails",
+        "operationId": "add_tag_to_highlight",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "book_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Book Id"
+            }
+          },
+          {
+            "name": "highlight_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Highlight Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TagAssociationRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Highlight"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/books/{book_id}/highlight/{highlight_id}/tag/{tag_id}": {
+      "delete": {
+        "tags": [
+          "tags"
+        ],
+        "summary": "Remove Tag From Highlight",
+        "description": "Remove a tag from a highlight.\n\nArgs:\n    book_id: ID of the book\n    highlight_id: ID of the highlight\n    tag_id: ID of the tag to remove\n\nReturns:\n    Updated Highlight with tags\n\nRaises:\n    HTTPException: If highlight not found or removal fails",
+        "operationId": "remove_tag_from_highlight",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "book_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Book Id"
+            }
+          },
+          {
+            "name": "highlight_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Highlight Id"
+            }
+          },
+          {
+            "name": "tag_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Tag Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Highlight"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/reading_sessions/upload": {
+      "post": {
+        "tags": [
+          "reading_sessions"
+        ],
+        "summary": "Upload Reading Sessions",
+        "description": "Upload reading sessions from KOReader for a single book.\n\nAll sessions in a request must be for the same book.\n\nArgs:\n    request: Upload request containing book metadata and reading sessions\n\nReturns:\n    ReadingSessionUploadResponse with upload statistics",
+        "operationId": "upload_reading_sessions",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReadingSessionUploadRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReadingSessionUploadResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/books/{book_id}/reading_sessions": {
+      "get": {
+        "tags": [
+          "reading_sessions"
+        ],
+        "summary": "Get Book Reading Sessions",
+        "description": "Get reading sessions for a specific book.\n\nReturns reading sessions ordered by start time (newest first).\n\nArgs:\n    book_id: ID of the book\n    limit: Maximum number of sessions\n    offset: Pagination offset\n\nReturns:\n    PaginatedResponse with sessions list",
+        "operationId": "get_book_reading_sessions",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "book_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Book Id"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 1000,
+              "minimum": 1,
+              "description": "Maximum sessions to return",
+              "default": 30,
+              "title": "Limit"
+            },
+            "description": "Maximum sessions to return"
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Number of sessions to skip",
+              "default": 0,
+              "title": "Offset"
+            },
+            "description": "Number of sessions to skip"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedResponse_ReadingSession_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/{reading_session_id}/ai_summary": {
+      "get": {
+        "tags": [
+          "reading_sessions"
+        ],
+        "summary": "Get Reading Session Ai Summary",
+        "description": "Get AI-generated summary for a reading session.\n\nReturns cached summary if available, otherwise generates new summary\nfrom the read content and caches it.\n\nArgs:\n    reading_session_id: ID of the reading session\n    current_user: Authenticated user\n\nReturns:\n    ReadingSessionAISummaryResponse with the AI summary\n\nRaises:\n    HTTPException 404: If reading session not found or not owned by user\n    HTTPException 400: If session has no position data or PDF not supported\n    HTTPException 500: For unexpected errors",
+        "operationId": "get_reading_session_ai_summary",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "reading_session_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Reading Session Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReadingSessionAISummaryResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/books/{book_id}/bookmarks": {
+      "post": {
+        "tags": [
+          "bookmarks"
+        ],
+        "summary": "Create Bookmark",
+        "description": "Create a bookmark for a highlight in a book.\n\nBookmarks allow users to track their reading progress by marking specific\nhighlights they want to return to later.\n\nArgs:\n    book_id: ID of the book\n    request: Request containing the highlight_id to bookmark\n    use_case: BookmarkService injected via dependency container\n\nReturns:\n    Created Bookmark\n\nRaises:\n    HTTPException: If book or highlight not found, or creation fails",
+        "operationId": "create_bookmark",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "book_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Book Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BookmarkCreateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Bookmark"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "bookmarks"
+        ],
+        "summary": "Get Bookmarks",
+        "description": "Get all bookmarks for a book.\n\nReturns all bookmarks ordered by creation date (newest first).\n\nArgs:\n    book_id: ID of the book\n    use_case: BookmarkService injected via dependency container\n\nReturns:\n    List of bookmarks for the book\n\nRaises:\n    HTTPException: If book not found or fetching fails",
+        "operationId": "get_bookmarks",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "book_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Book Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CollectionResponse_Bookmark_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/books/{book_id}/bookmarks/{bookmark_id}": {
+      "delete": {
+        "tags": [
+          "bookmarks"
+        ],
+        "summary": "Delete Bookmark",
+        "description": "Delete a bookmark from a book.\n\nThis operation is idempotent - calling it on a non-existent bookmark\nwill succeed and return 200 without error.\n\nArgs:\n    book_id: ID of the book\n    bookmark_id: ID of the bookmark to delete\n    use_case: BookmarkService injected via dependency container\n\nRaises:\n    HTTPException: If book not found or deletion fails",
+        "operationId": "delete_bookmark",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "book_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Book Id"
+            }
+          },
+          {
+            "name": "bookmark_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Bookmark Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/chapters/{chapter_id}/prereading": {
+      "get": {
+        "tags": [
+          "prereading"
+        ],
+        "summary": "Get Chapter Prereading",
+        "description": "Get existing prereading content for a chapter.",
+        "operationId": "get_chapter_prereading",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "chapter_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Chapter Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/ChapterPrereadingResponse"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "title": "Response Get Chapter Prereading"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/chapters/{chapter_id}/prereading/generate": {
+      "post": {
+        "tags": [
+          "prereading"
+        ],
+        "summary": "Generate Chapter Prereading",
+        "description": "Generate prereading content for a chapter.",
+        "operationId": "generate_chapter_prereading",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "chapter_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Chapter Id"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChapterPrereadingResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/chapters/{chapter_id}/prereading/answers": {
+      "put": {
+        "tags": [
+          "prereading"
+        ],
+        "summary": "Update Prereading Answers",
+        "description": "Update user answers for prereading questions.",
+        "operationId": "update_prereading_answers",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "chapter_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Chapter Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdatePrereadingAnswersRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChapterPrereadingResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/books/{book_id}/prereading": {
+      "get": {
+        "tags": [
+          "prereading"
+        ],
+        "summary": "Get Book Prereading",
+        "description": "Get all prereading content for chapters in a book.",
+        "operationId": "get_book_prereading",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "book_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Book Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CollectionResponse_ChapterPrereadingResponse_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/chapters/{chapter_id}/content": {
+      "get": {
+        "tags": [
+          "chapters"
+        ],
+        "summary": "Get Chapter Content",
+        "description": "Get the full text content of a chapter from the EPUB file.",
+        "operationId": "get_chapter_content",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "chapter_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Chapter Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChapterContentResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/books/{book_id}/highlight-labels": {
+      "get": {
+        "tags": [
+          "highlight-labels"
+        ],
+        "summary": "Get Book Highlight Labels",
+        "description": "Get all highlight labels for a book with resolved labels.",
+        "operationId": "get_book_highlight_labels",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "book_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Book Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CollectionResponse_HighlightLabelInBook_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/highlight-labels/{style_id}": {
+      "patch": {
+        "tags": [
+          "highlight-labels"
+        ],
+        "summary": "Update Highlight Label",
+        "description": "Update label and/or ui_color on a highlight style.",
+        "operationId": "update_highlight_label",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "style_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Style Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HighlightLabelUpdate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HighlightLabelInBook"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/highlight-labels/global": {
+      "get": {
+        "tags": [
+          "highlight-labels"
+        ],
+        "summary": "Get Global Highlight Labels",
+        "description": "Get all global default highlight labels.",
+        "operationId": "get_global_highlight_labels",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CollectionResponse_HighlightLabelInBook_"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "highlight-labels"
+        ],
+        "summary": "Create Global Highlight Label",
+        "description": "Create a global default highlight label.",
+        "operationId": "create_global_highlight_label",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HighlightLabelCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HighlightLabelInBook"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/books/{book_id}/flashcards": {
+      "post": {
+        "tags": [
+          "flashcards"
+        ],
+        "summary": "Create Flashcard For Book",
+        "description": "Create a standalone flashcard for a book (without a highlight).\n\nThis creates a flashcard that is associated with a book but not tied\nto any specific highlight.\n\nArgs:\n    book_id: ID of the book\n    request: Request containing question and answer\n    use_case: FlashcardUseCase injected via dependency container\n\nReturns:\n    Created flashcard\n\nRaises:\n    HTTPException: If book not found or creation fails",
+        "operationId": "create_flashcard_for_book",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "book_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Book Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FlashcardCreateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FlashcardCreateResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "flashcards"
+        ],
+        "summary": "Get Flashcards For Book",
+        "description": "Get all flashcards for a book with embedded highlight data.\n\nReturns all flashcards ordered by creation date (newest first).\n\nArgs:\n    book_id: ID of the book\n    use_case: FlashcardUseCase injected via dependency container\n\nReturns:\n    List of flashcards with highlight data for the book\n\nRaises:\n    HTTPException: If book not found or fetching fails",
+        "operationId": "get_flashcards_for_book",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "book_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Book Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CollectionResponse_FlashcardWithHighlight_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/flashcards/{flashcard_id}": {
+      "put": {
+        "tags": [
+          "flashcards"
+        ],
+        "summary": "Update Flashcard",
+        "description": "Update a flashcard's question and/or answer.\n\nArgs:\n    flashcard_id: ID of the flashcard to update\n    request: Request containing updated question and/or answer\n    use_case: FlashcardUseCase injected via dependency container\n\nReturns:\n    Updated flashcard\n\nRaises:\n    HTTPException: If flashcard not found or update fails",
+        "operationId": "update_flashcard",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "flashcard_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Flashcard Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FlashcardUpdateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FlashcardUpdateResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "flashcards"
+        ],
+        "summary": "Delete Flashcard",
+        "description": "Delete a flashcard.\n\nArgs:\n    flashcard_id: ID of the flashcard to delete\n    use_case: FlashcardUseCase injected via dependency container\n\nReturns:\n    Deletion confirmation\n\nRaises:\n    HTTPException: If flashcard not found or deletion fails",
+        "operationId": "delete_flashcard",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "flashcard_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Flashcard Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuccessResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/highlights/{highlight_id}/flashcard_suggestions": {
+      "get": {
+        "tags": [
+          "flashcards"
+        ],
+        "summary": "Get Highlight Flashcard Suggestions",
+        "description": "Get AI-generated flashcard suggestions for a highlight.\n\nArgs:\n    highlight_id: ID of the highlight\n    current_user: Authenticated user\n    use_case: FlashcardAIUseCase injected via dependency container\n\nReturns:\n    CollectionResponse with list of flashcard suggestions\n\nRaises:\n    HTTPException 404: If highlight not found or not owned by user",
+        "operationId": "get_highlight_flashcard_suggestions",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "highlight_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Highlight Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CollectionResponse_FlashcardSuggestionItem_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/chapters/{chapter_id}/flashcard_suggestions": {
+      "get": {
+        "tags": [
+          "flashcards"
+        ],
+        "summary": "Get Chapter Flashcard Suggestions",
+        "description": "Get AI-generated flashcard suggestions from chapter prereading content.\n\nRequires the chapter to have a generated pre-reading summary.",
+        "operationId": "get_chapter_flashcard_suggestions",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "chapter_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Chapter Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CollectionResponse_FlashcardSuggestionItem_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/highlights/{highlight_id}/flashcards": {
+      "post": {
+        "tags": [
+          "flashcards"
+        ],
+        "summary": "Create Flashcard For Highlight",
+        "description": "Create a flashcard for a highlight.\n\nCreates a flashcard that is associated with a specific highlight.\nThe flashcard will also be linked to the highlight's book.\n\nArgs:\n    highlight_id: ID of the highlight\n    request: Request containing question and answer\n    use_case: Use case injected via dependency container\n\nReturns:\n    Created flashcard\n\nRaises:\n    HTTPException: If highlight not found or creation fails",
+        "operationId": "create_flashcard_for_highlight",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "highlight_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Highlight Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FlashcardCreateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FlashcardCreateResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/notes/{note_id}/flashcards": {
+      "post": {
+        "tags": [
+          "flashcards"
+        ],
+        "summary": "Create Flashcard For Note",
+        "description": "Create a flashcard linked to a note.\n\nThe flashcard is filed under the requested book (which must be linked to\nthe note), or the note's first book when no book is given.\n\nArgs:\n    note_id: ID of the note\n    request: Request containing question, answer and optional book_id\n    use_case: Use case injected via dependency container\n\nReturns:\n    Created flashcard\n\nRaises:\n    HTTPException: If note not found or book is not linked to the note",
+        "operationId": "create_flashcard_for_note",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "note_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Note Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NoteFlashcardCreateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FlashcardCreateResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/notes/{note_id}/flashcard_suggestions": {
+      "get": {
+        "tags": [
+          "flashcards"
+        ],
+        "summary": "Get Note Flashcard Suggestions",
+        "description": "Get AI-generated flashcard suggestions for a note.\n\nSuggestions are generated from the note's title, body and the text of\nits linked highlights.\n\nArgs:\n    note_id: ID of the note\n    current_user: Authenticated user\n    use_case: Use case injected via dependency container\n\nReturns:\n    CollectionResponse with list of flashcard suggestions\n\nRaises:\n    HTTPException 404: If note not found or not owned by user",
+        "operationId": "get_note_flashcard_suggestions",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "note_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Note Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CollectionResponse_FlashcardSuggestionItem_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/chapters/{chapter_id}/quiz-sessions": {
+      "post": {
+        "tags": [
+          "chat"
+        ],
+        "summary": "Create Quiz Session",
+        "description": "Start a new quiz session for a chapter.",
+        "operationId": "create_quiz_session",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "chapter_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Chapter Id"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateChatSessionResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/quiz-sessions/{session_id}/messages": {
+      "post": {
+        "tags": [
+          "chat"
+        ],
+        "summary": "Send Quiz Message",
+        "description": "Send a message to an existing quiz session.",
+        "operationId": "send_quiz_message",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "session_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Session Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SendChatMessageRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SendChatMessageResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/chapters/{chapter_id}/chat-sessions": {
+      "post": {
+        "tags": [
+          "chat"
+        ],
+        "summary": "Create Chat Session",
+        "description": "Start a chat session for a chapter.",
+        "operationId": "create_chat_session",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "chapter_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Chapter Id"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateChatSessionResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/chat-sessions/{session_id}/messages": {
+      "post": {
+        "tags": [
+          "chat"
+        ],
+        "summary": "Send Chat Message",
+        "description": "Send a message to an existing chat session.",
+        "operationId": "send_chat_message",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "session_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Session Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SendChatMessageRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SendChatMessageResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/auth/login": {
+      "post": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "Login",
+        "operationId": "login",
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_login"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TokenWithRefresh"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/auth/refresh": {
+      "post": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "Refresh",
+        "operationId": "refresh",
+        "parameters": [
+          {
+            "name": "refresh_token",
+            "in": "cookie",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Refresh Token"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/RefreshTokenRequest"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "title": "Body"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TokenWithRefresh"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/auth/logout": {
+      "post": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "Logout",
+        "operationId": "logout",
+        "parameters": [
+          {
+            "name": "refresh_token",
+            "in": "cookie",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Refresh Token"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "title": "Response Logout"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/users/register": {
+      "post": {
+        "tags": [
+          "users"
+        ],
+        "summary": "Register",
+        "description": "Register a new user account.\n\nCreates a new user with the provided email and password.\nReturns token pair for immediate login after registration.",
+        "operationId": "register",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UserRegisterRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TokenWithRefresh"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/users/me": {
+      "get": {
+        "tags": [
+          "users"
+        ],
+        "summary": "Get Me",
+        "description": "Get the current user's profile information.",
+        "operationId": "get_me",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserDetailsResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "users"
+        ],
+        "summary": "Update Me",
+        "description": "Update the current user's profile.\n\n- To change email: provide `email` field\n- To change password: provide both `current_password` and `new_password` fields\n\nChanging the password signs every session out, this one included, so clients\nshould send the user back to the login screen afterwards.",
+        "operationId": "update_me",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UserUpdateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserDetailsResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/jobs/books/{book_id}/prereading": {
+      "post": {
+        "tags": [
+          "jobs"
+        ],
+        "summary": "Enqueue Book Prereading",
+        "description": "Enqueue prereading generation for all chapters of a book.",
+        "operationId": "enqueue_book_prereading",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "book_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Book Id"
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JobBatchResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "jobs"
+        ],
+        "summary": "Get Active Book Prereading Batch",
+        "description": "Get the active prereading batch for a book, if any.",
+        "operationId": "get_active_book_prereading_batch",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "book_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Book Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/JobBatchResponse"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "title": "Response Get Active Book Prereading Batch"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/jobs/batches/{batch_id}": {
+      "get": {
+        "tags": [
+          "jobs"
+        ],
+        "summary": "Get Job Batch",
+        "description": "Get job batch status.",
+        "operationId": "get_job_batch",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "batch_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Batch Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JobBatchResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "jobs"
+        ],
+        "summary": "Cancel Job Batch",
+        "description": "Cancel a job batch and abort all pending/active jobs.",
+        "operationId": "cancel_job_batch",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "batch_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Batch Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JobBatchResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/notes": {
+      "post": {
+        "tags": [
+          "notes"
+        ],
+        "summary": "Create Note",
+        "operationId": "create_note",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NoteCreateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NoteCreateResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/notes/{note_id}": {
+      "get": {
+        "tags": [
+          "notes"
+        ],
+        "summary": "Get Note",
+        "operationId": "get_note",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "note_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Note Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NoteWithLinks"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "notes"
+        ],
+        "summary": "Update Note",
+        "operationId": "update_note",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "note_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Note Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NoteUpdateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NoteUpdateResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "notes"
+        ],
+        "summary": "Delete Note",
+        "operationId": "delete_note",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "note_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Note Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuccessResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/books/{book_id}/notes": {
+      "get": {
+        "tags": [
+          "notes"
+        ],
+        "summary": "Get Notes For Book",
+        "operationId": "get_notes_for_book",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "book_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Book Id"
+            }
+          },
+          {
+            "name": "kind",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "enum": [
+                    "character",
+                    "term",
+                    "concept",
+                    "gist",
+                    "reflection",
+                    "other"
+                  ],
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Kind"
+            }
+          },
+          {
+            "name": "chapter_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Chapter Id"
+            }
+          },
+          {
+            "name": "highlight_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Highlight Id"
+            }
+          },
+          {
+            "name": "tag_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Tag Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CollectionResponse_NoteWithLinks_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/books/{book_id}/reflection": {
+      "get": {
+        "tags": [
+          "reflections"
+        ],
+        "summary": "Get Book Reflection",
+        "operationId": "get_book_reflection",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "book_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Book Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BookReflectionResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "reflections"
+        ],
+        "summary": "Upsert Book Reflection",
+        "operationId": "upsert_book_reflection",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "book_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Book Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BookReflectionUpdateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BookReflectionResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/settings": {
+      "get": {
+        "tags": [
+          "settings"
+        ],
+        "summary": "Get App Settings",
+        "description": "Get public application settings.\n\nReturns non-user-specific settings that affect application behavior.\nThis is a public endpoint that doesn't require authentication.",
+        "operationId": "get_app_settings",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AppSettingsResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/health": {
+      "get": {
+        "summary": "Health",
+        "description": "Health check endpoint. Exempt from rate limit so probes never trip it.",
+        "operationId": "health",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object",
+                  "title": "Response Health"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/": {
+      "get": {
+        "summary": "Api Root",
+        "description": "API root endpoint.",
+        "operationId": "api_root",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response Api Root"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "AppSettingsResponse": {
+        "properties": {
+          "feature_flags": {
+            "$ref": "#/components/schemas/FeatureFlags",
+            "description": "All feature flags"
+          }
+        },
+        "type": "object",
+        "required": [
+          "feature_flags"
+        ],
+        "title": "AppSettingsResponse",
+        "description": "Schema for returning public application settings."
+      },
+      "Body_login": {
+        "properties": {
+          "grant_type": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^password$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Grant Type"
+          },
+          "username": {
+            "type": "string",
+            "title": "Username"
+          },
+          "password": {
+            "type": "string",
+            "format": "password",
+            "title": "Password"
+          },
+          "scope": {
+            "type": "string",
+            "title": "Scope",
+            "default": ""
+          },
+          "client_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Client Id"
+          },
+          "client_secret": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "format": "password",
+            "title": "Client Secret"
+          }
+        },
+        "type": "object",
+        "required": [
+          "username",
+          "password"
+        ],
+        "title": "Body_login"
+      },
+      "Body_upload_book_epub": {
+        "properties": {
+          "epub": {
+            "type": "string",
+            "contentMediaType": "application/octet-stream",
+            "title": "Epub"
+          }
+        },
+        "type": "object",
+        "required": [
+          "epub"
+        ],
+        "title": "Body_upload_book_epub"
+      },
+      "BookCreate": {
+        "properties": {
+          "title": {
+            "type": "string",
+            "maxLength": 500,
+            "minLength": 1,
+            "title": "Title",
+            "description": "Book title"
+          },
+          "author": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 500
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Author",
+            "description": "Book author"
+          },
+          "isbn": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 20
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Isbn",
+            "description": "Book ISBN"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description",
+            "description": "Book description from ebook metadata"
+          },
+          "language": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 10
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Language",
+            "description": "Language code from ebook metadata"
+          },
+          "page_count": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "minimum": 1.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Page Count",
+            "description": "Total page count from ebook metadata"
+          },
+          "client_book_id": {
+            "type": "string",
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Client Book Id",
+            "description": "Client-provided stable book identifier for deduplication"
+          }
+        },
+        "type": "object",
+        "required": [
+          "title",
+          "client_book_id"
+        ],
+        "title": "BookCreate",
+        "description": "Schema for creating a Book."
+      },
+      "BookDetails": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "client_book_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Client Book Id"
+          },
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "author": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Author"
+          },
+          "isbn": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Isbn"
+          },
+          "cover_file": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cover File",
+            "description": "Cover image filename (UUID.jpg) or null"
+          },
+          "cover_blurhash": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cover Blurhash",
+            "description": "Blurhash string for cover placeholder"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "language": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Language"
+          },
+          "page_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Page Count"
+          },
+          "reading_stage": {
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "to_read",
+                  "skimming",
+                  "reading",
+                  "finished",
+                  "reflected"
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reading Stage",
+            "description": "Manual reading stage set by the user"
+          },
+          "tags": {
+            "items": {
+              "$ref": "#/components/schemas/TagInBook"
+            },
+            "type": "array",
+            "title": "Tags",
+            "description": "List of tags for this book"
+          },
+          "tag_groups": {
+            "items": {
+              "$ref": "#/components/schemas/TagGroupInBook"
+            },
+            "type": "array",
+            "title": "Tag Groups",
+            "description": "List of tag groups for this book"
+          },
+          "bookmarks": {
+            "items": {
+              "$ref": "#/components/schemas/Bookmark"
+            },
+            "type": "array",
+            "title": "Bookmarks",
+            "description": "List of bookmarks for this book"
+          },
+          "book_flashcards": {
+            "items": {
+              "$ref": "#/components/schemas/Flashcard"
+            },
+            "type": "array",
+            "title": "Book Flashcards",
+            "description": "Book-level flashcards not associated with any highlight"
+          },
+          "chapters": {
+            "items": {
+              "$ref": "#/components/schemas/ChapterWithHighlights"
+            },
+            "type": "array",
+            "title": "Chapters",
+            "description": "List of chapters with highlights"
+          },
+          "reading_position": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PositionResponse"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "User's current reading position from latest session"
+          },
+          "end_position": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PositionResponse"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "End position of the book (total document length)"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Updated At"
+          },
+          "last_viewed": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Viewed"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "title",
+          "author",
+          "isbn",
+          "tags",
+          "tag_groups",
+          "bookmarks",
+          "chapters",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "BookDetails",
+        "description": "Schema for detailed Book response with chapters and highlights."
+      },
+      "BookHighlightSearchResponse": {
+        "properties": {
+          "chapters": {
+            "items": {
+              "$ref": "#/components/schemas/ChapterWithHighlights"
+            },
+            "type": "array",
+            "title": "Chapters",
+            "description": "Chapters containing matching highlights"
+          },
+          "total": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Total",
+            "description": "Total number of matching highlights"
+          }
+        },
+        "type": "object",
+        "required": [
+          "chapters",
+          "total"
+        ],
+        "title": "BookHighlightSearchResponse",
+        "description": "Schema for book-scoped highlight search response grouped by chapter."
+      },
+      "BookReadingStageUpdateRequest": {
+        "properties": {
+          "reading_stage": {
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "to_read",
+                  "skimming",
+                  "reading",
+                  "finished",
+                  "reflected"
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reading Stage",
+            "description": "Reading stage, or null to clear it"
+          }
+        },
+        "type": "object",
+        "title": "BookReadingStageUpdateRequest",
+        "description": "Schema for updating a book's manual reading stage."
+      },
+      "BookReflectionResponse": {
+        "properties": {
+          "book_id": {
+            "type": "integer",
+            "title": "Book Id"
+          },
+          "what_is_it_about_note_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "What Is It About Note Id"
+          },
+          "what_does_it_say_note_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "What Does It Say Note Id"
+          },
+          "do_i_agree_note_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Do I Agree Note Id"
+          },
+          "so_what_note_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "So What Note Id"
+          },
+          "note_ids": {
+            "items": {
+              "type": "integer"
+            },
+            "type": "array",
+            "title": "Note Ids"
+          }
+        },
+        "type": "object",
+        "required": [
+          "book_id"
+        ],
+        "title": "BookReflectionResponse",
+        "description": "Schema for a book reflection response.\n\nEach answer is a reference to the note holding that answer's markdown, or\n``None`` when the question is unanswered. The frontend resolves the ids to\nnote content from its cached notes-for-book query."
+      },
+      "BookReflectionUpdateRequest": {
+        "properties": {
+          "what_is_it_about_note_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "What Is It About Note Id",
+            "description": "Q1 answer note id"
+          },
+          "what_does_it_say_note_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "What Does It Say Note Id",
+            "description": "Q2 answer note id"
+          },
+          "do_i_agree_note_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Do I Agree Note Id",
+            "description": "Q3 answer note id"
+          },
+          "so_what_note_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "So What Note Id",
+            "description": "Q4 answer note id"
+          },
+          "note_ids": {
+            "items": {
+              "type": "integer"
+            },
+            "type": "array",
+            "title": "Note Ids",
+            "description": "Linked term/concept notes"
+          }
+        },
+        "type": "object",
+        "title": "BookReflectionUpdateRequest",
+        "description": "Schema for upserting a book reflection (full replace)."
+      },
+      "BookWithHighlightCount": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "client_book_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Client Book Id"
+          },
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "author": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Author"
+          },
+          "isbn": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Isbn"
+          },
+          "cover_file": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cover File",
+            "description": "Cover image filename (UUID.jpg) or null"
+          },
+          "cover_blurhash": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cover Blurhash",
+            "description": "Blurhash string for cover placeholder"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "language": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Language"
+          },
+          "page_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Page Count"
+          },
+          "highlight_count": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Highlight Count",
+            "description": "Number of highlights for this book"
+          },
+          "flashcard_count": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Flashcard Count",
+            "description": "Number of flashcards for this book",
+            "default": 0
+          },
+          "end_position": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PositionResponse"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "End position of the book (total document length)"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Updated At"
+          },
+          "last_viewed": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Viewed"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "title",
+          "author",
+          "isbn",
+          "highlight_count",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "BookWithHighlightCount",
+        "description": "Schema for Book with highlight and flashcard counts."
+      },
+      "Bookmark": {
+        "properties": {
+          "highlight_id": {
+            "type": "integer",
+            "title": "Highlight Id",
+            "description": "ID of the highlight to bookmark"
+          },
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "book_id": {
+            "type": "integer",
+            "title": "Book Id"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "highlight_id",
+          "id",
+          "book_id",
+          "created_at"
+        ],
+        "title": "Bookmark",
+        "description": "Schema for Bookmark response."
+      },
+      "BookmarkCreateRequest": {
+        "properties": {
+          "highlight_id": {
+            "type": "integer",
+            "title": "Highlight Id",
+            "description": "ID of the highlight to bookmark"
+          }
+        },
+        "type": "object",
+        "required": [
+          "highlight_id"
+        ],
+        "title": "BookmarkCreateRequest",
+        "description": "Schema for creating a new bookmark."
+      },
+      "ChapterContentResponse": {
+        "properties": {
+          "chapter_id": {
+            "type": "integer",
+            "title": "Chapter Id",
+            "description": "ID of the chapter"
+          },
+          "chapter_name": {
+            "type": "string",
+            "title": "Chapter Name",
+            "description": "Name of the chapter"
+          },
+          "book_id": {
+            "type": "integer",
+            "title": "Book Id",
+            "description": "ID of the book"
+          },
+          "content": {
+            "type": "string",
+            "title": "Content",
+            "description": "Full text content of the chapter"
+          }
+        },
+        "type": "object",
+        "required": [
+          "chapter_id",
+          "chapter_name",
+          "book_id",
+          "content"
+        ],
+        "title": "ChapterContentResponse",
+        "description": "Response schema for chapter text content."
+      },
+      "ChapterPrereadingResponse": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "chapter_id": {
+            "type": "integer",
+            "title": "Chapter Id"
+          },
+          "summary": {
+            "type": "string",
+            "title": "Summary"
+          },
+          "keypoints": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Keypoints"
+          },
+          "questions": {
+            "items": {
+              "$ref": "#/components/schemas/PrereadingQuestionResponse"
+            },
+            "type": "array",
+            "title": "Questions"
+          },
+          "generated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Generated At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "chapter_id",
+          "summary",
+          "keypoints",
+          "questions",
+          "generated_at"
+        ],
+        "title": "ChapterPrereadingResponse",
+        "description": "Response schema for chapter prereading content."
+      },
+      "ChapterWithHighlights": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "chapter_number": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Chapter Number",
+            "description": "Chapter order number from TOC"
+          },
+          "parent_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Parent Id",
+            "description": "Parent chapter ID for hierarchy"
+          },
+          "start_position": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PositionResponse"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Chapter start position"
+          },
+          "highlights": {
+            "items": {
+              "$ref": "#/components/schemas/Highlight"
+            },
+            "type": "array",
+            "title": "Highlights",
+            "description": "List of highlights in this chapter"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Updated At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "highlights",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "ChapterWithHighlights",
+        "description": "Schema for Chapter with its highlights."
+      },
+      "CollectionResponse_BookWithHighlightCount_": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/BookWithHighlightCount"
+            },
+            "type": "array",
+            "title": "Items"
+          }
+        },
+        "type": "object",
+        "required": [
+          "items"
+        ],
+        "title": "CollectionResponse[BookWithHighlightCount]"
+      },
+      "CollectionResponse_Bookmark_": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/Bookmark"
+            },
+            "type": "array",
+            "title": "Items"
+          }
+        },
+        "type": "object",
+        "required": [
+          "items"
+        ],
+        "title": "CollectionResponse[Bookmark]"
+      },
+      "CollectionResponse_ChapterPrereadingResponse_": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/ChapterPrereadingResponse"
+            },
+            "type": "array",
+            "title": "Items"
+          }
+        },
+        "type": "object",
+        "required": [
+          "items"
+        ],
+        "title": "CollectionResponse[ChapterPrereadingResponse]"
+      },
+      "CollectionResponse_EreaderChapterPrereadingItem_": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/EreaderChapterPrereadingItem"
+            },
+            "type": "array",
+            "title": "Items"
+          }
+        },
+        "type": "object",
+        "required": [
+          "items"
+        ],
+        "title": "CollectionResponse[EreaderChapterPrereadingItem]"
+      },
+      "CollectionResponse_FlashcardSuggestionItem_": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/FlashcardSuggestionItem"
+            },
+            "type": "array",
+            "title": "Items"
+          }
+        },
+        "type": "object",
+        "required": [
+          "items"
+        ],
+        "title": "CollectionResponse[FlashcardSuggestionItem]"
+      },
+      "CollectionResponse_FlashcardWithHighlight_": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/FlashcardWithHighlight"
+            },
+            "type": "array",
+            "title": "Items"
+          }
+        },
+        "type": "object",
+        "required": [
+          "items"
+        ],
+        "title": "CollectionResponse[FlashcardWithHighlight]"
+      },
+      "CollectionResponse_HighlightLabelInBook_": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/HighlightLabelInBook"
+            },
+            "type": "array",
+            "title": "Items"
+          }
+        },
+        "type": "object",
+        "required": [
+          "items"
+        ],
+        "title": "CollectionResponse[HighlightLabelInBook]"
+      },
+      "CollectionResponse_NoteWithLinks_": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/NoteWithLinks"
+            },
+            "type": "array",
+            "title": "Items"
+          }
+        },
+        "type": "object",
+        "required": [
+          "items"
+        ],
+        "title": "CollectionResponse[NoteWithLinks]"
+      },
+      "CollectionResponse_Tag_": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/Tag"
+            },
+            "type": "array",
+            "title": "Items"
+          }
+        },
+        "type": "object",
+        "required": [
+          "items"
+        ],
+        "title": "CollectionResponse[Tag]"
+      },
+      "CreateChatSessionResponse": {
+        "properties": {
+          "session_id": {
+            "type": "integer",
+            "title": "Session Id"
+          },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          }
+        },
+        "type": "object",
+        "required": [
+          "session_id",
+          "message"
+        ],
+        "title": "CreateChatSessionResponse"
+      },
+      "EreaderBookMetadata": {
+        "properties": {
+          "book_id": {
+            "type": "integer",
+            "title": "Book Id",
+            "description": "Internal book ID"
+          },
+          "bookname": {
+            "type": "string",
+            "title": "Bookname",
+            "description": "Book title"
+          },
+          "author": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Author",
+            "description": "Book author"
+          },
+          "cover_file": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cover File",
+            "description": "Cover image filename (UUID.jpg) or null"
+          },
+          "cover_blurhash": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cover Blurhash",
+            "description": "Blurhash string for cover placeholder"
+          },
+          "has_ebook": {
+            "type": "boolean",
+            "title": "Has Ebook",
+            "description": "Whether the book has an ebook file"
+          }
+        },
+        "type": "object",
+        "required": [
+          "book_id",
+          "bookname",
+          "has_ebook"
+        ],
+        "title": "EreaderBookMetadata",
+        "description": "Schema for ereader book metadata response.\n\nThis lightweight response is used by KOReader to get basic book information\nfor deciding whether to upload cover images, epub files, etc."
+      },
+      "EreaderChapterPrereadingItem": {
+        "properties": {
+          "chapter_id": {
+            "type": "integer",
+            "title": "Chapter Id"
+          },
+          "chapter_name": {
+            "type": "string",
+            "title": "Chapter Name"
+          },
+          "chapter_number": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Chapter Number"
+          },
+          "parent_chapter_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Parent Chapter Name"
+          },
+          "summary": {
+            "type": "string",
+            "title": "Summary"
+          },
+          "keypoints": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Keypoints"
+          },
+          "questions": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Questions"
+          },
+          "generated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Generated At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "chapter_id",
+          "chapter_name",
+          "chapter_number",
+          "parent_chapter_name",
+          "summary",
+          "keypoints",
+          "questions",
+          "generated_at"
+        ],
+        "title": "EreaderChapterPrereadingItem",
+        "description": "Ereader-friendly prereading content for a single chapter.\n\nQuestions are exposed as plain strings only (no AI or user answers) to keep\nthe device payload small and preserve active-recall value."
+      },
+      "FeatureFlags": {
+        "properties": {
+          "ai": {
+            "type": "boolean",
+            "title": "Ai",
+            "description": "Whether AI features are enabled"
+          },
+          "user_registrations": {
+            "type": "boolean",
+            "title": "User Registrations",
+            "description": "Whether user registration is enabled"
+          }
+        },
+        "type": "object",
+        "required": [
+          "ai",
+          "user_registrations"
+        ],
+        "title": "FeatureFlags",
+        "description": "Pydantic model defining all feature flags in the application."
+      },
+      "Flashcard": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "user_id": {
+            "type": "integer",
+            "title": "User Id"
+          },
+          "book_id": {
+            "type": "integer",
+            "title": "Book Id"
+          },
+          "highlight_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Highlight Id"
+          },
+          "chapter_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Chapter Id"
+          },
+          "note_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Note Id"
+          },
+          "question": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Question",
+            "description": "Question text for the flashcard"
+          },
+          "answer": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Answer",
+            "description": "Answer text for the flashcard"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "user_id",
+          "book_id",
+          "highlight_id",
+          "question",
+          "answer"
+        ],
+        "title": "Flashcard",
+        "description": "Schema for Flashcard response (without embedded highlight)."
+      },
+      "FlashcardCreateRequest": {
+        "properties": {
+          "question": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Question",
+            "description": "Question text for the flashcard"
+          },
+          "answer": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Answer",
+            "description": "Answer text for the flashcard"
+          },
+          "chapter_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Chapter Id",
+            "description": "Optional chapter ID to associate with"
+          }
+        },
+        "type": "object",
+        "required": [
+          "question",
+          "answer"
+        ],
+        "title": "FlashcardCreateRequest",
+        "description": "Schema for creating a new flashcard."
+      },
+      "FlashcardCreateResponse": {
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "title": "Success",
+            "description": "Whether the creation was successful"
+          },
+          "message": {
+            "type": "string",
+            "title": "Message",
+            "description": "Response message"
+          },
+          "flashcard": {
+            "$ref": "#/components/schemas/Flashcard",
+            "description": "Created flashcard"
+          }
+        },
+        "type": "object",
+        "required": [
+          "success",
+          "message",
+          "flashcard"
+        ],
+        "title": "FlashcardCreateResponse",
+        "description": "Schema for flashcard creation response."
+      },
+      "FlashcardSuggestionItem": {
+        "properties": {
+          "question": {
+            "type": "string",
+            "title": "Question",
+            "description": "Suggested question for flashcard"
+          },
+          "answer": {
+            "type": "string",
+            "title": "Answer",
+            "description": "Suggested answer for flashcard"
+          }
+        },
+        "type": "object",
+        "required": [
+          "question",
+          "answer"
+        ],
+        "title": "FlashcardSuggestionItem",
+        "description": "Schema for a single AI-generated flashcard suggestion."
+      },
+      "FlashcardUpdateRequest": {
+        "properties": {
+          "question": {
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Question",
+            "description": "New question text"
+          },
+          "answer": {
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Answer",
+            "description": "New answer text"
+          }
+        },
+        "type": "object",
+        "title": "FlashcardUpdateRequest",
+        "description": "Schema for updating a flashcard."
+      },
+      "FlashcardUpdateResponse": {
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "title": "Success",
+            "description": "Whether the update was successful"
+          },
+          "message": {
+            "type": "string",
+            "title": "Message",
+            "description": "Response message"
+          },
+          "flashcard": {
+            "$ref": "#/components/schemas/Flashcard",
+            "description": "Updated flashcard"
+          }
+        },
+        "type": "object",
+        "required": [
+          "success",
+          "message",
+          "flashcard"
+        ],
+        "title": "FlashcardUpdateResponse",
+        "description": "Schema for flashcard update response."
+      },
+      "FlashcardWithHighlight": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "user_id": {
+            "type": "integer",
+            "title": "User Id"
+          },
+          "book_id": {
+            "type": "integer",
+            "title": "Book Id"
+          },
+          "highlight_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Highlight Id"
+          },
+          "chapter_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Chapter Id"
+          },
+          "note_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Note Id"
+          },
+          "question": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Question",
+            "description": "Question text for the flashcard"
+          },
+          "answer": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Answer",
+            "description": "Answer text for the flashcard"
+          },
+          "highlight": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/HighlightResponseBase"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Associated highlight data with tags (if any)"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "user_id",
+          "book_id",
+          "highlight_id",
+          "question",
+          "answer"
+        ],
+        "title": "FlashcardWithHighlight",
+        "description": "Flashcard response schema with embedded highlight data."
+      },
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "type": "array",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "title": "HTTPValidationError"
+      },
+      "Highlight": {
+        "properties": {
+          "text": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Text",
+            "description": "Highlighted text"
+          },
+          "chapter": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 500
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Chapter",
+            "description": "Chapter name"
+          },
+          "chapter_number": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "minimum": 1.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Chapter Number",
+            "description": "Chapter order number from TOC"
+          },
+          "page": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "minimum": 0.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Page",
+            "description": "Page number"
+          },
+          "datetime": {
+            "type": "string",
+            "maxLength": 50,
+            "minLength": 1,
+            "title": "Datetime",
+            "description": "KOReader datetime format"
+          },
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "book_id": {
+            "type": "integer",
+            "title": "Book Id"
+          },
+          "chapter_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Chapter Id"
+          },
+          "label": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/HighlightLabel"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Resolved label for this highlight"
+          },
+          "tags": {
+            "items": {
+              "$ref": "#/components/schemas/TagInBook"
+            },
+            "type": "array",
+            "title": "Tags",
+            "description": "List of tags for this highlight"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Updated At"
+          },
+          "flashcards": {
+            "items": {
+              "$ref": "#/components/schemas/Flashcard"
+            },
+            "type": "array",
+            "title": "Flashcards",
+            "description": "List of flashcards for this highlight"
+          }
+        },
+        "type": "object",
+        "required": [
+          "text",
+          "datetime",
+          "id",
+          "book_id",
+          "chapter_id",
+          "tags",
+          "created_at",
+          "updated_at",
+          "flashcards"
+        ],
+        "title": "Highlight",
+        "description": "Schema for Highlight response with flashcards."
+      },
+      "HighlightCreate": {
+        "properties": {
+          "text": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Text",
+            "description": "Highlighted text"
+          },
+          "chapter": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 500
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Chapter",
+            "description": "Chapter name"
+          },
+          "chapter_number": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "minimum": 1.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Chapter Number",
+            "description": "Chapter order number from TOC"
+          },
+          "page": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "minimum": 0.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Page",
+            "description": "Page number"
+          },
+          "datetime": {
+            "type": "string",
+            "maxLength": 50,
+            "minLength": 1,
+            "title": "Datetime",
+            "description": "KOReader datetime format"
+          },
+          "start_xpoint": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Start Xpoint",
+            "description": "Highlight start position in XML document"
+          },
+          "end_xpoint": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "End Xpoint",
+            "description": "Highlight end position in XML document"
+          },
+          "color": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Color",
+            "description": "Highlight color from KOReader (e.g. 'gray', 'yellow')"
+          },
+          "drawer": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Drawer",
+            "description": "Highlight drawer/style from KOReader (e.g. 'lighten', 'strikethrough')"
+          }
+        },
+        "type": "object",
+        "required": [
+          "text",
+          "datetime"
+        ],
+        "title": "HighlightCreate",
+        "description": "Schema for creating a Highlight."
+      },
+      "HighlightDeleteRequest": {
+        "properties": {
+          "highlight_ids": {
+            "items": {
+              "type": "integer"
+            },
+            "type": "array",
+            "minItems": 1,
+            "title": "Highlight Ids",
+            "description": "List of highlight IDs to soft delete"
+          }
+        },
+        "type": "object",
+        "required": [
+          "highlight_ids"
+        ],
+        "title": "HighlightDeleteRequest",
+        "description": "Schema for soft deleting highlights."
+      },
+      "HighlightDeleteResponse": {
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "title": "Success",
+            "description": "Whether the deletion was successful"
+          },
+          "message": {
+            "type": "string",
+            "title": "Message",
+            "description": "Response message"
+          },
+          "deleted_count": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Deleted Count",
+            "description": "Number of highlights deleted"
+          }
+        },
+        "type": "object",
+        "required": [
+          "success",
+          "message",
+          "deleted_count"
+        ],
+        "title": "HighlightDeleteResponse",
+        "description": "Schema for highlight delete response."
+      },
+      "HighlightLabel": {
+        "properties": {
+          "highlight_style_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Highlight Style Id",
+            "description": "ID of the highlight style"
+          },
+          "text": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Text",
+            "description": "Resolved label text"
+          },
+          "ui_color": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ui Color",
+            "description": "Resolved UI color"
+          }
+        },
+        "type": "object",
+        "title": "HighlightLabel",
+        "description": "Resolved label info for a highlight."
+      },
+      "HighlightLabelCreate": {
+        "properties": {
+          "device_color": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Device Color",
+            "description": "Device color to label"
+          },
+          "device_style": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Device Style",
+            "description": "Device style to label"
+          },
+          "label": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Label",
+            "description": "Label to assign"
+          },
+          "ui_color": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ui Color",
+            "description": "UI color to assign"
+          }
+        },
+        "type": "object",
+        "title": "HighlightLabelCreate",
+        "description": "Schema for creating a global highlight label."
+      },
+      "HighlightLabelInBook": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "device_color": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Device Color",
+            "description": "Device highlight color"
+          },
+          "device_style": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Device Style",
+            "description": "Device drawing style"
+          },
+          "label": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Label",
+            "description": "User-assigned label"
+          },
+          "ui_color": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ui Color",
+            "description": "User-chosen UI color"
+          },
+          "label_source": {
+            "type": "string",
+            "title": "Label Source",
+            "description": "Where the label comes from: 'book', 'global', or 'none'"
+          },
+          "highlight_count": {
+            "type": "integer",
+            "title": "Highlight Count",
+            "description": "Number of highlights using this style"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "label_source",
+          "highlight_count"
+        ],
+        "title": "HighlightLabelInBook",
+        "description": "Schema for a highlight label as shown in book context."
+      },
+      "HighlightLabelUpdate": {
+        "properties": {
+          "label": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Label",
+            "description": "New label (null to clear)"
+          },
+          "ui_color": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ui Color",
+            "description": "New UI color (null to clear)"
+          }
+        },
+        "type": "object",
+        "title": "HighlightLabelUpdate",
+        "description": "Schema for updating a highlight label."
+      },
+      "HighlightResponseBase": {
+        "properties": {
+          "text": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Text",
+            "description": "Highlighted text"
+          },
+          "chapter": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 500
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Chapter",
+            "description": "Chapter name"
+          },
+          "chapter_number": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "minimum": 1.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Chapter Number",
+            "description": "Chapter order number from TOC"
+          },
+          "page": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "minimum": 0.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Page",
+            "description": "Page number"
+          },
+          "datetime": {
+            "type": "string",
+            "maxLength": 50,
+            "minLength": 1,
+            "title": "Datetime",
+            "description": "KOReader datetime format"
+          },
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "book_id": {
+            "type": "integer",
+            "title": "Book Id"
+          },
+          "chapter_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Chapter Id"
+          },
+          "label": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/HighlightLabel"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Resolved label for this highlight"
+          },
+          "tags": {
+            "items": {
+              "$ref": "#/components/schemas/TagInBook"
+            },
+            "type": "array",
+            "title": "Tags",
+            "description": "List of tags for this highlight"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Updated At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "text",
+          "datetime",
+          "id",
+          "book_id",
+          "chapter_id",
+          "tags",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "HighlightResponseBase",
+        "description": "Base schema for Highlight response (without flashcards).\n\nUse this when you need highlight data but don't want nested flashcards."
+      },
+      "HighlightUploadRequest": {
+        "properties": {
+          "client_book_id": {
+            "type": "string",
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Client Book Id",
+            "description": "Client-provided stable book identifier for deduplication"
+          },
+          "highlights": {
+            "items": {
+              "$ref": "#/components/schemas/HighlightCreate"
+            },
+            "type": "array",
+            "title": "Highlights",
+            "description": "List of highlights to upload"
+          }
+        },
+        "type": "object",
+        "required": [
+          "client_book_id",
+          "highlights"
+        ],
+        "title": "HighlightUploadRequest",
+        "description": "Schema for uploading highlights from KOReader."
+      },
+      "HighlightUploadResponse": {
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "title": "Success",
+            "description": "Whether the upload was successful"
+          },
+          "message": {
+            "type": "string",
+            "title": "Message",
+            "description": "Response message"
+          },
+          "book_id": {
+            "type": "integer",
+            "title": "Book Id",
+            "description": "ID of the book"
+          },
+          "highlights_created": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Highlights Created",
+            "description": "Number of highlights created"
+          },
+          "highlights_skipped": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Highlights Skipped",
+            "description": "Number of highlights skipped (duplicates)"
+          }
+        },
+        "type": "object",
+        "required": [
+          "success",
+          "message",
+          "book_id",
+          "highlights_created",
+          "highlights_skipped"
+        ],
+        "title": "HighlightUploadResponse",
+        "description": "Schema for highlight upload response."
+      },
+      "JobBatchResponse": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "batch_type": {
+            "type": "string",
+            "title": "Batch Type"
+          },
+          "reference_id": {
+            "type": "string",
+            "title": "Reference Id"
+          },
+          "total_jobs": {
+            "type": "integer",
+            "title": "Total Jobs"
+          },
+          "completed_jobs": {
+            "type": "integer",
+            "title": "Completed Jobs"
+          },
+          "failed_jobs": {
+            "type": "integer",
+            "title": "Failed Jobs"
+          },
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Updated At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "batch_type",
+          "reference_id",
+          "total_jobs",
+          "completed_jobs",
+          "failed_jobs",
+          "status",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "JobBatchResponse"
+      },
+      "Note": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "user_id": {
+            "type": "integer",
+            "title": "User Id"
+          },
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "body": {
+            "type": "string",
+            "title": "Body"
+          },
+          "kind": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Kind"
+          },
+          "book_ids": {
+            "items": {
+              "type": "integer"
+            },
+            "type": "array",
+            "title": "Book Ids"
+          },
+          "chapter_ids": {
+            "items": {
+              "type": "integer"
+            },
+            "type": "array",
+            "title": "Chapter Ids"
+          },
+          "highlight_ids": {
+            "items": {
+              "type": "integer"
+            },
+            "type": "array",
+            "title": "Highlight Ids"
+          },
+          "tag_ids": {
+            "items": {
+              "type": "integer"
+            },
+            "type": "array",
+            "title": "Tag Ids"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Updated At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "user_id",
+          "title",
+          "body",
+          "kind",
+          "book_ids",
+          "chapter_ids",
+          "highlight_ids",
+          "tag_ids",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "Note",
+        "description": "Schema for Note response."
+      },
+      "NoteCreateRequest": {
+        "properties": {
+          "title": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Title",
+            "description": "Note title"
+          },
+          "body": {
+            "type": "string",
+            "title": "Body",
+            "description": "Markdown body",
+            "default": ""
+          },
+          "kind": {
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "character",
+                  "term",
+                  "concept",
+                  "gist",
+                  "reflection",
+                  "other"
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Kind",
+            "description": "Optional note kind"
+          },
+          "book_id": {
+            "type": "integer",
+            "title": "Book Id",
+            "description": "Book this note is created in"
+          },
+          "chapter_ids": {
+            "items": {
+              "type": "integer"
+            },
+            "type": "array",
+            "title": "Chapter Ids"
+          },
+          "highlight_ids": {
+            "items": {
+              "type": "integer"
+            },
+            "type": "array",
+            "title": "Highlight Ids"
+          },
+          "tag_ids": {
+            "items": {
+              "type": "integer"
+            },
+            "type": "array",
+            "title": "Tag Ids"
+          }
+        },
+        "type": "object",
+        "required": [
+          "title",
+          "book_id"
+        ],
+        "title": "NoteCreateRequest",
+        "description": "Schema for creating a note."
+      },
+      "NoteCreateResponse": {
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "title": "Success",
+            "description": "Whether the creation was successful"
+          },
+          "message": {
+            "type": "string",
+            "title": "Message",
+            "description": "Response message"
+          },
+          "note": {
+            "$ref": "#/components/schemas/Note",
+            "description": "Created note"
+          }
+        },
+        "type": "object",
+        "required": [
+          "success",
+          "message",
+          "note"
+        ],
+        "title": "NoteCreateResponse",
+        "description": "Schema for note creation response."
+      },
+      "NoteFlashcardCreateRequest": {
+        "properties": {
+          "question": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Question",
+            "description": "Question text for the flashcard"
+          },
+          "answer": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Answer",
+            "description": "Answer text for the flashcard"
+          },
+          "book_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Book Id",
+            "description": "Book (must be linked to the note) to file the flashcard under; defaults to the note's first book"
+          }
+        },
+        "type": "object",
+        "required": [
+          "question",
+          "answer"
+        ],
+        "title": "NoteFlashcardCreateRequest",
+        "description": "Schema for creating a new flashcard linked to a note."
+      },
+      "NoteLinkedChapter": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "name"
+        ],
+        "title": "NoteLinkedChapter",
+        "description": "Lightweight summary of a chapter linked to a note."
+      },
+      "NoteLinkedHighlight": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "text": {
+            "type": "string",
+            "title": "Text"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "text"
+        ],
+        "title": "NoteLinkedHighlight",
+        "description": "Lightweight summary of a highlight linked to a note."
+      },
+      "NoteLinkedTag": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "name"
+        ],
+        "title": "NoteLinkedTag",
+        "description": "Lightweight summary of a tag linked to a note."
+      },
+      "NoteUpdateRequest": {
+        "properties": {
+          "title": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Title",
+            "description": "Note title"
+          },
+          "body": {
+            "type": "string",
+            "title": "Body",
+            "description": "Markdown body",
+            "default": ""
+          },
+          "kind": {
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "character",
+                  "term",
+                  "concept",
+                  "gist",
+                  "reflection",
+                  "other"
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Kind",
+            "description": "Optional note kind"
+          },
+          "chapter_ids": {
+            "items": {
+              "type": "integer"
+            },
+            "type": "array",
+            "title": "Chapter Ids"
+          },
+          "highlight_ids": {
+            "items": {
+              "type": "integer"
+            },
+            "type": "array",
+            "title": "Highlight Ids"
+          },
+          "tag_ids": {
+            "items": {
+              "type": "integer"
+            },
+            "type": "array",
+            "title": "Tag Ids"
+          }
+        },
+        "type": "object",
+        "required": [
+          "title"
+        ],
+        "title": "NoteUpdateRequest",
+        "description": "Schema for updating a note (full replace of fields and links)."
+      },
+      "NoteUpdateResponse": {
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "title": "Success",
+            "description": "Whether the update was successful"
+          },
+          "message": {
+            "type": "string",
+            "title": "Message",
+            "description": "Response message"
+          },
+          "note": {
+            "$ref": "#/components/schemas/Note",
+            "description": "Updated note"
+          }
+        },
+        "type": "object",
+        "required": [
+          "success",
+          "message",
+          "note"
+        ],
+        "title": "NoteUpdateResponse",
+        "description": "Schema for note update response."
+      },
+      "NoteWithLinks": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "user_id": {
+            "type": "integer",
+            "title": "User Id"
+          },
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "body": {
+            "type": "string",
+            "title": "Body"
+          },
+          "kind": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Kind"
+          },
+          "book_ids": {
+            "items": {
+              "type": "integer"
+            },
+            "type": "array",
+            "title": "Book Ids"
+          },
+          "chapter_ids": {
+            "items": {
+              "type": "integer"
+            },
+            "type": "array",
+            "title": "Chapter Ids"
+          },
+          "highlight_ids": {
+            "items": {
+              "type": "integer"
+            },
+            "type": "array",
+            "title": "Highlight Ids"
+          },
+          "tag_ids": {
+            "items": {
+              "type": "integer"
+            },
+            "type": "array",
+            "title": "Tag Ids"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Updated At"
+          },
+          "chapters": {
+            "items": {
+              "$ref": "#/components/schemas/NoteLinkedChapter"
+            },
+            "type": "array",
+            "title": "Chapters"
+          },
+          "highlights": {
+            "items": {
+              "$ref": "#/components/schemas/NoteLinkedHighlight"
+            },
+            "type": "array",
+            "title": "Highlights"
+          },
+          "tags": {
+            "items": {
+              "$ref": "#/components/schemas/NoteLinkedTag"
+            },
+            "type": "array",
+            "title": "Tags"
+          },
+          "flashcards": {
+            "items": {
+              "$ref": "#/components/schemas/Flashcard"
+            },
+            "type": "array",
+            "title": "Flashcards"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "user_id",
+          "title",
+          "body",
+          "kind",
+          "book_ids",
+          "chapter_ids",
+          "highlight_ids",
+          "tag_ids",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "NoteWithLinks",
+        "description": "Note response with linked entity summaries."
+      },
+      "PaginatedResponse_BookWithHighlightCount_": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/BookWithHighlightCount"
+            },
+            "type": "array",
+            "title": "Items"
+          },
+          "total": {
+            "type": "integer",
+            "title": "Total"
+          },
+          "offset": {
+            "type": "integer",
+            "title": "Offset"
+          },
+          "limit": {
+            "type": "integer",
+            "title": "Limit"
+          }
+        },
+        "type": "object",
+        "required": [
+          "items",
+          "total",
+          "offset",
+          "limit"
+        ],
+        "title": "PaginatedResponse[BookWithHighlightCount]"
+      },
+      "PaginatedResponse_ReadingSession_": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/ReadingSession"
+            },
+            "type": "array",
+            "title": "Items"
+          },
+          "total": {
+            "type": "integer",
+            "title": "Total"
+          },
+          "offset": {
+            "type": "integer",
+            "title": "Offset"
+          },
+          "limit": {
+            "type": "integer",
+            "title": "Limit"
+          }
+        },
+        "type": "object",
+        "required": [
+          "items",
+          "total",
+          "offset",
+          "limit"
+        ],
+        "title": "PaginatedResponse[ReadingSession]"
+      },
+      "PositionResponse": {
+        "properties": {
+          "index": {
+            "type": "integer",
+            "title": "Index",
+            "description": "Document-order element number"
+          },
+          "char_index": {
+            "type": "integer",
+            "title": "Char Index",
+            "description": "Character offset within element"
+          }
+        },
+        "type": "object",
+        "required": [
+          "index",
+          "char_index"
+        ],
+        "title": "PositionResponse",
+        "description": "Position in a book document."
+      },
+      "PrereadingAnswerUpdate": {
+        "properties": {
+          "question_index": {
+            "type": "integer",
+            "title": "Question Index"
+          },
+          "user_answer": {
+            "type": "string",
+            "title": "User Answer"
+          }
+        },
+        "type": "object",
+        "required": [
+          "question_index",
+          "user_answer"
+        ],
+        "title": "PrereadingAnswerUpdate",
+        "description": "Schema for a single answer update."
+      },
+      "PrereadingQuestionResponse": {
+        "properties": {
+          "question": {
+            "type": "string",
+            "title": "Question"
+          },
+          "answer": {
+            "type": "string",
+            "title": "Answer"
+          },
+          "user_answer": {
+            "type": "string",
+            "title": "User Answer"
+          }
+        },
+        "type": "object",
+        "required": [
+          "question",
+          "answer",
+          "user_answer"
+        ],
+        "title": "PrereadingQuestionResponse",
+        "description": "Response schema for a pre-reading question/answer pair."
+      },
+      "ReadingSession": {
+        "properties": {
+          "book_id": {
+            "type": "integer",
+            "title": "Book Id"
+          },
+          "device_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Device Id"
+          },
+          "content_hash": {
+            "type": "string",
+            "title": "Content Hash"
+          },
+          "start_time": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Start Time",
+            "description": "Session start timestamp"
+          },
+          "end_time": {
+            "type": "string",
+            "format": "date-time",
+            "title": "End Time",
+            "description": "Session end timestamp"
+          },
+          "start_page": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "minimum": 0.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Start Page",
+            "description": "Start page number (for PDFs)"
+          },
+          "end_page": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "minimum": 0.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "End Page",
+            "description": "End page number (for PDFs)"
+          },
+          "content": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Content",
+            "description": "Extracted text content of the session"
+          },
+          "ai_summary": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ai Summary",
+            "description": "AI generated summary of the read content"
+          },
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "highlights": {
+            "items": {
+              "$ref": "#/components/schemas/Highlight"
+            },
+            "type": "array",
+            "title": "Highlights",
+            "description": "Highlights that appear within this reading session"
+          }
+        },
+        "type": "object",
+        "required": [
+          "book_id",
+          "device_id",
+          "content_hash",
+          "start_time",
+          "end_time",
+          "id",
+          "created_at",
+          "highlights"
+        ],
+        "title": "ReadingSession",
+        "description": "Schema for ReadingSession response."
+      },
+      "ReadingSessionAISummaryResponse": {
+        "properties": {
+          "summary": {
+            "type": "string",
+            "title": "Summary",
+            "description": "AI-generated summary of the reading session"
+          }
+        },
+        "type": "object",
+        "required": [
+          "summary"
+        ],
+        "title": "ReadingSessionAISummaryResponse",
+        "description": "Schema for AI summary response."
+      },
+      "ReadingSessionUploadRequest": {
+        "properties": {
+          "client_book_id": {
+            "type": "string",
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Client Book Id",
+            "description": "Client-provided stable book identifier for deduplication"
+          },
+          "sessions": {
+            "items": {
+              "$ref": "#/components/schemas/ReadingSessionUploadSessionItem"
+            },
+            "type": "array",
+            "minItems": 1,
+            "title": "Sessions",
+            "description": "List of reading sessions for this book"
+          }
+        },
+        "type": "object",
+        "required": [
+          "client_book_id",
+          "sessions"
+        ],
+        "title": "ReadingSessionUploadRequest",
+        "description": "Schema for uploading reading sessions from KOReader."
+      },
+      "ReadingSessionUploadResponse": {
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "title": "Success",
+            "description": "Whether the upload was successful (always True)"
+          },
+          "message": {
+            "type": "string",
+            "title": "Message",
+            "description": "Response message"
+          },
+          "book_id": {
+            "type": "integer",
+            "title": "Book Id",
+            "description": "ID of the book for these sessions"
+          },
+          "created_count": {
+            "type": "integer",
+            "title": "Created Count",
+            "description": "Number of sessions created",
+            "default": 0
+          },
+          "skipped_duplicate_count": {
+            "type": "integer",
+            "title": "Skipped Duplicate Count",
+            "description": "Sessions skipped because already uploaded",
+            "default": 0
+          }
+        },
+        "type": "object",
+        "required": [
+          "success",
+          "message",
+          "book_id"
+        ],
+        "title": "ReadingSessionUploadResponse",
+        "description": "Schema for reading session upload response.\n\nNote: If any session is invalid,\nthe entire request fails with 422 and this response is never returned."
+      },
+      "ReadingSessionUploadSessionItem": {
+        "properties": {
+          "start_time": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Start Time",
+            "description": "Session start timestamp"
+          },
+          "end_time": {
+            "type": "string",
+            "format": "date-time",
+            "title": "End Time",
+            "description": "Session end timestamp"
+          },
+          "start_xpoint": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Start Xpoint",
+            "description": "Start position (xpoint string)"
+          },
+          "end_xpoint": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "End Xpoint",
+            "description": "End position (xpoint string)"
+          },
+          "start_page": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "minimum": 0.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Start Page",
+            "description": "Start page for PDFs"
+          },
+          "end_page": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "minimum": 0.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "End Page",
+            "description": "End page for PDFs"
+          },
+          "device_id": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 100
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Device Id",
+            "description": "Device identifier"
+          }
+        },
+        "type": "object",
+        "required": [
+          "start_time",
+          "end_time"
+        ],
+        "title": "ReadingSessionUploadSessionItem",
+        "description": "Schema for a single reading session in the upload request."
+      },
+      "RefreshTokenRequest": {
+        "properties": {
+          "refresh_token": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Refresh Token"
+          }
+        },
+        "type": "object",
+        "title": "RefreshTokenRequest",
+        "description": "Request body for refresh token (used by plugins)."
+      },
+      "SendChatMessageRequest": {
+        "properties": {
+          "message": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Message"
+          }
+        },
+        "type": "object",
+        "required": [
+          "message"
+        ],
+        "title": "SendChatMessageRequest"
+      },
+      "SendChatMessageResponse": {
+        "properties": {
+          "message": {
+            "type": "string",
+            "title": "Message"
+          }
+        },
+        "type": "object",
+        "required": [
+          "message"
+        ],
+        "title": "SendChatMessageResponse"
+      },
+      "SuccessResponse": {
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "title": "Success"
+          },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          }
+        },
+        "type": "object",
+        "required": [
+          "success",
+          "message"
+        ],
+        "title": "SuccessResponse",
+        "description": "Generic success response wrapper."
+      },
+      "Tag": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "book_id": {
+            "type": "integer",
+            "title": "Book Id"
+          },
+          "tag_group_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tag Group Id"
+          },
+          "name": {
+            "type": "string",
+            "maxLength": 100,
+            "minLength": 1,
+            "title": "Name",
+            "description": "Tag name"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "book_id",
+          "name"
+        ],
+        "title": "Tag",
+        "description": "Schema for Tag response."
+      },
+      "TagAssociationRequest": {
+        "properties": {
+          "tag_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tag Id",
+            "description": "ID of existing tag to associate"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 100,
+                "minLength": 1
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name",
+            "description": "Name of tag to create/associate"
+          }
+        },
+        "type": "object",
+        "title": "TagAssociationRequest",
+        "description": "Schema for associating a tag with a highlight."
+      },
+      "TagCreateRequest": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "maxLength": 100,
+            "minLength": 1,
+            "title": "Name",
+            "description": "Tag name"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "title": "TagCreateRequest",
+        "description": "Schema for creating a new tag."
+      },
+      "TagGroup": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "book_id": {
+            "type": "integer",
+            "title": "Book Id"
+          },
+          "name": {
+            "type": "string",
+            "maxLength": 100,
+            "minLength": 1,
+            "title": "Name",
+            "description": "Tag group name"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "book_id",
+          "name"
+        ],
+        "title": "TagGroup",
+        "description": "Schema for TagGroup response."
+      },
+      "TagGroupCreateRequest": {
+        "properties": {
+          "id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id",
+            "description": "ID of existing tag group to update (optional)"
+          },
+          "book_id": {
+            "type": "integer",
+            "title": "Book Id",
+            "description": "ID of the book this tag group belongs to"
+          },
+          "name": {
+            "type": "string",
+            "maxLength": 100,
+            "minLength": 1,
+            "title": "Name",
+            "description": "Tag group name"
+          }
+        },
+        "type": "object",
+        "required": [
+          "book_id",
+          "name"
+        ],
+        "title": "TagGroupCreateRequest",
+        "description": "Schema for creating or updating a tag group."
+      },
+      "TagGroupInBook": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "name"
+        ],
+        "title": "TagGroupInBook",
+        "description": "Minimal tag group schema for book responses."
+      },
+      "TagInBook": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "tag_group_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tag Group Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "name"
+        ],
+        "title": "TagInBook",
+        "description": "Minimal tag schema for book responses."
+      },
+      "TagUpdateRequest": {
+        "properties": {
+          "name": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 100,
+                "minLength": 1
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name",
+            "description": "Tag name"
+          },
+          "tag_group_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tag Group Id",
+            "description": "ID of tag group to associate with"
+          }
+        },
+        "type": "object",
+        "title": "TagUpdateRequest",
+        "description": "Schema for updating an existing tag."
+      },
+      "TokenWithRefresh": {
+        "properties": {
+          "access_token": {
+            "type": "string",
+            "title": "Access Token"
+          },
+          "refresh_token": {
+            "type": "string",
+            "title": "Refresh Token"
+          },
+          "token_type": {
+            "type": "string",
+            "title": "Token Type"
+          },
+          "expires_in": {
+            "type": "integer",
+            "title": "Expires In"
+          }
+        },
+        "type": "object",
+        "required": [
+          "access_token",
+          "refresh_token",
+          "token_type",
+          "expires_in"
+        ],
+        "title": "TokenWithRefresh",
+        "description": "Pydantic response model for HTTP API responses."
+      },
+      "UpdatePrereadingAnswersRequest": {
+        "properties": {
+          "answers": {
+            "items": {
+              "$ref": "#/components/schemas/PrereadingAnswerUpdate"
+            },
+            "type": "array",
+            "title": "Answers"
+          }
+        },
+        "type": "object",
+        "required": [
+          "answers"
+        ],
+        "title": "UpdatePrereadingAnswersRequest",
+        "description": "Request schema for updating prereading answers."
+      },
+      "UserDetailsResponse": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id",
+            "description": "User id"
+          },
+          "email": {
+            "type": "string",
+            "maxLength": 100,
+            "minLength": 1,
+            "title": "Email",
+            "description": "User email"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "email"
+        ],
+        "title": "UserDetailsResponse",
+        "description": "Schema for returning user details."
+      },
+      "UserRegisterRequest": {
+        "properties": {
+          "email": {
+            "type": "string",
+            "maxLength": 100,
+            "minLength": 1,
+            "title": "Email",
+            "description": "Email for the new account"
+          },
+          "password": {
+            "type": "string",
+            "minLength": 8,
+            "title": "Password",
+            "description": "Password (min 8 characters)"
+          }
+        },
+        "type": "object",
+        "required": [
+          "email",
+          "password"
+        ],
+        "title": "UserRegisterRequest",
+        "description": "Schema for user registration."
+      },
+      "UserUpdateRequest": {
+        "properties": {
+          "email": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 100,
+                "minLength": 1
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Email",
+            "description": "New user email"
+          },
+          "current_password": {
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Current Password",
+            "description": "Current password (required when changing password)"
+          },
+          "new_password": {
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 8
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "New Password",
+            "description": "New password (min 8 characters)"
+          }
+        },
+        "type": "object",
+        "title": "UserUpdateRequest",
+        "description": "Schema for updating user profile."
+      },
+      "ValidationError": {
+        "properties": {
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "type": "array",
+            "title": "Location"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Message"
+          },
+          "type": {
+            "type": "string",
+            "title": "Error Type"
+          },
+          "input": {
+            "title": "Input"
+          },
+          "ctx": {
+            "type": "object",
+            "title": "Context"
+          }
+        },
+        "type": "object",
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError"
+      }
+    },
+    "securitySchemes": {
+      "OAuth2PasswordBearer": {
+        "type": "oauth2",
+        "flows": {
+          "password": {
+            "scopes": {},
+            "tokenUrl": "auth/login"
+          }
+        }
+      }
+    }
+  }
+}

--- a/backend/scripts/export_openapi.py
+++ b/backend/scripts/export_openapi.py
@@ -1,0 +1,41 @@
+"""Export the app's OpenAPI schema to a committed file, without a running server.
+
+The exported ``backend/openapi.json`` is the API contract the frontend's
+generated client is built from: ``frontend/orval.config.ts`` reads it, so
+regenerating the client needs no running backend. CI re-exports the schema and
+fails on any diff, which surfaces a backend API change as a stale-contract
+failure (and, after regeneration, a type error) in the same PR.
+
+Usage: ``uv run python scripts/export_openapi.py [target-path]``
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+
+# Settings are constructed at import time in src.main, so the same env
+# defaults tests/conftest.py uses must be set before importing it. None of
+# these values affect the schema.
+os.environ.setdefault("TESTING", "1")
+os.environ.setdefault("ADMIN_PASSWORD", "test-admin-password")
+os.environ.setdefault("SECRET_KEY", "test-secret-key-at-least-32-bytes-long")
+os.environ.setdefault(
+    "REFRESH_TOKEN_SECRET_KEY",
+    "test-refresh-token-secret-key-at-least-32-bytes-long",
+)
+os.environ.setdefault("RATE_LIMIT_ENABLED", "false")
+
+from src.main import app
+
+DEFAULT_TARGET = Path(__file__).resolve().parent.parent / "openapi.json"
+
+
+def main() -> None:
+    target = Path(sys.argv[1]) if len(sys.argv) > 1 else DEFAULT_TARGET
+    target.write_text(json.dumps(app.openapi(), indent=2) + "\n", encoding="utf-8")
+    sys.stdout.write(f"Wrote OpenAPI schema to {target}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/frontend/claude.md
+++ b/frontend/claude.md
@@ -111,6 +111,11 @@ const HighlightsList = ({ bookId }: Props) => {
 ## API Integration
 
 - **USE** generated API client from Orval
+- The client is generated from the committed `backend/openapi.json` (no running
+  backend needed). After changing backend endpoints, run `make api-client` from
+  the repo root and commit the schema + regenerated client — CI fails if either
+  is stale
+- **NEVER** hand-edit files under `src/api/generated`
 - **ALWAYS** handle loading and error states
 - **USE** optimistic updates for better UX
 - **INVALIDATE** queries after mutations

--- a/frontend/orval.config.ts
+++ b/frontend/orval.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'orval';
 export default defineConfig({
   crossbill: {
     input: {
-      target: 'http://localhost:8000/api/v1/openapi.json',
+      target: '../backend/openapi.json',
     },
     output: {
       mode: 'tags-split',


### PR DESCRIPTION
First step of the frontend testing plan: a static contract gate that turns backend API changes into frontend CI failures, with no runtime tests involved.

## What changed

- **`backend/openapi.json` is now a committed contract.** `backend/scripts/export_openapi.py` builds it from `app.openapi()` without a running server (same env defaults as `tests/conftest.py`).
- **orval reads the file instead of `localhost:8000`**, so `npm run api:generate` and `npm run build` work offline. `make api-client` does export + regen in one step.
- **Two new CI checks:**
  - Backend job: re-export the schema and fail on `git diff` — catches an API change committed without re-exporting.
  - Frontend job: regenerate the orval client and fail on `git diff` (`git add -N` first so brand-new endpoint files count as drift, not just edits). Type-check then runs against the fresh client, so a breaking backend change surfaces as a `tsc` error in the same PR.
- `frontend/claude.md` tells agents to run `make api-client` after endpoint changes and never to hand-edit `src/api/generated`.

## Verification

- Regenerated client from the exported schema is byte-identical to what was committed — everything is in sync today.
- Simulated drift locally: perturbing `openapi.json` makes the diff check fail; re-exporting makes it pass.
- ruff, pyright (strict), import-linter, eslint, and `tsc` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)