### PR TITLE
Deduplicate the backend unit tests

### DIFF
--- a/backend/.jscpd.json
+++ b/backend/.jscpd.json
@@ -12,5 +12,5 @@
   "minLines": 5,
   "minTokens": 50,
   "reporters": ["ai", "threshold"],
-  "threshold": 3.5
+  "threshold": 2.9
 }

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -82,6 +82,23 @@ async def create_test_book(
     return book
 
 
+async def create_test_chapter(
+    db_session: AsyncSession,
+    book: Book,
+    name: str,
+    chapter_number: int | None = None,
+    parent_id: int | None = None,
+) -> Chapter:
+    """Attach a chapter to a book."""
+    chapter = Chapter(
+        book_id=book.id, name=name, chapter_number=chapter_number, parent_id=parent_id
+    )
+    db_session.add(chapter)
+    await db_session.commit()
+    await db_session.refresh(chapter)
+    return chapter
+
+
 async def create_test_highlight(
     db_session: AsyncSession,
     book: Book,

--- a/backend/tests/test_ereader_prereading.py
+++ b/backend/tests/test_ereader_prereading.py
@@ -8,26 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.models import Book, Chapter
 from src.models import ChapterPrereadingContent as PrereadingContentORM
-from tests.conftest import create_test_book
-
-
-async def _add_chapter(
-    db_session: AsyncSession,
-    book: Book,
-    name: str,
-    chapter_number: int | None = None,
-    parent_id: int | None = None,
-) -> Chapter:
-    chapter = Chapter(
-        book_id=book.id,
-        name=name,
-        chapter_number=chapter_number,
-        parent_id=parent_id,
-    )
-    db_session.add(chapter)
-    await db_session.commit()
-    await db_session.refresh(chapter)
-    return chapter
+from tests.conftest import create_test_book, create_test_chapter
 
 
 async def _add_prereading(
@@ -66,11 +47,11 @@ async def prereading_book(db_session: AsyncSession, test_user: Book) -> Book:
 async def test_returns_items_ordered_by_chapter_number(
     client: AsyncClient, db_session: AsyncSession, prereading_book: Book
 ) -> None:
-    parent = await _add_chapter(db_session, prereading_book, "Topic 1", chapter_number=1)
-    ch_a = await _add_chapter(
+    parent = await create_test_chapter(db_session, prereading_book, "Topic 1", chapter_number=1)
+    ch_a = await create_test_chapter(
         db_session, prereading_book, "Exercises", chapter_number=7, parent_id=parent.id
     )
-    ch_b = await _add_chapter(
+    ch_b = await create_test_chapter(
         db_session, prereading_book, "Intro", chapter_number=2, parent_id=parent.id
     )
     await _add_prereading(db_session, ch_a, summary="Exercises summary")
@@ -91,12 +72,12 @@ async def test_returns_items_ordered_by_chapter_number(
 async def test_duplicate_chapter_names_disambiguated_by_parent(
     client: AsyncClient, db_session: AsyncSession, prereading_book: Book
 ) -> None:
-    topic1 = await _add_chapter(db_session, prereading_book, "Topic 1", chapter_number=1)
-    topic2 = await _add_chapter(db_session, prereading_book, "Topic 2", chapter_number=2)
-    ex1 = await _add_chapter(
+    topic1 = await create_test_chapter(db_session, prereading_book, "Topic 1", chapter_number=1)
+    topic2 = await create_test_chapter(db_session, prereading_book, "Topic 2", chapter_number=2)
+    ex1 = await create_test_chapter(
         db_session, prereading_book, "Exercises", chapter_number=3, parent_id=topic1.id
     )
-    ex2 = await _add_chapter(
+    ex2 = await create_test_chapter(
         db_session, prereading_book, "Exercises", chapter_number=4, parent_id=topic2.id
     )
     await _add_prereading(db_session, ex1)
@@ -115,7 +96,7 @@ async def test_duplicate_chapter_names_disambiguated_by_parent(
 async def test_root_chapter_has_null_parent_name(
     client: AsyncClient, db_session: AsyncSession, prereading_book: Book
 ) -> None:
-    root = await _add_chapter(db_session, prereading_book, "Root Chapter", chapter_number=1)
+    root = await create_test_chapter(db_session, prereading_book, "Root Chapter", chapter_number=1)
     await _add_prereading(db_session, root)
 
     response = await client.get("/api/v1/ereader/books/client-abc/prereading")
@@ -129,8 +110,10 @@ async def test_root_chapter_has_null_parent_name(
 async def test_chapters_without_prereading_are_omitted(
     client: AsyncClient, db_session: AsyncSession, prereading_book: Book
 ) -> None:
-    ch_with = await _add_chapter(db_session, prereading_book, "Has prereading", chapter_number=1)
-    await _add_chapter(db_session, prereading_book, "No prereading", chapter_number=2)
+    ch_with = await create_test_chapter(
+        db_session, prereading_book, "Has prereading", chapter_number=1
+    )
+    await create_test_chapter(db_session, prereading_book, "No prereading", chapter_number=2)
     await _add_prereading(db_session, ch_with)
 
     response = await client.get("/api/v1/ereader/books/client-abc/prereading")
@@ -144,7 +127,7 @@ async def test_chapters_without_prereading_are_omitted(
 async def test_book_with_zero_prereading_returns_empty_list(
     client: AsyncClient, db_session: AsyncSession, prereading_book: Book
 ) -> None:
-    await _add_chapter(db_session, prereading_book, "Lonely chapter", chapter_number=1)
+    await create_test_chapter(db_session, prereading_book, "Lonely chapter", chapter_number=1)
 
     response = await client.get("/api/v1/ereader/books/client-abc/prereading")
 
@@ -161,7 +144,7 @@ async def test_unknown_client_book_id_returns_404(client: AsyncClient) -> None:
 async def test_questions_contain_only_question_strings(
     client: AsyncClient, db_session: AsyncSession, prereading_book: Book
 ) -> None:
-    chapter = await _add_chapter(db_session, prereading_book, "Chapter", chapter_number=1)
+    chapter = await create_test_chapter(db_session, prereading_book, "Chapter", chapter_number=1)
     await _add_prereading(
         db_session,
         chapter,

--- a/backend/tests/unit/application/identity/commands/authentication/test_authenticate_user_use_case.py
+++ b/backend/tests/unit/application/identity/commands/authentication/test_authenticate_user_use_case.py
@@ -1,6 +1,5 @@
 """Tests for AuthenticateUserUseCase with token rotation."""
 
-from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -12,6 +11,7 @@ from src.application.identity.dtos import TokenPairWithMetadata
 from src.domain.common.value_objects.ids import UserId
 from src.domain.identity.entities.user import User
 from src.domain.identity.exceptions import InvalidCredentialsError
+from tests.unit.application.identity.commands.conftest import make_token_pair
 
 
 def _make_user(user_id: int = 1) -> User:
@@ -24,39 +24,7 @@ def _make_user(user_id: int = 1) -> User:
     )
 
 
-def _make_token_pair() -> TokenPairWithMetadata:
-    return TokenPairWithMetadata(
-        access_token="access",
-        refresh_token="refresh",
-        token_type="bearer",
-        expires_in=900,
-        jti="test-jti",
-        family_id="test-family",
-        refresh_token_expires_at=datetime.now(UTC) + timedelta(days=30),
-    )
-
-
 class TestAuthenticateUserUseCase:
-    @pytest.fixture
-    def user_repository(self) -> AsyncMock:
-        return AsyncMock()
-
-    @pytest.fixture
-    def password_service(self) -> MagicMock:
-        # Hashing is awaited (it runs on a worker thread); get_dummy_hash is not.
-        service = MagicMock()
-        service.hash_password = AsyncMock(return_value="hashed")
-        service.verify_password = AsyncMock(return_value=False)
-        return service
-
-    @pytest.fixture
-    def token_service(self) -> MagicMock:
-        return MagicMock()
-
-    @pytest.fixture
-    def refresh_token_repository(self) -> AsyncMock:
-        return AsyncMock()
-
     @pytest.fixture
     def use_case(
         self,
@@ -83,7 +51,7 @@ class TestAuthenticateUserUseCase:
         user = _make_user()
         user_repository.find_by_email.return_value = user
         password_service.verify_password.return_value = True
-        token_pair = _make_token_pair()
+        token_pair = make_token_pair()
         token_service.create_token_pair.return_value = token_pair
         refresh_token_repository.save.return_value = MagicMock()
         return token_pair

--- a/backend/tests/unit/application/identity/commands/conftest.py
+++ b/backend/tests/unit/application/identity/commands/conftest.py
@@ -1,0 +1,49 @@
+"""Shared doubles for the identity command use cases.
+
+Authentication, registration and logout all take the same four collaborators,
+so the mocks live here rather than being re-declared per test class.
+"""
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.application.identity.dtos import TokenPairWithMetadata
+
+
+def make_token_pair() -> TokenPairWithMetadata:
+    """The token pair the token service hands back on a successful login."""
+    return TokenPairWithMetadata(
+        access_token="access",
+        refresh_token="refresh",
+        token_type="bearer",
+        expires_in=900,
+        jti="test-jti",
+        family_id="test-family",
+        refresh_token_expires_at=datetime.now(UTC) + timedelta(days=30),
+    )
+
+
+@pytest.fixture
+def user_repository() -> AsyncMock:
+    return AsyncMock()
+
+
+@pytest.fixture
+def password_service() -> MagicMock:
+    # Hashing is awaited (it runs on a worker thread); get_dummy_hash is not.
+    service = MagicMock()
+    service.hash_password = AsyncMock(return_value="hashed")
+    service.verify_password = AsyncMock(return_value=False)
+    return service
+
+
+@pytest.fixture
+def token_service() -> MagicMock:
+    return MagicMock()
+
+
+@pytest.fixture
+def refresh_token_repository() -> AsyncMock:
+    return AsyncMock()

--- a/backend/tests/unit/application/identity/commands/test_register_user_use_case.py
+++ b/backend/tests/unit/application/identity/commands/test_register_user_use_case.py
@@ -1,6 +1,5 @@
 """Tests for RegisterUserUseCase with token rotation."""
 
-from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -9,6 +8,7 @@ from src.application.identity.commands.register_user_use_case import RegisterUse
 from src.application.identity.dtos import TokenPairWithMetadata
 from src.domain.common.value_objects.ids import UserId
 from src.domain.identity.entities.user import User
+from tests.unit.application.identity.commands.conftest import make_token_pair
 
 
 def _make_user(user_id: int = 1) -> User:
@@ -21,39 +21,7 @@ def _make_user(user_id: int = 1) -> User:
     )
 
 
-def _make_token_pair() -> TokenPairWithMetadata:
-    return TokenPairWithMetadata(
-        access_token="access",
-        refresh_token="refresh",
-        token_type="bearer",
-        expires_in=900,
-        jti="test-jti",
-        family_id="test-family",
-        refresh_token_expires_at=datetime.now(UTC) + timedelta(days=30),
-    )
-
-
 class TestRegisterUserUseCase:
-    @pytest.fixture
-    def user_repository(self) -> AsyncMock:
-        return AsyncMock()
-
-    @pytest.fixture
-    def password_service(self) -> MagicMock:
-        # Hashing is awaited (it runs on a worker thread); get_dummy_hash is not.
-        service = MagicMock()
-        service.hash_password = AsyncMock(return_value="hashed")
-        service.verify_password = AsyncMock(return_value=False)
-        return service
-
-    @pytest.fixture
-    def token_service(self) -> MagicMock:
-        return MagicMock()
-
-    @pytest.fixture
-    def refresh_token_repository(self) -> AsyncMock:
-        return AsyncMock()
-
     @pytest.fixture
     def use_case(
         self,
@@ -80,7 +48,7 @@ class TestRegisterUserUseCase:
         password_service.hash_password.return_value = "hashed"
         user = _make_user()
         user_repository.save.return_value = user
-        token_pair = _make_token_pair()
+        token_pair = make_token_pair()
         token_service.create_token_pair.return_value = token_pair
         refresh_token_repository.save.return_value = MagicMock()
         return token_pair

--- a/backend/tests/unit/infrastructure/conftest.py
+++ b/backend/tests/unit/infrastructure/conftest.py
@@ -1,0 +1,75 @@
+"""Shared scaffolding for the infrastructure-level read-model tests.
+
+Every query test wires its query service against the real in-memory SQLite
+session, so they all need the same three things: the label resolution service
+the container injects, a second user to prove ownership scoping, and chapters
+to hang highlights off.
+"""
+
+from collections.abc import Awaitable, Callable
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.application.reading.services.label_resolution_service import LabelResolutionService
+from src.domain.reading.services.highlight_style_resolver import HighlightStyleResolver
+from src.infrastructure.reading.repositories.highlight_style_repository import (
+    HighlightStyleRepository,
+)
+from src.models import Book, Chapter, HighlightStyle, User
+from tests.conftest import create_test_chapter, create_test_highlight_style
+
+DEFAULT_USER_ID = 1
+OTHER_USER_ID = 2
+LABEL_TEXT = "Key idea"
+LABEL_UI_COLOR = "#ffcc00"
+
+AddChapter = Callable[..., Awaitable[Chapter]]
+
+
+@pytest.fixture
+def label_resolution_service(db_session: AsyncSession) -> LabelResolutionService:
+    """The label resolution service wired the way the container wires it."""
+    return LabelResolutionService(
+        highlight_style_repository=HighlightStyleRepository(db_session),
+        highlight_style_resolver=HighlightStyleResolver(),
+    )
+
+
+@pytest.fixture
+async def other_user(db_session: AsyncSession) -> User:
+    """A second user, to check ownership scoping."""
+    user = User(id=OTHER_USER_ID, email="other@test.com")
+    db_session.add(user)
+    await db_session.commit()
+    await db_session.refresh(user)
+    return user
+
+
+@pytest.fixture
+def add_chapter(db_session: AsyncSession) -> AddChapter:
+    """Attach a chapter to a book."""
+
+    async def _add_chapter(
+        book: Book,
+        name: str,
+        chapter_number: int | None = None,
+        parent_id: int | None = None,
+    ) -> Chapter:
+        return await create_test_chapter(db_session, book, name, chapter_number, parent_id)
+
+    return _add_chapter
+
+
+@pytest.fixture
+async def labelled_style(db_session: AsyncSession, test_book: Book) -> HighlightStyle:
+    """A style carrying the label the resolution service is expected to surface."""
+    return await create_test_highlight_style(
+        db_session=db_session,
+        user_id=DEFAULT_USER_ID,
+        book_id=test_book.id,
+        device_color="yellow",
+        device_style="lighten",
+        label=LABEL_TEXT,
+        ui_color=LABEL_UI_COLOR,
+    )

--- a/backend/tests/unit/infrastructure/jobs/queries/test_job_batch_query.py
+++ b/backend/tests/unit/infrastructure/jobs/queries/test_job_batch_query.py
@@ -52,15 +52,6 @@ async def add_batch(
     return batch
 
 
-async def add_other_user(db_session: AsyncSession) -> User:
-    """Create a second user to check ownership scoping."""
-    other = User(id=OTHER_USER_ID, email="other@test.com")
-    db_session.add(other)
-    await db_session.commit()
-    await db_session.refresh(other)
-    return other
-
-
 async def test_get_batch_returns_the_progress_counters(
     query: JobBatchQuery, db_session: AsyncSession
 ) -> None:
@@ -90,9 +81,8 @@ async def test_get_batch_returns_none_for_an_unknown_batch(query: JobBatchQuery)
 
 
 async def test_get_batch_hides_another_users_batch(
-    query: JobBatchQuery, db_session: AsyncSession
+    query: JobBatchQuery, db_session: AsyncSession, other_user: User
 ) -> None:
-    await add_other_user(db_session)
     batch = await add_batch(db_session, user_id=OTHER_USER_ID)
 
     assert await query.get_batch(JobBatchId(batch.id), UserId(DEFAULT_USER_ID)) is None
@@ -165,9 +155,8 @@ async def test_another_books_batch_is_not_returned(
 
 
 async def test_another_users_active_batch_is_invisible(
-    query: JobBatchQuery, db_session: AsyncSession
+    query: JobBatchQuery, db_session: AsyncSession, other_user: User
 ) -> None:
-    await add_other_user(db_session)
     await add_batch(db_session, status=JobBatchStatus.RUNNING, user_id=OTHER_USER_ID)
 
     view = await query.get_active_for_reference(

--- a/backend/tests/unit/infrastructure/learning/queries/test_book_flashcard_query.py
+++ b/backend/tests/unit/infrastructure/learning/queries/test_book_flashcard_query.py
@@ -7,42 +7,20 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.application.reading.services.label_resolution_service import LabelResolutionService
 from src.domain.common.value_objects.ids import BookId, UserId
-from src.domain.reading.services.highlight_style_resolver import HighlightStyleResolver
 from src.infrastructure.learning.queries.book_flashcard_query import BookFlashcardQuery
-from src.infrastructure.reading.repositories.highlight_style_repository import (
-    HighlightStyleRepository,
-)
-from src.models import Book, Chapter, Flashcard, Highlight, Note, Tag, User
-from tests.conftest import (
-    create_test_book,
-    create_test_highlight,
-    create_test_highlight_style,
-)
+from src.models import Book, Flashcard, Highlight, HighlightStyle, Note, Tag, User
+from tests.conftest import create_test_book, create_test_highlight
+from tests.unit.infrastructure.conftest import AddChapter
 
 DEFAULT_USER_ID = 1
-OTHER_USER_ID = 2
 
 
 @pytest.fixture
-def query(db_session: AsyncSession) -> BookFlashcardQuery:
+def query(
+    db_session: AsyncSession, label_resolution_service: LabelResolutionService
+) -> BookFlashcardQuery:
     """The query service wired the way the container wires it."""
-    return BookFlashcardQuery(
-        db=db_session,
-        label_resolution_service=LabelResolutionService(
-            highlight_style_repository=HighlightStyleRepository(db_session),
-            highlight_style_resolver=HighlightStyleResolver(),
-        ),
-    )
-
-
-@pytest.fixture
-async def other_user(db_session: AsyncSession) -> User:
-    """A second user, to check ownership scoping."""
-    user = User(id=OTHER_USER_ID, email="other@test.com")
-    db_session.add(user)
-    await db_session.commit()
-    await db_session.refresh(user)
-    return user
+    return BookFlashcardQuery(db=db_session, label_resolution_service=label_resolution_service)
 
 
 async def add_flashcard(
@@ -75,15 +53,28 @@ async def add_flashcard(
     return flashcard
 
 
-async def add_chapter(
-    db_session: AsyncSession, book: Book, name: str, chapter_number: int | None = None
-) -> Chapter:
-    """Attach a chapter to a book."""
-    chapter = Chapter(book_id=book.id, name=name, chapter_number=chapter_number)
-    db_session.add(chapter)
-    await db_session.commit()
-    await db_session.refresh(chapter)
-    return chapter
+async def add_highlight(
+    db_session: AsyncSession,
+    book: Book,
+    text: str,
+    chapter_id: int | None = None,
+    page: int | None = None,
+    user_id: int = DEFAULT_USER_ID,
+    highlight_style_id: int | None = None,
+    deleted_at: datetime | None = None,
+) -> Highlight:
+    """A highlight on the book, owned by the default user unless told otherwise."""
+    return await create_test_highlight(
+        db_session=db_session,
+        book=book,
+        user_id=user_id,
+        chapter_id=chapter_id,
+        text=text,
+        page=page,
+        datetime_str="2024-01-15 14:30:22",
+        highlight_style_id=highlight_style_id,
+        deleted_at=deleted_at,
+    )
 
 
 async def tag_highlight(
@@ -121,9 +112,9 @@ async def test_flashcards_come_back_newest_first(
 
 
 async def test_book_level_flashcard_has_no_highlight(
-    query: BookFlashcardQuery, db_session: AsyncSession, test_book: Book
+    query: BookFlashcardQuery, db_session: AsyncSession, test_book: Book, add_chapter: AddChapter
 ) -> None:
-    chapter = await add_chapter(db_session, test_book, "Chapter", chapter_number=1)
+    chapter = await add_chapter(test_book, "Chapter", chapter_number=1)
     await add_flashcard(db_session, test_book, chapter_id=chapter.id)
 
     view = await query.list_for_book(BookId(test_book.id), UserId(DEFAULT_USER_ID))
@@ -151,19 +142,11 @@ async def test_flashcard_made_from_a_note_carries_its_note_id(
 
 
 async def test_highlight_carries_its_chapter_and_tags(
-    query: BookFlashcardQuery,
-    db_session: AsyncSession,
-    test_book: Book,
+    query: BookFlashcardQuery, db_session: AsyncSession, test_book: Book, add_chapter: AddChapter
 ) -> None:
-    chapter = await add_chapter(db_session, test_book, "Crime", chapter_number=3)
-    highlight = await create_test_highlight(
-        db_session=db_session,
-        book=test_book,
-        user_id=DEFAULT_USER_ID,
-        chapter_id=chapter.id,
-        text="Highlighted text",
-        page=42,
-        datetime_str="2024-01-15 14:30:22",
+    chapter = await add_chapter(test_book, "Crime", chapter_number=3)
+    highlight = await add_highlight(
+        db_session, test_book, "Highlighted text", chapter_id=chapter.id, page=42
     )
     tag = await tag_highlight(db_session, test_book, highlight, "Motif")
     await add_flashcard(db_session, test_book, highlight=highlight)
@@ -187,25 +170,14 @@ async def test_highlight_carries_its_chapter_and_tags(
 
 
 async def test_label_comes_from_the_label_resolution_service(
-    query: BookFlashcardQuery, db_session: AsyncSession, test_book: Book
+    query: BookFlashcardQuery,
+    db_session: AsyncSession,
+    test_book: Book,
+    labelled_style: HighlightStyle,
 ) -> None:
     """The rule-derived label is resolved by the shared service, not re-encoded in SQL."""
-    style = await create_test_highlight_style(
-        db_session=db_session,
-        user_id=DEFAULT_USER_ID,
-        book_id=test_book.id,
-        device_color="yellow",
-        device_style="lighten",
-        label="Key idea",
-        ui_color="#ffcc00",
-    )
-    highlight = await create_test_highlight(
-        db_session=db_session,
-        book=test_book,
-        user_id=DEFAULT_USER_ID,
-        text="Labelled",
-        datetime_str="2024-01-15 14:30:22",
-        highlight_style_id=style.id,
+    highlight = await add_highlight(
+        db_session, test_book, "Labelled", highlight_style_id=labelled_style.id
     )
     await add_flashcard(db_session, test_book, highlight=highlight)
 
@@ -215,22 +187,16 @@ async def test_label_comes_from_the_label_resolution_service(
     assert embedded is not None
     assert embedded.label is not None
     assert (embedded.label.highlight_style_id, embedded.label.text, embedded.label.ui_color) == (
-        style.id,
-        "Key idea",
-        "#ffcc00",
+        labelled_style.id,
+        labelled_style.label,
+        labelled_style.ui_color,
     )
 
 
 async def test_unstyled_highlight_has_no_label(
     query: BookFlashcardQuery, db_session: AsyncSession, test_book: Book
 ) -> None:
-    highlight = await create_test_highlight(
-        db_session=db_session,
-        book=test_book,
-        user_id=DEFAULT_USER_ID,
-        text="Unstyled",
-        datetime_str="2024-01-15 14:30:22",
-    )
+    highlight = await add_highlight(db_session, test_book, "Unstyled")
     await add_flashcard(db_session, test_book, highlight=highlight)
 
     view = await query.list_for_book(BookId(test_book.id), UserId(DEFAULT_USER_ID))
@@ -243,14 +209,7 @@ async def test_unstyled_highlight_has_no_label(
 async def test_soft_deleted_highlight_keeps_its_id_but_is_not_rendered(
     query: BookFlashcardQuery, db_session: AsyncSession, test_book: Book
 ) -> None:
-    highlight = await create_test_highlight(
-        db_session=db_session,
-        book=test_book,
-        user_id=DEFAULT_USER_ID,
-        text="Gone",
-        datetime_str="2024-01-15 14:30:22",
-        deleted_at=datetime.now(UTC),
-    )
+    highlight = await add_highlight(db_session, test_book, "Gone", deleted_at=datetime.now(UTC))
     await add_flashcard(db_session, test_book, highlight=highlight)
 
     view = await query.list_for_book(BookId(test_book.id), UserId(DEFAULT_USER_ID))
@@ -268,13 +227,7 @@ async def test_highlight_owned_by_another_user_is_not_rendered(
     other_book = await create_test_book(
         db_session=db_session, user_id=other_user.id, title="Their book"
     )
-    their_highlight = await create_test_highlight(
-        db_session=db_session,
-        book=other_book,
-        user_id=other_user.id,
-        text="Theirs",
-        datetime_str="2024-01-15 14:30:22",
-    )
+    their_highlight = await add_highlight(db_session, other_book, "Theirs", user_id=other_user.id)
     await add_flashcard(db_session, test_book, highlight_id=their_highlight.id)
 
     view = await query.list_for_book(BookId(test_book.id), UserId(DEFAULT_USER_ID))

--- a/backend/tests/unit/infrastructure/library/queries/test_book_details_query.py
+++ b/backend/tests/unit/infrastructure/library/queries/test_book_details_query.py
@@ -7,58 +7,27 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.application.reading.services.label_resolution_service import LabelResolutionService
 from src.domain.common.value_objects.ids import BookId, UserId
-from src.domain.reading.services.highlight_style_resolver import HighlightStyleResolver
 from src.infrastructure.library.queries.book_details_query import BookDetailsQuery
-from src.infrastructure.reading.repositories.highlight_style_repository import (
-    HighlightStyleRepository,
-)
-from src.models import Book, Chapter, Flashcard, Note, User
-from tests.conftest import (
-    create_test_book,
-    create_test_highlight,
-    create_test_highlight_style,
-)
+from src.models import Book, Flashcard, HighlightStyle, Note, User
+from tests.conftest import create_test_book, create_test_highlight
+from tests.unit.infrastructure.conftest import AddChapter
 
 DEFAULT_USER_ID = 1
 
 
 @pytest.fixture
-def query(db_session: AsyncSession) -> BookDetailsQuery:
+def query(
+    db_session: AsyncSession, label_resolution_service: LabelResolutionService
+) -> BookDetailsQuery:
     """The query service wired the way the container wires it."""
-    return BookDetailsQuery(
-        db=db_session,
-        label_resolution_service=LabelResolutionService(
-            highlight_style_repository=HighlightStyleRepository(db_session),
-            highlight_style_resolver=HighlightStyleResolver(),
-        ),
-    )
-
-
-async def add_chapter(
-    db_session: AsyncSession, book: Book, name: str, chapter_number: int | None = None
-) -> Chapter:
-    """Attach a chapter to a book."""
-    chapter = Chapter(book_id=book.id, name=name, chapter_number=chapter_number)
-    db_session.add(chapter)
-    await db_session.commit()
-    await db_session.refresh(chapter)
-    return chapter
-
-
-async def add_other_user(db_session: AsyncSession) -> User:
-    """Create a second user to check ownership scoping."""
-    other = User(id=2, email="other@test.com")
-    db_session.add(other)
-    await db_session.commit()
-    await db_session.refresh(other)
-    return other
+    return BookDetailsQuery(db=db_session, label_resolution_service=label_resolution_service)
 
 
 async def test_chapters_without_highlights_still_appear(
-    query: BookDetailsQuery, db_session: AsyncSession, test_book: Book
+    query: BookDetailsQuery, db_session: AsyncSession, test_book: Book, add_chapter: AddChapter
 ) -> None:
-    first = await add_chapter(db_session, test_book, "With highlights", chapter_number=1)
-    await add_chapter(db_session, test_book, "Empty", chapter_number=2)
+    first = await add_chapter(test_book, "With highlights", chapter_number=1)
+    await add_chapter(test_book, "Empty", chapter_number=2)
     await create_test_highlight(
         db_session=db_session,
         book=test_book,
@@ -78,14 +47,14 @@ async def test_chapters_without_highlights_still_appear(
 
 
 async def test_highlight_group_for_a_chapter_outside_the_book_is_appended(
-    query: BookDetailsQuery, db_session: AsyncSession, test_book: Book
+    query: BookDetailsQuery, db_session: AsyncSession, test_book: Book, add_chapter: AddChapter
 ) -> None:
     """Groups whose chapter is not one of the book's chapters must not be dropped."""
-    own = await add_chapter(db_session, test_book, "Own chapter", chapter_number=1)
+    own = await add_chapter(test_book, "Own chapter", chapter_number=1)
     other_book = await create_test_book(
         db_session=db_session, user_id=DEFAULT_USER_ID, title="Other Book"
     )
-    stray = await add_chapter(db_session, other_book, "Stray chapter", chapter_number=9)
+    stray = await add_chapter(other_book, "Stray chapter", chapter_number=9)
     await create_test_highlight(
         db_session=db_session,
         book=test_book,
@@ -103,9 +72,9 @@ async def test_highlight_group_for_a_chapter_outside_the_book_is_appended(
 
 
 async def test_soft_deleted_highlights_are_excluded(
-    query: BookDetailsQuery, db_session: AsyncSession, test_book: Book
+    query: BookDetailsQuery, db_session: AsyncSession, test_book: Book, add_chapter: AddChapter
 ) -> None:
-    chapter = await add_chapter(db_session, test_book, "Chapter", chapter_number=1)
+    chapter = await add_chapter(test_book, "Chapter", chapter_number=1)
     await create_test_highlight(
         db_session=db_session,
         book=test_book,
@@ -131,9 +100,9 @@ async def test_soft_deleted_highlights_are_excluded(
 
 
 async def test_book_flashcards_exclude_highlight_cards(
-    query: BookDetailsQuery, db_session: AsyncSession, test_book: Book
+    query: BookDetailsQuery, db_session: AsyncSession, test_book: Book, add_chapter: AddChapter
 ) -> None:
-    chapter = await add_chapter(db_session, test_book, "Chapter", chapter_number=1)
+    chapter = await add_chapter(test_book, "Chapter", chapter_number=1)
     highlight = await create_test_highlight(
         db_session=db_session,
         book=test_book,
@@ -216,23 +185,24 @@ async def test_book_flashcards_carry_the_note_they_came_from(
 
 
 async def test_another_users_book_is_invisible(
-    query: BookDetailsQuery, db_session: AsyncSession, test_book: Book
+    query: BookDetailsQuery, test_book: Book, other_user: User
 ) -> None:
-    other = await add_other_user(db_session)
-
-    assert await query.get_book_details(BookId(test_book.id), UserId(other.id)) is None
+    assert await query.get_book_details(BookId(test_book.id), UserId(other_user.id)) is None
 
 
 async def test_another_users_highlights_are_invisible(
-    query: BookDetailsQuery, db_session: AsyncSession, test_book: Book
+    query: BookDetailsQuery,
+    db_session: AsyncSession,
+    test_book: Book,
+    add_chapter: AddChapter,
+    other_user: User,
 ) -> None:
     """A book is scoped to its owner, but highlight rows carry their own user_id."""
-    other = await add_other_user(db_session)
-    chapter = await add_chapter(db_session, test_book, "Chapter", chapter_number=1)
+    chapter = await add_chapter(test_book, "Chapter", chapter_number=1)
     await create_test_highlight(
         db_session=db_session,
         book=test_book,
-        user_id=other.id,
+        user_id=other_user.id,
         chapter_id=chapter.id,
         text="Not mine",
         datetime_str="2024-01-15 14:30:22",
@@ -245,19 +215,14 @@ async def test_another_users_highlights_are_invisible(
 
 
 async def test_labels_come_from_the_label_resolution_service(
-    query: BookDetailsQuery, db_session: AsyncSession, test_book: Book
+    query: BookDetailsQuery,
+    db_session: AsyncSession,
+    test_book: Book,
+    add_chapter: AddChapter,
+    labelled_style: HighlightStyle,
 ) -> None:
     """The rule-derived label is resolved by the shared service, not re-encoded in SQL."""
-    style = await create_test_highlight_style(
-        db_session=db_session,
-        user_id=DEFAULT_USER_ID,
-        book_id=test_book.id,
-        device_color="yellow",
-        device_style="lighten",
-        label="Key idea",
-        ui_color="#ffcc00",
-    )
-    chapter = await add_chapter(db_session, test_book, "Chapter", chapter_number=1)
+    chapter = await add_chapter(test_book, "Chapter", chapter_number=1)
     await create_test_highlight(
         db_session=db_session,
         book=test_book,
@@ -265,7 +230,7 @@ async def test_labels_come_from_the_label_resolution_service(
         chapter_id=chapter.id,
         text="Labelled",
         datetime_str="2024-01-15 14:30:22",
-        highlight_style_id=style.id,
+        highlight_style_id=labelled_style.id,
     )
 
     view = await query.get_book_details(BookId(test_book.id), UserId(DEFAULT_USER_ID))
@@ -274,7 +239,7 @@ async def test_labels_come_from_the_label_resolution_service(
     label = view.chapters[0].highlights[0].label
     assert label is not None
     assert (label.highlight_style_id, label.text, label.ui_color) == (
-        style.id,
-        "Key idea",
-        "#ffcc00",
+        labelled_style.id,
+        labelled_style.label,
+        labelled_style.ui_color,
     )

--- a/backend/tests/unit/infrastructure/library/queries/test_book_list_query.py
+++ b/backend/tests/unit/infrastructure/library/queries/test_book_list_query.py
@@ -20,15 +20,6 @@ def query(db_session: AsyncSession) -> BookListQuery:
     return BookListQuery(db=db_session)
 
 
-async def add_other_user(db_session: AsyncSession) -> User:
-    """Create a second user to check ownership scoping."""
-    other = User(id=OTHER_USER_ID, email="other@test.com")
-    db_session.add(other)
-    await db_session.commit()
-    await db_session.refresh(other)
-    return other
-
-
 async def add_flashcard(db_session: AsyncSession, book: Book, user_id: int) -> Flashcard:
     """Attach a flashcard to a book."""
     card = Flashcard(user_id=user_id, book_id=book.id, question="Q", answer="A")
@@ -42,6 +33,26 @@ async def mark_viewed(db_session: AsyncSession, book: Book, when: datetime) -> N
     """Stamp a book's last_viewed so it shows up in the recently-viewed list."""
     book.last_viewed = when
     await db_session.commit()
+
+
+async def add_one_of_each_countable(db_session: AsyncSession, book: Book) -> None:
+    """A live highlight, a soft-deleted one that must not be counted, and a flashcard."""
+    await create_test_highlight(
+        db_session=db_session,
+        book=book,
+        user_id=DEFAULT_USER_ID,
+        text="Kept",
+        datetime_str="2024-01-15 14:30:22",
+    )
+    await create_test_highlight(
+        db_session=db_session,
+        book=book,
+        user_id=DEFAULT_USER_ID,
+        text="Gone",
+        datetime_str="2024-01-15 14:31:22",
+        deleted_at=datetime(2024, 2, 1, tzinfo=UTC),
+    )
+    await add_flashcard(db_session, book, DEFAULT_USER_ID)
 
 
 async def test_books_are_ordered_by_title_with_zero_counts(
@@ -68,22 +79,7 @@ async def test_books_are_ordered_by_title_with_zero_counts(
 async def test_counts_exclude_soft_deleted_highlights(
     query: BookListQuery, db_session: AsyncSession, test_book: Book
 ) -> None:
-    await create_test_highlight(
-        db_session=db_session,
-        book=test_book,
-        user_id=DEFAULT_USER_ID,
-        text="Kept",
-        datetime_str="2024-01-15 14:30:22",
-    )
-    await create_test_highlight(
-        db_session=db_session,
-        book=test_book,
-        user_id=DEFAULT_USER_ID,
-        text="Gone",
-        datetime_str="2024-01-15 14:31:22",
-        deleted_at=datetime(2024, 2, 1, tzinfo=UTC),
-    )
-    await add_flashcard(db_session, test_book, DEFAULT_USER_ID)
+    await add_one_of_each_countable(db_session, test_book)
 
     page = await query.list_books(
         user_id=UserId(DEFAULT_USER_ID),
@@ -97,9 +93,8 @@ async def test_counts_exclude_soft_deleted_highlights(
 
 
 async def test_another_users_books_are_invisible(
-    query: BookListQuery, db_session: AsyncSession, test_book: Book
+    query: BookListQuery, db_session: AsyncSession, test_book: Book, other_user: User
 ) -> None:
-    await add_other_user(db_session)
     await create_test_book(db_session=db_session, user_id=OTHER_USER_ID, title="Not Mine")
 
     page = await query.list_books(
@@ -210,9 +205,8 @@ async def test_recently_viewed_skips_books_never_opened(
 
 
 async def test_recently_viewed_excludes_another_users_books(
-    query: BookListQuery, db_session: AsyncSession, test_book: Book
+    query: BookListQuery, db_session: AsyncSession, test_book: Book, other_user: User
 ) -> None:
-    await add_other_user(db_session)
     theirs = await create_test_book(db_session=db_session, user_id=OTHER_USER_ID, title="Not Mine")
     await mark_viewed(db_session, test_book, datetime(2024, 1, 1, tzinfo=UTC))
     await mark_viewed(db_session, theirs, datetime(2024, 6, 1, tzinfo=UTC))
@@ -237,22 +231,7 @@ async def test_recently_viewed_honours_the_limit(
 async def test_recently_viewed_carries_the_same_counts_as_the_library_list(
     query: BookListQuery, db_session: AsyncSession, test_book: Book
 ) -> None:
-    await create_test_highlight(
-        db_session=db_session,
-        book=test_book,
-        user_id=DEFAULT_USER_ID,
-        text="Kept",
-        datetime_str="2024-01-15 14:30:22",
-    )
-    await create_test_highlight(
-        db_session=db_session,
-        book=test_book,
-        user_id=DEFAULT_USER_ID,
-        text="Gone",
-        datetime_str="2024-01-15 14:31:22",
-        deleted_at=datetime(2024, 2, 1, tzinfo=UTC),
-    )
-    await add_flashcard(db_session, test_book, DEFAULT_USER_ID)
+    await add_one_of_each_countable(db_session, test_book)
     await mark_viewed(db_session, test_book, datetime(2024, 6, 1, tzinfo=UTC))
 
     books = await query.list_recently_viewed(user_id=UserId(DEFAULT_USER_ID), limit=10)

--- a/backend/tests/unit/infrastructure/library/services/test_epub_parser_service.py
+++ b/backend/tests/unit/infrastructure/library/services/test_epub_parser_service.py
@@ -10,6 +10,20 @@ from src.infrastructure.library.services.epub_parser_service import EpubParserSe
 FAKE_IMAGE = b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR fake image bytes"
 
 
+def _write_epub(book: epub.EpubBook, path: Path, filename: str) -> Path:
+    """Give the book the minimal chapter and navigation it needs, then write it out."""
+    chapter = epub.EpubHtml(title="Chapter 1", file_name="chap01.xhtml", lang="en")
+    chapter.content = b"<html><body><p>Hello</p></body></html>"
+    book.add_item(chapter)
+    book.spine = [chapter]
+    book.add_item(epub.EpubNcx())
+    book.add_item(epub.EpubNav())
+
+    epub_path = path / filename
+    epub.write_epub(str(epub_path), book)
+    return epub_path
+
+
 def _create_epub_with_cover_meta(path: Path) -> Path:
     """Create an EPUB where cover is declared via <meta name="cover" content="cover-img"/>
     but ebooklib's get_metadata("OPF", "cover") doesn't return it.
@@ -34,17 +48,7 @@ def _create_epub_with_cover_meta(path: Path) -> Path:
     # This is the standard EPUB 2 way: <meta name="cover" content="cover-img"/>
     book.add_metadata("OPF", "meta", None, {"name": "cover", "content": "cover-img"})
 
-    # Add a minimal chapter so the EPUB is valid
-    c1 = epub.EpubHtml(title="Chapter 1", file_name="chap01.xhtml", lang="en")
-    c1.content = b"<html><body><p>Hello</p></body></html>"
-    book.add_item(c1)
-    book.spine = [c1]
-    book.add_item(epub.EpubNcx())
-    book.add_item(epub.EpubNav())
-
-    epub_path = path / "cover_meta.epub"
-    epub.write_epub(str(epub_path), book)
-    return epub_path
+    return _write_epub(book, path, "cover_meta.epub")
 
 
 def _create_epub_without_cover(path: Path) -> Path:
@@ -54,16 +58,7 @@ def _create_epub_without_cover(path: Path) -> Path:
     book.set_title("No Cover")
     book.set_language("en")
 
-    c1 = epub.EpubHtml(title="Chapter 1", file_name="chap01.xhtml", lang="en")
-    c1.content = b"<html><body><p>Hello</p></body></html>"
-    book.add_item(c1)
-    book.spine = [c1]
-    book.add_item(epub.EpubNcx())
-    book.add_item(epub.EpubNav())
-
-    epub_path = path / "no_cover.epub"
-    epub.write_epub(str(epub_path), book)
-    return epub_path
+    return _write_epub(book, path, "no_cover.epub")
 
 
 @pytest.fixture

--- a/backend/tests/unit/infrastructure/notes/queries/test_note_query.py
+++ b/backend/tests/unit/infrastructure/notes/queries/test_note_query.py
@@ -18,6 +18,7 @@ from src.domain.notes.entities.note import NoteKind
 from src.infrastructure.notes.queries.note_query import NoteQuery
 from src.models import Book, Chapter, Flashcard, Highlight, Note, Tag, User
 from tests.conftest import create_test_book, create_test_highlight
+from tests.unit.infrastructure.conftest import AddChapter
 
 DEFAULT_USER_ID = 1
 OTHER_USER_ID = 2
@@ -29,16 +30,6 @@ AddNote = Callable[..., Awaitable[Note]]
 def query(db_session: AsyncSession) -> NoteQuery:
     """The query service wired the way the container wires it."""
     return NoteQuery(db=db_session)
-
-
-@pytest.fixture
-async def other_user(db_session: AsyncSession) -> User:
-    """A second user, to check ownership scoping."""
-    user = User(id=OTHER_USER_ID, email="other@test.com")
-    db_session.add(user)
-    await db_session.commit()
-    await db_session.refresh(user)
-    return user
 
 
 @pytest.fixture
@@ -73,15 +64,6 @@ def add_note(db_session: AsyncSession) -> AddNote:
     return _add_note
 
 
-async def add_chapter(db_session: AsyncSession, book: Book, name: str) -> Chapter:
-    """Attach a chapter to a book."""
-    chapter = Chapter(book_id=book.id, name=name)
-    db_session.add(chapter)
-    await db_session.commit()
-    await db_session.refresh(chapter)
-    return chapter
-
-
 async def add_tag(db_session: AsyncSession, book: Book, name: str, user_id: int) -> Tag:
     """Attach a tag to a book."""
     tag = Tag(book_id=book.id, user_id=user_id, name=name)
@@ -110,6 +92,16 @@ async def add_flashcard(
     await db_session.commit()
     await db_session.refresh(flashcard)
     return flashcard
+
+
+@pytest.fixture
+async def note_with_another_users_flashcard(
+    db_session: AsyncSession, test_book: Book, add_note: AddNote, other_user: User
+) -> Note:
+    """One of the viewer's notes, carrying a flashcard somebody else owns."""
+    note = await add_note(test_book)
+    await add_flashcard(db_session, test_book, note.id, "Theirs", user_id=OTHER_USER_ID)
+    return note
 
 
 class TestGetNote:
@@ -205,6 +197,7 @@ class TestGetNote:
         db_session: AsyncSession,
         test_book: Book,
         add_note: AddNote,
+        add_chapter: AddChapter,
         other_user: User,
     ) -> None:
         # A note may point at rows the viewer does not own; the API reports the
@@ -212,7 +205,7 @@ class TestGetNote:
         other_book = await create_test_book(
             db_session=db_session, user_id=OTHER_USER_ID, title="Theirs"
         )
-        other_chapter = await add_chapter(db_session, other_book, "Their chapter")
+        other_chapter = await add_chapter(other_book, "Their chapter")
         other_highlight = await create_test_highlight(
             db_session=db_session,
             book=other_book,
@@ -271,15 +264,9 @@ class TestGetNote:
         assert view.flashcards[0].note_id == note.id
 
     async def test_another_users_flashcard_on_the_note_is_invisible(
-        self,
-        query: NoteQuery,
-        db_session: AsyncSession,
-        test_book: Book,
-        add_note: AddNote,
-        other_user: User,
+        self, query: NoteQuery, note_with_another_users_flashcard: Note
     ) -> None:
-        note = await add_note(test_book)
-        await add_flashcard(db_session, test_book, note.id, "Theirs", user_id=OTHER_USER_ID)
+        note = note_with_another_users_flashcard
 
         view = await query.get_note(NoteId(note.id), UserId(DEFAULT_USER_ID))
 
@@ -336,16 +323,8 @@ class TestListForBook:
         ]
 
     async def test_another_users_flashcard_is_invisible_in_the_list(
-        self,
-        query: NoteQuery,
-        db_session: AsyncSession,
-        test_book: Book,
-        add_note: AddNote,
-        other_user: User,
+        self, query: NoteQuery, test_book: Book, note_with_another_users_flashcard: Note
     ) -> None:
-        note = await add_note(test_book)
-        await add_flashcard(db_session, test_book, note.id, "Theirs", user_id=OTHER_USER_ID)
-
         (view,) = await query.list_for_book(BookId(test_book.id), UserId(DEFAULT_USER_ID))
 
         assert view.flashcards == ()
@@ -365,12 +344,12 @@ class TestListForBook:
     async def test_filters_by_chapter(
         self,
         query: NoteQuery,
-        db_session: AsyncSession,
         test_book: Book,
         test_chapter: Chapter,
         add_note: AddNote,
+        add_chapter: AddChapter,
     ) -> None:
-        other_chapter = await add_chapter(db_session, test_book, "Elsewhere")
+        other_chapter = await add_chapter(test_book, "Elsewhere")
         await add_note(test_book, title="Linked", chapters=[test_chapter])
         await add_note(test_book, title="Unlinked", chapters=[other_chapter])
 
@@ -413,12 +392,12 @@ class TestListForBook:
     async def test_resolves_links_for_every_note_in_the_list(
         self,
         query: NoteQuery,
-        db_session: AsyncSession,
         test_book: Book,
         test_chapter: Chapter,
         add_note: AddNote,
+        add_chapter: AddChapter,
     ) -> None:
-        second_chapter = await add_chapter(db_session, test_book, "Second")
+        second_chapter = await add_chapter(test_book, "Second")
         await add_note(test_book, title="First", chapters=[test_chapter])
         await add_note(test_book, title="Second", chapters=[second_chapter])
 

--- a/backend/tests/unit/infrastructure/reading/queries/test_bookmark_query.py
+++ b/backend/tests/unit/infrastructure/reading/queries/test_bookmark_query.py
@@ -26,15 +26,6 @@ async def add_bookmark(db_session: AsyncSession, book: Book, highlight: Highligh
     return bookmark
 
 
-async def add_other_user(db_session: AsyncSession) -> User:
-    """Create a second user to check ownership scoping."""
-    other = User(id=2, email="other@test.com")
-    db_session.add(other)
-    await db_session.commit()
-    await db_session.refresh(other)
-    return other
-
-
 async def test_book_without_bookmarks_returns_empty_tuple(
     query: BookmarkQuery, test_book: Book
 ) -> None:
@@ -80,11 +71,11 @@ async def test_another_users_book_is_invisible(
     db_session: AsyncSession,
     test_book: Book,
     test_highlight: Highlight,
+    other_user: User,
 ) -> None:
     await add_bookmark(db_session, test_book, test_highlight)
-    other = await add_other_user(db_session)
 
-    assert await query.list_for_book(BookId(test_book.id), UserId(other.id)) is None
+    assert await query.list_for_book(BookId(test_book.id), UserId(other_user.id)) is None
 
 
 async def test_bookmarks_of_another_book_are_not_included(

--- a/backend/tests/unit/infrastructure/reading/queries/test_ereader_prereading_query.py
+++ b/backend/tests/unit/infrastructure/reading/queries/test_ereader_prereading_query.py
@@ -9,6 +9,7 @@ from src.domain.common.value_objects.ids import UserId
 from src.infrastructure.reading.queries.ereader_prereading_query import EreaderPrereadingQuery
 from src.models import Book, Chapter, ChapterPrereadingContent, User
 from tests.conftest import create_test_book
+from tests.unit.infrastructure.conftest import AddChapter
 
 DEFAULT_USER_ID = 1
 CLIENT_BOOK_ID = "koreader-book-1"
@@ -29,23 +30,6 @@ async def synced_book(db_session: AsyncSession) -> Book:
         title="Synced Book",
         client_book_id=CLIENT_BOOK_ID,
     )
-
-
-async def add_chapter(
-    db_session: AsyncSession,
-    book: Book,
-    name: str,
-    chapter_number: int | None = None,
-    parent_id: int | None = None,
-) -> Chapter:
-    """Attach a chapter to a book."""
-    chapter = Chapter(
-        book_id=book.id, name=name, chapter_number=chapter_number, parent_id=parent_id
-    )
-    db_session.add(chapter)
-    await db_session.commit()
-    await db_session.refresh(chapter)
-    return chapter
 
 
 async def add_prereading(
@@ -69,40 +53,37 @@ async def add_prereading(
     return content
 
 
-async def add_other_user(db_session: AsyncSession) -> User:
-    """Create a second user to check ownership scoping."""
-    other = User(id=2, email="other@test.com")
-    db_session.add(other)
-    await db_session.commit()
-    await db_session.refresh(other)
-    return other
-
-
 async def test_unknown_client_book_is_distinguished_from_one_without_prereading(
-    query: EreaderPrereadingQuery, db_session: AsyncSession, synced_book: Book
+    query: EreaderPrereadingQuery, synced_book: Book, add_chapter: AddChapter
 ) -> None:
-    await add_chapter(db_session, synced_book, "No prereading", chapter_number=1)
+    await add_chapter(synced_book, "No prereading", chapter_number=1)
 
     assert await query.list_for_client_book(CLIENT_BOOK_ID, UserId(DEFAULT_USER_ID)) == ()
     assert await query.list_for_client_book("unknown", UserId(DEFAULT_USER_ID)) is None
 
 
 async def test_another_users_book_is_invisible(
-    query: EreaderPrereadingQuery, db_session: AsyncSession, synced_book: Book
+    query: EreaderPrereadingQuery,
+    db_session: AsyncSession,
+    synced_book: Book,
+    add_chapter: AddChapter,
+    other_user: User,
 ) -> None:
-    chapter = await add_chapter(db_session, synced_book, "One", chapter_number=1)
+    chapter = await add_chapter(synced_book, "One", chapter_number=1)
     await add_prereading(db_session, chapter)
-    other = await add_other_user(db_session)
 
-    assert await query.list_for_client_book(CLIENT_BOOK_ID, UserId(other.id)) is None
+    assert await query.list_for_client_book(CLIENT_BOOK_ID, UserId(other_user.id)) is None
 
 
 async def test_only_chapters_with_prereading_are_listed_in_chapter_order(
-    query: EreaderPrereadingQuery, db_session: AsyncSession, synced_book: Book
+    query: EreaderPrereadingQuery,
+    db_session: AsyncSession,
+    synced_book: Book,
+    add_chapter: AddChapter,
 ) -> None:
-    third = await add_chapter(db_session, synced_book, "Third", chapter_number=3)
-    first = await add_chapter(db_session, synced_book, "First", chapter_number=1)
-    await add_chapter(db_session, synced_book, "Second", chapter_number=2)
+    third = await add_chapter(synced_book, "Third", chapter_number=3)
+    first = await add_chapter(synced_book, "First", chapter_number=1)
+    await add_chapter(synced_book, "Second", chapter_number=2)
     await add_prereading(db_session, third)
     await add_prereading(db_session, first)
 
@@ -113,9 +94,12 @@ async def test_only_chapters_with_prereading_are_listed_in_chapter_order(
 
 
 async def test_only_question_text_is_exposed_alongside_summary_and_keypoints(
-    query: EreaderPrereadingQuery, db_session: AsyncSession, synced_book: Book
+    query: EreaderPrereadingQuery,
+    db_session: AsyncSession,
+    synced_book: Book,
+    add_chapter: AddChapter,
 ) -> None:
-    chapter = await add_chapter(db_session, synced_book, "One", chapter_number=1)
+    chapter = await add_chapter(synced_book, "One", chapter_number=1)
     content = await add_prereading(db_session, chapter, summary="What this chapter covers")
 
     items = await query.list_for_client_book(CLIENT_BOOK_ID, UserId(DEFAULT_USER_ID))
@@ -131,12 +115,13 @@ async def test_only_question_text_is_exposed_alongside_summary_and_keypoints(
 
 
 async def test_a_nested_chapter_carries_its_parents_name(
-    query: EreaderPrereadingQuery, db_session: AsyncSession, synced_book: Book
+    query: EreaderPrereadingQuery,
+    db_session: AsyncSession,
+    synced_book: Book,
+    add_chapter: AddChapter,
 ) -> None:
-    part = await add_chapter(db_session, synced_book, "Part One", chapter_number=1)
-    nested = await add_chapter(
-        db_session, synced_book, "Chapter 1.1", chapter_number=2, parent_id=part.id
-    )
+    part = await add_chapter(synced_book, "Part One", chapter_number=1)
+    nested = await add_chapter(synced_book, "Chapter 1.1", chapter_number=2, parent_id=part.id)
     await add_prereading(db_session, nested)
 
     items = await query.list_for_client_book(CLIENT_BOOK_ID, UserId(DEFAULT_USER_ID))
@@ -146,9 +131,12 @@ async def test_a_nested_chapter_carries_its_parents_name(
 
 
 async def test_a_top_level_chapter_has_no_parent_name(
-    query: EreaderPrereadingQuery, db_session: AsyncSession, synced_book: Book
+    query: EreaderPrereadingQuery,
+    db_session: AsyncSession,
+    synced_book: Book,
+    add_chapter: AddChapter,
 ) -> None:
-    chapter = await add_chapter(db_session, synced_book, "One", chapter_number=1)
+    chapter = await add_chapter(synced_book, "One", chapter_number=1)
     await add_prereading(db_session, chapter)
 
     items = await query.list_for_client_book(CLIENT_BOOK_ID, UserId(DEFAULT_USER_ID))
@@ -158,7 +146,10 @@ async def test_a_top_level_chapter_has_no_parent_name(
 
 
 async def test_prereading_of_another_book_is_excluded(
-    query: EreaderPrereadingQuery, db_session: AsyncSession, synced_book: Book
+    query: EreaderPrereadingQuery,
+    db_session: AsyncSession,
+    synced_book: Book,
+    add_chapter: AddChapter,
 ) -> None:
     other_book = await create_test_book(
         db_session=db_session,
@@ -166,8 +157,8 @@ async def test_prereading_of_another_book_is_excluded(
         title="Other Book",
         client_book_id="koreader-book-2",
     )
-    mine = await add_chapter(db_session, synced_book, "Mine", chapter_number=1)
-    theirs = await add_chapter(db_session, other_book, "Theirs", chapter_number=1)
+    mine = await add_chapter(synced_book, "Mine", chapter_number=1)
+    theirs = await add_chapter(other_book, "Theirs", chapter_number=1)
     await add_prereading(db_session, mine)
     await add_prereading(db_session, theirs)
 

--- a/backend/tests/unit/infrastructure/reading/queries/test_highlight_label_query.py
+++ b/backend/tests/unit/infrastructure/reading/queries/test_highlight_label_query.py
@@ -7,11 +7,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.application.reading.services.label_resolution_service import LabelResolutionService
 from src.domain.common.value_objects.ids import BookId, UserId
-from src.domain.reading.services.highlight_style_resolver import HighlightStyleResolver
 from src.infrastructure.reading.queries.highlight_label_query import HighlightLabelQuery
-from src.infrastructure.reading.repositories.highlight_style_repository import (
-    HighlightStyleRepository,
-)
 from src.models import Book, HighlightStyle, User
 from tests.conftest import create_test_highlight, create_test_highlight_style
 
@@ -19,15 +15,11 @@ DEFAULT_USER_ID = 1
 
 
 @pytest.fixture
-def query(db_session: AsyncSession) -> HighlightLabelQuery:
+def query(
+    db_session: AsyncSession, label_resolution_service: LabelResolutionService
+) -> HighlightLabelQuery:
     """The query service wired the way the container wires it."""
-    return HighlightLabelQuery(
-        db=db_session,
-        label_resolution_service=LabelResolutionService(
-            highlight_style_repository=HighlightStyleRepository(db_session),
-            highlight_style_resolver=HighlightStyleResolver(),
-        ),
-    )
+    return HighlightLabelQuery(db=db_session, label_resolution_service=label_resolution_service)
 
 
 async def add_global_style(
@@ -51,15 +43,6 @@ async def add_global_style(
     return style
 
 
-async def add_other_user(db_session: AsyncSession) -> User:
-    """Create a second user to check ownership scoping."""
-    other = User(id=2, email="other@test.com")
-    db_session.add(other)
-    await db_session.commit()
-    await db_session.refresh(other)
-    return other
-
-
 async def test_missing_book_is_distinguished_from_a_book_without_labels(
     query: HighlightLabelQuery, test_book: Book
 ) -> None:
@@ -68,14 +51,13 @@ async def test_missing_book_is_distinguished_from_a_book_without_labels(
 
 
 async def test_another_users_book_is_invisible(
-    query: HighlightLabelQuery, db_session: AsyncSession, test_book: Book
+    query: HighlightLabelQuery, db_session: AsyncSession, test_book: Book, other_user: User
 ) -> None:
     await create_test_highlight_style(
         db_session=db_session, user_id=DEFAULT_USER_ID, book_id=test_book.id, label="Mine"
     )
-    other = await add_other_user(db_session)
 
-    assert await query.list_for_book(BookId(test_book.id), UserId(other.id)) is None
+    assert await query.list_for_book(BookId(test_book.id), UserId(other_user.id)) is None
 
 
 async def test_counts_live_highlights_per_style(
@@ -159,11 +141,10 @@ async def test_global_list_excludes_book_scoped_styles_and_reports_no_counts(
 
 
 async def test_global_list_is_scoped_to_the_user(
-    query: HighlightLabelQuery, db_session: AsyncSession
+    query: HighlightLabelQuery, db_session: AsyncSession, other_user: User
 ) -> None:
     await add_global_style(db_session, DEFAULT_USER_ID, label="Mine")
-    other = await add_other_user(db_session)
-    await add_global_style(db_session, other.id, device_color="red", label="Theirs")
+    await add_global_style(db_session, other_user.id, device_color="red", label="Theirs")
 
     labels = await query.list_global(UserId(DEFAULT_USER_ID))
 

--- a/backend/tests/unit/infrastructure/reading/queries/test_highlight_search_query.py
+++ b/backend/tests/unit/infrastructure/reading/queries/test_highlight_search_query.py
@@ -7,51 +7,48 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.application.reading.services.label_resolution_service import LabelResolutionService
 from src.domain.common.value_objects.ids import BookId, UserId
-from src.domain.reading.services.highlight_style_resolver import HighlightStyleResolver
 from src.infrastructure.reading.queries.highlight_search_query import HighlightSearchQuery
-from src.infrastructure.reading.repositories.highlight_style_repository import (
-    HighlightStyleRepository,
-)
-from src.models import Book, Chapter, Flashcard, Note, Tag, User
+from src.models import Book, Flashcard, Highlight, Note, Tag, User
 from tests.conftest import (
     create_test_book,
     create_test_highlight,
     create_test_highlight_style,
 )
+from tests.unit.infrastructure.conftest import AddChapter
 
 DEFAULT_USER_ID = 1
 
 
 @pytest.fixture
-def query(db_session: AsyncSession) -> HighlightSearchQuery:
+def query(
+    db_session: AsyncSession, label_resolution_service: LabelResolutionService
+) -> HighlightSearchQuery:
     """The query service wired the way the container wires it."""
-    return HighlightSearchQuery(
-        db=db_session,
-        label_resolution_service=LabelResolutionService(
-            highlight_style_repository=HighlightStyleRepository(db_session),
-            highlight_style_resolver=HighlightStyleResolver(),
-        ),
+    return HighlightSearchQuery(db=db_session, label_resolution_service=label_resolution_service)
+
+
+async def add_highlight(
+    db_session: AsyncSession,
+    book: Book,
+    text: str,
+    datetime_str: str,
+    chapter_id: int | None = None,
+    page: int | None = None,
+    deleted_at: datetime | None = None,
+    highlight_style_id: int | None = None,
+) -> Highlight:
+    """A matchable highlight on the book, owned by the default user."""
+    return await create_test_highlight(
+        db_session=db_session,
+        book=book,
+        user_id=DEFAULT_USER_ID,
+        text=text,
+        datetime_str=datetime_str,
+        chapter_id=chapter_id,
+        page=page,
+        deleted_at=deleted_at,
+        highlight_style_id=highlight_style_id,
     )
-
-
-async def add_chapter(
-    db_session: AsyncSession, book: Book, name: str, chapter_number: int | None = None
-) -> Chapter:
-    """Attach a chapter to a book."""
-    chapter = Chapter(book_id=book.id, name=name, chapter_number=chapter_number)
-    db_session.add(chapter)
-    await db_session.commit()
-    await db_session.refresh(chapter)
-    return chapter
-
-
-async def add_other_user(db_session: AsyncSession) -> User:
-    """Create a second user to check ownership scoping."""
-    other = User(id=2, email="other@test.com")
-    db_session.add(other)
-    await db_session.commit()
-    await db_session.refresh(other)
-    return other
 
 
 async def test_missing_book_is_distinguished_from_a_book_with_no_matches(
@@ -68,32 +65,29 @@ async def test_missing_book_is_distinguished_from_a_book_with_no_matches(
 
 
 async def test_another_users_book_is_invisible(
-    query: HighlightSearchQuery, db_session: AsyncSession, test_book: Book
+    query: HighlightSearchQuery, test_book: Book, other_user: User
 ) -> None:
-    other = await add_other_user(db_session)
-    assert await query.search_in_book(BookId(test_book.id), UserId(other.id), "needle") is None
+    assert await query.search_in_book(BookId(test_book.id), UserId(other_user.id), "needle") is None
 
 
 async def test_matches_are_grouped_by_chapter_in_chapter_number_order(
-    query: HighlightSearchQuery, db_session: AsyncSession, test_book: Book
+    query: HighlightSearchQuery, db_session: AsyncSession, test_book: Book, add_chapter: AddChapter
 ) -> None:
-    second = await add_chapter(db_session, test_book, "Second", chapter_number=2)
-    first = await add_chapter(db_session, test_book, "First", chapter_number=1)
-    await create_test_highlight(
-        db_session=db_session,
-        book=test_book,
-        user_id=DEFAULT_USER_ID,
-        text="needle in chapter two",
-        datetime_str="2024-01-01 10:00:00",
+    second = await add_chapter(test_book, "Second", chapter_number=2)
+    first = await add_chapter(test_book, "First", chapter_number=1)
+    await add_highlight(
+        db_session,
+        test_book,
+        "needle in chapter two",
+        "2024-01-01 10:00:00",
         chapter_id=second.id,
         page=5,
     )
-    await create_test_highlight(
-        db_session=db_session,
-        book=test_book,
-        user_id=DEFAULT_USER_ID,
-        text="needle in chapter one",
-        datetime_str="2024-01-02 10:00:00",
+    await add_highlight(
+        db_session,
+        test_book,
+        "needle in chapter one",
+        "2024-01-02 10:00:00",
         chapter_id=first.id,
         page=1,
     )
@@ -106,21 +100,16 @@ async def test_matches_are_grouped_by_chapter_in_chapter_number_order(
 
 
 async def test_a_chapters_own_timestamps_are_reported(
-    query: HighlightSearchQuery, db_session: AsyncSession, test_book: Book
+    query: HighlightSearchQuery, db_session: AsyncSession, test_book: Book, add_chapter: AddChapter
 ) -> None:
-    chapter = await add_chapter(db_session, test_book, "Renamed since", chapter_number=1)
+    chapter = await add_chapter(test_book, "Renamed since", chapter_number=1)
     # A chapter that was created once and edited later must report both times,
     # not the creation time twice.
     chapter.created_at = datetime(2024, 1, 1, tzinfo=UTC)
     chapter.updated_at = datetime(2024, 6, 30, tzinfo=UTC)
     await db_session.commit()
-    await create_test_highlight(
-        db_session=db_session,
-        book=test_book,
-        user_id=DEFAULT_USER_ID,
-        text="needle here",
-        datetime_str="2024-01-01 10:00:00",
-        chapter_id=chapter.id,
+    await add_highlight(
+        db_session, test_book, "needle here", "2024-01-01 10:00:00", chapter_id=chapter.id
     )
 
     view = await query.search_in_book(BookId(test_book.id), UserId(DEFAULT_USER_ID), "needle")
@@ -132,16 +121,15 @@ async def test_a_chapters_own_timestamps_are_reported(
 
 
 async def test_highlights_within_a_chapter_are_ordered_by_page(
-    query: HighlightSearchQuery, db_session: AsyncSession, test_book: Book
+    query: HighlightSearchQuery, db_session: AsyncSession, test_book: Book, add_chapter: AddChapter
 ) -> None:
-    chapter = await add_chapter(db_session, test_book, "Only", chapter_number=1)
+    chapter = await add_chapter(test_book, "Only", chapter_number=1)
     for page, text in ((9, "needle late"), (2, "needle early")):
-        await create_test_highlight(
-            db_session=db_session,
-            book=test_book,
-            user_id=DEFAULT_USER_ID,
-            text=text,
-            datetime_str=f"2024-01-0{page % 8 + 1} 10:00:00",
+        await add_highlight(
+            db_session,
+            test_book,
+            text,
+            f"2024-01-0{page % 8 + 1} 10:00:00",
             chapter_id=chapter.id,
             page=page,
         )
@@ -153,33 +141,21 @@ async def test_highlights_within_a_chapter_are_ordered_by_page(
 
 
 async def test_soft_deleted_and_chapterless_matches_are_excluded_from_rows_and_total(
-    query: HighlightSearchQuery, db_session: AsyncSession, test_book: Book
+    query: HighlightSearchQuery, db_session: AsyncSession, test_book: Book, add_chapter: AddChapter
 ) -> None:
-    chapter = await add_chapter(db_session, test_book, "Only", chapter_number=1)
-    await create_test_highlight(
-        db_session=db_session,
-        book=test_book,
-        user_id=DEFAULT_USER_ID,
-        text="needle kept",
-        datetime_str="2024-01-01 10:00:00",
-        chapter_id=chapter.id,
+    chapter = await add_chapter(test_book, "Only", chapter_number=1)
+    await add_highlight(
+        db_session, test_book, "needle kept", "2024-01-01 10:00:00", chapter_id=chapter.id
     )
-    await create_test_highlight(
-        db_session=db_session,
-        book=test_book,
-        user_id=DEFAULT_USER_ID,
-        text="needle deleted",
-        datetime_str="2024-01-02 10:00:00",
+    await add_highlight(
+        db_session,
+        test_book,
+        "needle deleted",
+        "2024-01-02 10:00:00",
         chapter_id=chapter.id,
         deleted_at=datetime.now(UTC),
     )
-    await create_test_highlight(
-        db_session=db_session,
-        book=test_book,
-        user_id=DEFAULT_USER_ID,
-        text="needle without a chapter",
-        datetime_str="2024-01-03 10:00:00",
-    )
+    await add_highlight(db_session, test_book, "needle without a chapter", "2024-01-03 10:00:00")
 
     view = await query.search_in_book(BookId(test_book.id), UserId(DEFAULT_USER_ID), "needle")
 
@@ -189,27 +165,21 @@ async def test_soft_deleted_and_chapterless_matches_are_excluded_from_rows_and_t
 
 
 async def test_matches_in_another_book_are_excluded(
-    query: HighlightSearchQuery, db_session: AsyncSession, test_book: Book
+    query: HighlightSearchQuery, db_session: AsyncSession, test_book: Book, add_chapter: AddChapter
 ) -> None:
     other_book = await create_test_book(
         db_session=db_session, user_id=DEFAULT_USER_ID, title="Other Book"
     )
-    chapter = await add_chapter(db_session, test_book, "Mine", chapter_number=1)
-    other_chapter = await add_chapter(db_session, other_book, "Theirs", chapter_number=1)
-    await create_test_highlight(
-        db_session=db_session,
-        book=test_book,
-        user_id=DEFAULT_USER_ID,
-        text="needle here",
-        datetime_str="2024-01-01 10:00:00",
-        chapter_id=chapter.id,
+    chapter = await add_chapter(test_book, "Mine", chapter_number=1)
+    other_chapter = await add_chapter(other_book, "Theirs", chapter_number=1)
+    await add_highlight(
+        db_session, test_book, "needle here", "2024-01-01 10:00:00", chapter_id=chapter.id
     )
-    await create_test_highlight(
-        db_session=db_session,
-        book=other_book,
-        user_id=DEFAULT_USER_ID,
-        text="needle elsewhere",
-        datetime_str="2024-01-02 10:00:00",
+    await add_highlight(
+        db_session,
+        other_book,
+        "needle elsewhere",
+        "2024-01-02 10:00:00",
         chapter_id=other_chapter.id,
     )
 
@@ -220,9 +190,9 @@ async def test_matches_in_another_book_are_excluded(
 
 
 async def test_tags_flashcards_and_the_resolved_label_ride_along(
-    query: HighlightSearchQuery, db_session: AsyncSession, test_book: Book
+    query: HighlightSearchQuery, db_session: AsyncSession, test_book: Book, add_chapter: AddChapter
 ) -> None:
-    chapter = await add_chapter(db_session, test_book, "Only", chapter_number=1)
+    chapter = await add_chapter(test_book, "Only", chapter_number=1)
     style = await create_test_highlight_style(
         db_session=db_session,
         user_id=DEFAULT_USER_ID,
@@ -230,12 +200,11 @@ async def test_tags_flashcards_and_the_resolved_label_ride_along(
         label="Key idea",
         ui_color="#123456",
     )
-    highlight = await create_test_highlight(
-        db_session=db_session,
-        book=test_book,
-        user_id=DEFAULT_USER_ID,
-        text="needle with context",
-        datetime_str="2024-01-01 10:00:00",
+    highlight = await add_highlight(
+        db_session,
+        test_book,
+        "needle with context",
+        "2024-01-01 10:00:00",
         chapter_id=chapter.id,
         highlight_style_id=style.id,
     )
@@ -276,16 +245,15 @@ async def test_tags_flashcards_and_the_resolved_label_ride_along(
 
 
 async def test_limit_caps_the_matches_before_grouping(
-    query: HighlightSearchQuery, db_session: AsyncSession, test_book: Book
+    query: HighlightSearchQuery, db_session: AsyncSession, test_book: Book, add_chapter: AddChapter
 ) -> None:
-    chapter = await add_chapter(db_session, test_book, "Only", chapter_number=1)
+    chapter = await add_chapter(test_book, "Only", chapter_number=1)
     for index in range(3):
-        await create_test_highlight(
-            db_session=db_session,
-            book=test_book,
-            user_id=DEFAULT_USER_ID,
-            text=f"needle {index}",
-            datetime_str=f"2024-01-0{index + 1} 10:00:00",
+        await add_highlight(
+            db_session,
+            test_book,
+            f"needle {index}",
+            f"2024-01-0{index + 1} 10:00:00",
             chapter_id=chapter.id,
         )
 
@@ -298,24 +266,14 @@ async def test_limit_caps_the_matches_before_grouping(
 
 
 async def test_like_wildcards_in_the_search_text_are_escaped(
-    query: HighlightSearchQuery, db_session: AsyncSession, test_book: Book
+    query: HighlightSearchQuery, db_session: AsyncSession, test_book: Book, add_chapter: AddChapter
 ) -> None:
-    chapter = await add_chapter(db_session, test_book, "Only", chapter_number=1)
-    await create_test_highlight(
-        db_session=db_session,
-        book=test_book,
-        user_id=DEFAULT_USER_ID,
-        text="a literal 100% match",
-        datetime_str="2024-01-01 10:00:00",
-        chapter_id=chapter.id,
+    chapter = await add_chapter(test_book, "Only", chapter_number=1)
+    await add_highlight(
+        db_session, test_book, "a literal 100% match", "2024-01-01 10:00:00", chapter_id=chapter.id
     )
-    await create_test_highlight(
-        db_session=db_session,
-        book=test_book,
-        user_id=DEFAULT_USER_ID,
-        text="no percent sign here",
-        datetime_str="2024-01-02 10:00:00",
-        chapter_id=chapter.id,
+    await add_highlight(
+        db_session, test_book, "no percent sign here", "2024-01-02 10:00:00", chapter_id=chapter.id
     )
 
     view = await query.search_in_book(BookId(test_book.id), UserId(DEFAULT_USER_ID), "100%")

--- a/backend/tests/unit/infrastructure/reading/queries/test_reading_session_query.py
+++ b/backend/tests/unit/infrastructure/reading/queries/test_reading_session_query.py
@@ -8,11 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from src.application.reading.services.label_resolution_service import LabelResolutionService
 from src.domain.common.value_objects import XPointRange
 from src.domain.common.value_objects.ids import BookId, UserId
-from src.domain.reading.services.highlight_style_resolver import HighlightStyleResolver
 from src.infrastructure.reading.queries.reading_session_query import ReadingSessionQuery
-from src.infrastructure.reading.repositories.highlight_style_repository import (
-    HighlightStyleRepository,
-)
 from src.models import Book, Highlight, ReadingSession, User
 from tests.conftest import create_test_book, create_test_highlight
 
@@ -61,16 +57,14 @@ def text_extraction_service() -> FakeTextExtractionService:
 @pytest.fixture
 def query(
     db_session: AsyncSession,
+    label_resolution_service: LabelResolutionService,
     file_repository: FakeFileRepository,
     text_extraction_service: FakeTextExtractionService,
 ) -> ReadingSessionQuery:
     """The query service wired the way the container wires it."""
     return ReadingSessionQuery(
         db=db_session,
-        label_resolution_service=LabelResolutionService(
-            highlight_style_repository=HighlightStyleRepository(db_session),
-            highlight_style_resolver=HighlightStyleResolver(),
-        ),
+        label_resolution_service=label_resolution_service,
         file_repository=file_repository,  # pyright: ignore[reportArgumentType]
         text_extraction_service=text_extraction_service,  # pyright: ignore[reportArgumentType]
     )
@@ -113,13 +107,30 @@ async def link(db_session: AsyncSession, session: ReadingSession, highlight: Hig
     await db_session.commit()
 
 
-async def add_other_user(db_session: AsyncSession) -> User:
-    """Create a second user to check ownership scoping."""
-    other = User(id=2, email="other@test.com")
-    db_session.add(other)
-    await db_session.commit()
-    await db_session.refresh(other)
-    return other
+async def add_highlight(
+    db_session: AsyncSession,
+    book: Book,
+    text: str,
+    datetime_str: str,
+    user_id: int = DEFAULT_USER_ID,
+    deleted_at: datetime | None = None,
+) -> Highlight:
+    """A highlight on the book, owned by the default user unless told otherwise."""
+    return await create_test_highlight(
+        db_session=db_session,
+        book=book,
+        user_id=user_id,
+        text=text,
+        datetime_str=datetime_str,
+        deleted_at=deleted_at,
+    )
+
+
+async def list_first_session_highlights(query: ReadingSessionQuery, book: Book) -> list[str]:
+    """The highlight texts of the book's first (newest) session."""
+    page = await query.list_for_book(BookId(book.id), UserId(DEFAULT_USER_ID), 30, 0)
+    assert page is not None
+    return [h.text for h in page.sessions[0].highlights]
 
 
 async def test_missing_book_is_distinguished_from_a_book_without_sessions(
@@ -137,10 +148,9 @@ async def test_missing_book_is_distinguished_from_a_book_without_sessions(
 
 
 async def test_another_users_book_is_invisible(
-    query: ReadingSessionQuery, db_session: AsyncSession, test_book: Book
+    query: ReadingSessionQuery, test_book: Book, other_user: User
 ) -> None:
-    other = await add_other_user(db_session)
-    assert await query.list_for_book(BookId(test_book.id), UserId(other.id), 30, 0) is None
+    assert await query.list_for_book(BookId(test_book.id), UserId(other_user.id), 30, 0) is None
 
 
 async def test_sessions_are_paginated_newest_first_with_an_unpaginated_total(
@@ -176,41 +186,22 @@ async def test_sessions_of_another_book_are_excluded(
 
 
 async def test_soft_deleted_and_other_users_highlights_are_excluded(
-    query: ReadingSessionQuery, db_session: AsyncSession, test_book: Book
+    query: ReadingSessionQuery, db_session: AsyncSession, test_book: Book, other_user: User
 ) -> None:
     session = await add_session(
         db_session, test_book, DEFAULT_USER_ID, datetime(2024, 1, 1, tzinfo=UTC)
     )
-    kept = await create_test_highlight(
-        db_session=db_session,
-        book=test_book,
-        user_id=DEFAULT_USER_ID,
-        text="Kept",
-        datetime_str="2024-01-01 10:00:00",
+    kept = await add_highlight(db_session, test_book, "Kept", "2024-01-01 10:00:00")
+    deleted = await add_highlight(
+        db_session, test_book, "Deleted", "2024-01-01 11:00:00", deleted_at=datetime.now(UTC)
     )
-    deleted = await create_test_highlight(
-        db_session=db_session,
-        book=test_book,
-        user_id=DEFAULT_USER_ID,
-        text="Deleted",
-        datetime_str="2024-01-01 11:00:00",
-        deleted_at=datetime.now(UTC),
-    )
-    other = await add_other_user(db_session)
-    theirs = await create_test_highlight(
-        db_session=db_session,
-        book=test_book,
-        user_id=other.id,
-        text="Theirs",
-        datetime_str="2024-01-01 12:00:00",
+    theirs = await add_highlight(
+        db_session, test_book, "Theirs", "2024-01-01 12:00:00", user_id=other_user.id
     )
     for highlight in (kept, deleted, theirs):
         await link(db_session, session, highlight)
 
-    page = await query.list_for_book(BookId(test_book.id), UserId(DEFAULT_USER_ID), 30, 0)
-
-    assert page is not None
-    assert [h.text for h in page.sessions[0].highlights] == ["Kept"]
+    assert await list_first_session_highlights(query, test_book) == ["Kept"]
 
 
 async def test_highlights_are_ordered_by_position_with_positionless_last(
@@ -221,21 +212,14 @@ async def test_highlights_are_ordered_by_position_with_positionless_last(
     )
     positions: list[list[int] | None] = [[9, 0], None, [2, 5], [2, 1]]
     for index, position in enumerate(positions):
-        highlight = await create_test_highlight(
-            db_session=db_session,
-            book=test_book,
-            user_id=DEFAULT_USER_ID,
-            text=f"Highlight {index}",
-            datetime_str=f"2024-01-01 1{index}:00:00",
+        highlight = await add_highlight(
+            db_session, test_book, f"Highlight {index}", f"2024-01-01 1{index}:00:00"
         )
         highlight.position = position
         await db_session.commit()
         await link(db_session, session, highlight)
 
-    page = await query.list_for_book(BookId(test_book.id), UserId(DEFAULT_USER_ID), 30, 0)
-
-    assert page is not None
-    assert [h.text for h in page.sessions[0].highlights] == [
+    assert await list_first_session_highlights(query, test_book) == [
         "Highlight 3",
         "Highlight 2",
         "Highlight 0",
@@ -296,16 +280,14 @@ async def test_content_is_none_without_an_epub_or_without_a_recorded_range(
 async def test_a_session_whose_extraction_fails_is_still_listed(
     db_session: AsyncSession,
     test_book: Book,
+    label_resolution_service: LabelResolutionService,
     file_repository: FakeFileRepository,
 ) -> None:
     await add_epub(db_session, test_book)
     await add_session(db_session, test_book, DEFAULT_USER_ID, datetime(2024, 1, 1, tzinfo=UTC))
     query = ReadingSessionQuery(
         db=db_session,
-        label_resolution_service=LabelResolutionService(
-            highlight_style_repository=HighlightStyleRepository(db_session),
-            highlight_style_resolver=HighlightStyleResolver(),
-        ),
+        label_resolution_service=label_resolution_service,
         file_repository=file_repository,  # pyright: ignore[reportArgumentType]
         text_extraction_service=FakeTextExtractionService(fail=True),  # pyright: ignore[reportArgumentType]
     )


### PR DESCRIPTION
`make duplication-check` reported 123 clones at 3.4%, with the unit tests as the densest cluster. This clears every unit-test clone but one and ratchets the threshold down to 2.9%.

## What the repetition was

Nine query-test modules each re-declared the same scaffolding: an `add_other_user` helper, an `add_chapter` helper, and a `query` fixture that hand-wired `LabelResolutionService(HighlightStyleRepository(...), HighlightStyleResolver())`.

## Changes

**Shared fixtures**
- `tests/unit/infrastructure/conftest.py` (new) — `label_resolution_service`, `other_user`, `add_chapter`, `labelled_style`. Each `query` fixture is now a single line.
- `tests/unit/application/identity/commands/conftest.py` (new) — the four collaborator mocks plus `make_token_pair()`, shared by the authenticate and register tests.
- `create_test_chapter` moves up into the root `tests/conftest.py`, so `test_ereader_prereading.py` shares it instead of keeping its own copy (13 call sites).

**Per-module extractions** for the duplication that stayed inside one file: local `add_highlight` wrappers in the search, session and flashcard query tests; `add_one_of_each_countable` (book list), `list_first_session_highlights` (reading session), `note_with_another_users_flashcard` (notes), `_write_epub` (EPUB parser).

## One clone left, deliberately

`test_highlight_label_query.py:1-10 ~ test_highlight_search_query.py:1-10` — the module docstring and import header. jscpd matches these because the import lines are structurally identical, not because anything was copy-pasted. Breaking it would mean reordering imports (ruff's isort owns that) or dropping type annotations; neither is worth it.

## Verification

- 641 tests pass
- `pyright` clean — 0 errors
- `ruff check` and `ruff format --check` clean
- `lint-imports` — 5/5 contracts kept
- duplication 3.4% → 2.84% (123 → 105 clones); threshold lowered 3.5 → 2.9

Net −301 lines across 18 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)