### PR TITLE
Quiet access logs for scanner and SPA traffic

### DIFF
--- a/backend/src/infrastructure/common/request_logging.py
+++ b/backend/src/infrastructure/common/request_logging.py
@@ -1,0 +1,28 @@
+"""Log-level policy for the request access log.
+
+Scanner probes and SPA deep links all land on the static/catch-all routes. At
+INFO they bury the API traffic that actually carries signal, so they are logged
+at DEBUG instead — unless the request failed with a server error.
+"""
+
+import logging
+
+SERVER_ERROR_STATUS = 500
+
+
+def is_api_path(path: str, api_prefix: str) -> bool:
+    """True when the path is handled by an API router rather than by static/SPA."""
+    prefix = api_prefix.rstrip("/")
+    return path == prefix or path.startswith(f"{prefix}/")
+
+
+def access_log_level(path: str, api_prefix: str, status_code: int | None = None) -> int:
+    """Level for the request_started / request_completed pair.
+
+    ``status_code`` is None on request_started, where the outcome isn't known yet.
+    """
+    if status_code is not None and status_code >= SERVER_ERROR_STATUS:
+        return logging.WARNING
+    if is_api_path(path, api_prefix):
+        return logging.INFO
+    return logging.DEBUG

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -33,6 +33,7 @@ from src.domain.common.exceptions import (
 from src.infrastructure.common.client_ip import client_ip, client_ip_from_scope, proxy_chain
 from src.infrastructure.common.openapi import operation_id
 from src.infrastructure.common.rate_limit import RateLimitMiddleware, limiter
+from src.infrastructure.common.request_logging import access_log_level
 from src.infrastructure.common.routers import settings as settings_router
 from src.infrastructure.identity.repositories.user_repository import UserRepository
 from src.infrastructure.identity.routers import auth, users
@@ -221,7 +222,10 @@ class RequestIdAndLoggingMiddleware:
         method = scope.get("method")
         path = scope.get("path")
 
-        logger.info(
+        log_path = path or ""
+
+        logger.log(
+            access_log_level(log_path, settings.API_V1_PREFIX),
             "request_started",
             method=method,
             path=path,
@@ -245,7 +249,8 @@ class RequestIdAndLoggingMiddleware:
             await self.app(scope, receive, wrapped_send)
         finally:
             duration = time.time() - start_time
-            logger.info(
+            logger.log(
+                access_log_level(log_path, settings.API_V1_PREFIX, status_code),
                 "request_completed",
                 method=method,
                 path=path,

--- a/backend/tests/test_request_logging.py
+++ b/backend/tests/test_request_logging.py
@@ -1,0 +1,81 @@
+"""Access-log levels: scanner and SPA traffic must not drown out API traffic."""
+
+import logging
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from src.config import get_settings
+from src.main import RequestIdAndLoggingMiddleware
+
+API_PREFIX = get_settings().API_V1_PREFIX
+ACCESS_LOG_EVENTS = ("request_started", "request_completed")
+
+
+@pytest.fixture
+def app() -> FastAPI:
+    application = FastAPI()
+    application.add_middleware(RequestIdAndLoggingMiddleware)
+
+    @application.get(f"{API_PREFIX}/books")
+    async def books() -> dict[str, str]:  # pyright: ignore[reportUnusedFunction]
+        return {"status": "ok"}
+
+    @application.get("/{full_path:path}")
+    async def spa(full_path: str) -> dict[str, str]:  # pyright: ignore[reportUnusedFunction]
+        if full_path == "boom":
+            raise RuntimeError("kaboom")
+        return {"status": "spa"}
+
+    return application
+
+
+async def _access_log_levels(
+    app: FastAPI, path: str, caplog: pytest.LogCaptureFixture
+) -> dict[str, int]:
+    caplog.set_level(logging.DEBUG)
+    caplog.clear()
+    transport = ASGITransport(app=app, raise_app_exceptions=False)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        await client.get(path)
+    return {
+        event: record.levelno
+        for record in caplog.records
+        for event in ACCESS_LOG_EVENTS
+        if event in record.getMessage()
+    }
+
+
+@pytest.mark.asyncio
+async def test_api_requests_are_logged_at_info(
+    app: FastAPI, caplog: pytest.LogCaptureFixture
+) -> None:
+    levels = await _access_log_levels(app, f"{API_PREFIX}/books", caplog)
+
+    assert levels == {
+        "request_started": logging.INFO,
+        "request_completed": logging.INFO,
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("path", ["/.env", "/wp-admin/setup-config.php", "/books/42"])
+async def test_static_and_spa_requests_are_logged_at_debug(
+    app: FastAPI, caplog: pytest.LogCaptureFixture, path: str
+) -> None:
+    levels = await _access_log_levels(app, path, caplog)
+
+    assert levels == {
+        "request_started": logging.DEBUG,
+        "request_completed": logging.DEBUG,
+    }
+
+
+@pytest.mark.asyncio
+async def test_server_errors_stay_visible_on_quiet_paths(
+    app: FastAPI, caplog: pytest.LogCaptureFixture
+) -> None:
+    levels = await _access_log_levels(app, "/boom", caplog)
+
+    assert levels["request_completed"] == logging.WARNING


### PR DESCRIPTION
Fixes #342

## Problem

`RequestIdAndLoggingMiddleware` emitted `request_started` / `request_completed` at INFO for **every** request. Path-scanning bots hitting the SPA catch-all (hundreds of probes in a burst) looked like API spikes and buried the traffic that actually carries signal.

## Change

New `src/infrastructure/common/request_logging.py` holds the level policy:

| request | level |
| --- | --- |
| completed with a 5xx (any path) | WARNING |
| path under `API_V1_PREFIX` | INFO |
| everything else | DEBUG |

The middleware now calls `logger.log(access_log_level(...), ...)` for both events.

Every registered router lives under `/api/v1`, so "not an API path" is exactly the `/assets` mount, the SPA catch-all, and scanner probes — the noise the ticket targets. `/health` (the Railway probe) falls into the same bucket. In production (`level=INFO`) those lines disappear; in development everything is still visible at DEBUG.

Note: #341, the scanner short-circuit this was meant to pair with, was closed as not planned — this change stands on its own and doesn't depend on it.

## Tests

`tests/test_request_logging.py` drives real requests through the middleware and asserts the captured record levels: API path → INFO, `/.env` / `/wp-admin/setup-config.php` / `/books/42` → DEBUG, a 5xx on a quiet path → WARNING. Verified the tests fail when the policy is broken.

Full backend suite (639 tests), `pyright`, `ruff check`, `ruff format --check`, and `lint-imports` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)