### PR TITLE
Let keyboard users reach dialog tabs

### DIFF
--- a/frontend/src/components/dialogs/DialogTabs.test.tsx
+++ b/frontend/src/components/dialogs/DialogTabs.test.tsx
@@ -1,0 +1,80 @@
+import { DialogTabs } from '@/components/dialogs/DialogTabs';
+import { useDialogHorizontalNavigation } from '@/components/dialogs/useDialogHorizontalNavigation';
+import { expect, test, vi } from 'vitest';
+import { render } from 'vitest-browser-react';
+import { userEvent } from 'vitest/browser';
+
+/**
+ * Stand-in for the entity detail modals: tabs nested inside a dialog whose
+ * arrow keys page to the previous/next entity.
+ */
+const NavigableDialog = ({ onNavigate }: { onNavigate: (newIndex: number) => void }) => {
+  const { swipeHandlers } = useDialogHorizontalNavigation({
+    open: true,
+    currentIndex: 1,
+    totalCount: 3,
+    onNavigate,
+  });
+
+  return (
+    <div>
+      <button type="button">Body control</button>
+      <DialogTabs
+        panelSwipeHandlers={swipeHandlers}
+        tabs={[
+          { key: 'notes', label: 'Notes', count: 1, content: <div>Linked notes</div> },
+          { key: 'flashcards', label: 'Flashcards', count: 2, content: <div>Flashcard list</div> },
+        ]}
+      />
+    </div>
+  );
+};
+
+/** Opens the dialog on the first tab and walks focus one tab to the right. */
+const renderAndArrowToSecondTab = async (onNavigate: (newIndex: number) => void) => {
+  const screen = await render(<NavigableDialog onNavigate={onNavigate} />);
+
+  await userEvent.click(screen.getByRole('tab', { name: 'Notes (1)' }));
+  await userEvent.keyboard('{ArrowRight}');
+
+  return screen;
+};
+
+test('arrow keys move between tabs instead of paging the dialog', async () => {
+  const onNavigate = vi.fn();
+  const screen = await renderAndArrowToSecondTab(onNavigate);
+
+  await expect.element(screen.getByRole('tab', { name: 'Flashcards (2)' })).toHaveFocus();
+  expect(onNavigate).not.toHaveBeenCalled();
+});
+
+test('a tab reached by keyboard can be activated to reveal its panel', async () => {
+  const onNavigate = vi.fn();
+  const screen = await renderAndArrowToSecondTab(onNavigate);
+
+  await userEvent.keyboard('{Enter}');
+
+  await expect.element(screen.getByText('Flashcard list')).toBeInTheDocument();
+  await expect.element(screen.getByText('Linked notes')).not.toBeInTheDocument();
+  expect(onNavigate).not.toHaveBeenCalled();
+});
+
+test('arrow keys outside the tab strip still page the dialog', async () => {
+  const onNavigate = vi.fn();
+  const screen = await render(<NavigableDialog onNavigate={onNavigate} />);
+
+  await userEvent.click(screen.getByRole('button', { name: 'Body control' }));
+  await userEvent.keyboard('{ArrowRight}');
+
+  expect(onNavigate).toHaveBeenCalledWith(2);
+});
+
+test('the panel is named by the tab that opened it', async () => {
+  const screen = await render(<NavigableDialog onNavigate={vi.fn()} />);
+
+  const panel = screen.getByRole('tabpanel');
+  const tab = screen.getByRole('tab', { name: 'Notes (1)' });
+
+  await expect.element(panel).toHaveAccessibleName('Notes (1)');
+  await expect.element(tab).toHaveAttribute('aria-controls', panel.element().id);
+});

--- a/frontend/src/components/dialogs/DialogTabs.tsx
+++ b/frontend/src/components/dialogs/DialogTabs.tsx
@@ -1,5 +1,5 @@
 import { Box, Tab, Tabs } from '@mui/material';
-import { type ReactNode, useState } from 'react';
+import { type ReactNode, useId, useState } from 'react';
 import type { SwipeableHandlers } from 'react-swipeable';
 
 export interface DialogTabItem {
@@ -39,6 +39,7 @@ export const DialogTabs = ({
   onTabChange,
 }: DialogTabsProps) => {
   const [internalTab, setInternalTab] = useState(0);
+  const instanceId = useId();
   const currentTab = activeTab ?? internalTab;
   const setTab = onTabChange ?? setInternalTab;
 
@@ -56,12 +57,26 @@ export const DialogTabs = ({
         onTouchStart={(e) => e.stopPropagation()}
         onTouchMove={(e) => e.stopPropagation()}
         onTouchEnd={(e) => e.stopPropagation()}
+        // Arrow keys belong to the tab strip while it holds focus; without this
+        // the enclosing modal steals them to page to the previous/next entity.
+        data-prevent-navigation="true"
       >
-        {tabs.map((tab) => (
-          <Tab key={tab.key} label={formatTabLabel(tab.label, tab.count)} />
+        {tabs.map((tab, index) => (
+          <Tab
+            key={tab.key}
+            id={`${instanceId}-tab-${index}`}
+            aria-controls={`${instanceId}-panel-${index}`}
+            label={formatTabLabel(tab.label, tab.count)}
+          />
         ))}
       </Tabs>
-      <Box sx={{ pt: 2, pb: 2 }} {...panelSwipeHandlers}>
+      <Box
+        role="tabpanel"
+        id={`${instanceId}-panel-${safeActiveTab}`}
+        aria-labelledby={`${instanceId}-tab-${safeActiveTab}`}
+        sx={{ pt: 2, pb: 2 }}
+        {...panelSwipeHandlers}
+      >
         {tabs[safeActiveTab]?.content}
       </Box>
     </Box>


### PR DESCRIPTION
Fixes #510

## Problem

The highlight / note / chapter detail modals bind ArrowLeft/ArrowRight on
`window` to page to the previous/next entity. That listener also fired while
focus sat on the modal's tab strip, so a keyboard user could never move focus
off the first tab — the Flashcards tab was unreachable without a pointer.

## Fix

- Mark the `Tabs` strip in `DialogTabs` with the existing
  `data-prevent-navigation` escape hatch (already used by `TagInput`), so
  `useDialogHorizontalNavigation` leaves arrow keys to the tab strip while it
  holds focus. Arrows outside the strip still page the dialog.
- While in there, pair each tab with its panel (`role="tabpanel"`, `id` /
  `aria-controls` / `aria-labelledby`), which the panel was missing.

Activation stays manual (arrows move focus, Enter/Space selects), matching the
ARIA tabs pattern.

## Tests

New `DialogTabs.test.tsx` drives a dialog-with-tabs harness in Chromium:
arrowing between tabs does not page the dialog, Enter opens the focused tab's
panel, arrows outside the strip still page, and the panel is named by its tab.
The two keyboard tests fail on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)