### PR TITLE
Keep crawlers out of the site

### DIFF
--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -271,6 +271,9 @@ class SecurityHeadersMiddleware:
                 headers["Permissions-Policy"] = (
                     "camera=(), microphone=(), geolocation=(), payment=()"
                 )
+                # robots.txt only asks crawlers not to fetch; this keeps URLs
+                # that leak out anyway from being indexed.
+                headers["X-Robots-Tag"] = "noindex, nofollow, noarchive"
                 if settings.ENVIRONMENT != "development":
                     headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
                     headers["Strict-Transport-Security"] = "max-age=31536000; includeSubDomains"

--- a/backend/tests/test_middleware_file_response.py
+++ b/backend/tests/test_middleware_file_response.py
@@ -87,6 +87,7 @@ async def test_request_id_and_security_headers_present(static_dir: Path) -> None
     assert response.headers.get("x-request-id")
     assert response.headers["x-content-type-options"] == "nosniff"
     assert response.headers["x-frame-options"] == "DENY"
+    assert response.headers["x-robots-tag"] == "noindex, nofollow, noarchive"
 
 
 @pytest.mark.asyncio

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <meta name="robots" content="noindex, nofollow, noarchive" />
 
     <!-- PWA Manifest -->
     <link rel="manifest" href="/manifest.json" />

--- a/frontend/public/robots.txt
+++ b/frontend/public/robots.txt
@@ -1,0 +1,3 @@
+# Crossbill is a private reading library — nothing here should be indexed.
+User-agent: *
+Disallow: /


### PR DESCRIPTION
Fixes #350

The site is a private reading library; nothing on it should be indexed.

- **`frontend/public/robots.txt`** (new) — disallow-all for every user agent. Vite copies `public/` into `dist/`, the Dockerfile copies that to `backend/static/`, and the SPA catch-all serves it as a real file (verified against an actual build).
- **`X-Robots-Tag: noindex, nofollow, noarchive`** in `SecurityHeadersMiddleware` — on every response, in every environment.
- **matching `<meta name="robots">`** in `index.html`.

robots.txt only asks crawlers not to *fetch*. Google will still index a URL it learns about elsewhere and list it with "no information available", so the header and meta tag are what actually keep pages out of the index.

Note for anything already indexed: `Disallow: /` blocks deindexing, because the crawler can't fetch the page to see the `noindex`. The header alone handles that case if it ever comes up.

## Testing

- `pytest` — 634 passed; the security-headers test now asserts `X-Robots-Tag` (confirmed it fails without the header).
- `pyright` clean.
- `vite build` — confirmed `dist/robots.txt` is emitted with the expected content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)