### PR TITLE
Build the site with Node 24 in the Pages deploy

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -29,6 +29,8 @@ jobs:
         uses: withastro/action@v3
         with:
           path: site
+          # Astro 7 needs Node >= 22.12; the action defaults to 20.
+          node-version: 24
 
   deploy:
     needs: build


### PR DESCRIPTION
The Pages deploy failed on main: withastro/action defaults to Node 20, and Astro 7 requires >= 22.12. Pin the action's node-version to 24 (current LTS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)