### PR TITLE
Use a Postgres image that provides the vector extension

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -2,7 +2,9 @@
 # Frontend and backend run on the host.
 services:
   postgres:
-    image: postgres:18-alpine
+    # pgvector/pgvector:pgNN is the official Postgres image plus the `vector`
+    # extension, required by the semantic-search embeddings table.
+    image: pgvector/pgvector:pg18
     container_name: crossbill-postgres
     restart: unless-stopped
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,9 @@
 # Deployment sample config
 services:
   postgres:
-    image: postgres:18-alpine
+    # pgvector/pgvector:pgNN is the official Postgres image plus the `vector`
+    # extension, required by the semantic-search embeddings table.
+    image: pgvector/pgvector:pg18
     container_name: crossbill-postgres
     restart: unless-stopped
     ports:


### PR DESCRIPTION
Points both compose files at `pgvector/pgvector:pg18` — the official Postgres image plus the `vector` extension.

Split out of #532 so it can land and be rolled out ahead of the feature that needs it.

### Why it can't wait for that PR

Migration `062` there runs `CREATE EXTENSION IF NOT EXISTS vector`. The stock `postgres:18-alpine` has no way to satisfy that, so `alembic upgrade head` against a dev or self-host database built from these files **fails outright** rather than leaving the feature switched off.

That makes the order load-bearing: **this should merge before #532.**

### Compatibility

- Same PG major, so an existing volume keeps working — no dump/restore.
- Railway's managed Postgres provides pgvector separately and is unaffected. Production wiring is still deferred.
- No application code changes, and CI's test suite runs on SQLite, so there is nothing here for it to exercise.

### Verified

The image ships **pgvector 0.8.6**, checked against a running container:

```
$ psql -tAc "select default_version, installed_version
             from pg_available_extensions where name='vector'"
0.8.6|0.8.6
```

That matters beyond "the extension exists": #532's read path sets `hnsw.iterative_scan`, which needs pgvector 0.8 or newer, so this image satisfies it with room to spare.

🤖 Generated with [Claude Code](https://claude.com/claude-code)