### PR TITLE
Accept a provider-issued postgres:// database URL

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -8,6 +8,7 @@ from alembic import context
 # add your model's MetaData object here
 # for 'autogenerate' support
 # Import your models here to enable autogenerate
+from src.config import normalize_database_url
 from src.models import Base
 
 # this is the Alembic Config object, which provides
@@ -21,9 +22,12 @@ if config.config_file_name is not None:
 
 target_metadata = Base.metadata
 
-# Get database URL from environment variable
-database_url = os.getenv(
-    "DATABASE_URL", "postgresql://crossbill:crossbill_dev_password@localhost:5432/crossbill"
+# Get database URL from environment variable. Read here rather than through
+# Settings, so the scheme has to be normalized again on this path.
+database_url = normalize_database_url(
+    os.getenv(
+        "DATABASE_URL", "postgresql://crossbill:crossbill_dev_password@localhost:5432/crossbill"
+    )
 )
 if database_url:
     config.set_main_option("sqlalchemy.url", database_url)

--- a/backend/src/config.py
+++ b/backend/src/config.py
@@ -19,6 +19,19 @@ BOOK_COVERS_DIR = BOOK_FILES_DIR / "book-covers"
 EPUBS_DIR = BOOK_FILES_DIR / "epubs"
 
 
+def normalize_database_url(url: str) -> str:
+    """Rewrite the legacy `postgres://` scheme to the `postgresql://` SQLAlchemy needs.
+
+    Hosted Postgres providers still hand out `postgres://` URLs — Railway's pgvector
+    image is one — but SQLAlchemy dropped that dialect alias in 1.4 and fails the whole
+    process with `NoSuchModuleError`. Normalizing at the edge keeps every consumer
+    (engine, Alembic, SAQ) working whichever spelling the provider chose.
+    """
+    if url.startswith("postgres://"):
+        return url.replace("postgres://", "postgresql://", 1)
+    return url
+
+
 class Settings(BaseSettings):
     """Application settings."""
 
@@ -162,6 +175,12 @@ class Settings(BaseSettings):
             and self.S3_SECRET_ACCESS_KEY is not None
             and self.S3_BUCKET_NAME is not None
         )
+
+    @field_validator("DATABASE_URL", mode="after")
+    @classmethod
+    def normalize_database_scheme(cls, value: str) -> str:
+        """Accept a provider-issued `postgres://` URL without breaking SQLAlchemy."""
+        return normalize_database_url(value)
 
     @field_validator("ADMIN_PASSWORD", mode="after")
     @classmethod

--- a/backend/src/database.py
+++ b/backend/src/database.py
@@ -15,7 +15,7 @@ from sqlalchemy.ext.asyncio import (
 from sqlalchemy.orm import DeclarativeBase
 from sqlalchemy.pool import StaticPool
 
-from src.config import Settings, get_settings
+from src.config import Settings, get_settings, normalize_database_url
 
 
 class Base(DeclarativeBase):
@@ -27,8 +27,9 @@ _engine: AsyncEngine | None = None
 _session_factory: async_sessionmaker[AsyncSession] | None = None
 
 
-def _make_async_url(url: str) -> str:
+def make_async_url(url: str) -> str:
     """Convert a database URL to its async-compatible dialect."""
+    url = normalize_database_url(url)
     if url.startswith("sqlite://"):
         return url.replace("sqlite://", "sqlite+aiosqlite://", 1)
     if url.startswith("postgresql://"):
@@ -48,7 +49,7 @@ def initialize_database(settings: Settings) -> None:
     if _engine is not None:
         return
 
-    async_url = _make_async_url(settings.DATABASE_URL)
+    async_url = make_async_url(settings.DATABASE_URL)
 
     # Connection pool configuration
     if async_url.startswith("sqlite"):

--- a/backend/tests/unit/test_database_url.py
+++ b/backend/tests/unit/test_database_url.py
@@ -1,0 +1,77 @@
+"""Tests for database URL scheme handling.
+
+Hosted providers hand out `postgres://` URLs that SQLAlchemy refuses to load, which
+takes down the whole process at startup. These cover both paths that build an engine
+URL: application settings and Alembic's own environment read.
+"""
+
+import pytest
+from sqlalchemy.engine.url import make_url
+
+from src.config import Settings, normalize_database_url
+from src.database import make_async_url
+
+
+class TestNormalizeDatabaseUrl:
+    def test_legacy_postgres_scheme_is_rewritten(self) -> None:
+        assert (
+            normalize_database_url("postgres://user:pw@host:5432/db")
+            == "postgresql://user:pw@host:5432/db"
+        )
+
+    def test_canonical_postgresql_scheme_is_untouched(self) -> None:
+        url = "postgresql://user:pw@host:5432/db"
+        assert normalize_database_url(url) == url
+
+    def test_sqlite_url_is_untouched(self) -> None:
+        url = "sqlite+aiosqlite:///:memory:"
+        assert normalize_database_url(url) == url
+
+    def test_driver_qualified_postgres_url_is_untouched(self) -> None:
+        url = "postgresql+psycopg://user:pw@host:5432/db"
+        assert normalize_database_url(url) == url
+
+    def test_only_the_scheme_is_rewritten(self) -> None:
+        """A password or query value may itself contain the legacy prefix."""
+        normalized = normalize_database_url("postgres://user:postgres://@host:5432/db")
+        assert normalized == "postgresql://user:postgres://@host:5432/db"
+
+
+class TestSettingsNormalizeDatabaseUrl:
+    def test_settings_normalizes_a_legacy_url(self) -> None:
+        settings = Settings(  # type: ignore[call-arg]
+            SECRET_KEY="test-secret-key-at-least-32-bytes-long",
+            REFRESH_TOKEN_SECRET_KEY="test-refresh-token-secret-key-at-least-32-bytes-long",
+            ADMIN_PASSWORD="test-admin-password",
+            DATABASE_URL="postgres://user:pw@host:5432/db",
+        )
+        assert settings.DATABASE_URL == "postgresql://user:pw@host:5432/db"
+
+
+class TestMakeAsyncUrl:
+    def test_legacy_postgres_url_becomes_an_async_driver_url(self) -> None:
+        assert (
+            make_async_url("postgres://user:pw@host:5432/db")
+            == "postgresql+psycopg://user:pw@host:5432/db"
+        )
+
+    def test_postgresql_url_becomes_an_async_driver_url(self) -> None:
+        assert (
+            make_async_url("postgresql://user:pw@host:5432/db")
+            == "postgresql+psycopg://user:pw@host:5432/db"
+        )
+
+    def test_sqlite_url_becomes_an_async_driver_url(self) -> None:
+        assert make_async_url("sqlite:///./app.db") == "sqlite+aiosqlite:///./app.db"
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "postgres://user:pw@host:5432/db",
+            "postgresql://user:pw@host:5432/db",
+            "sqlite:///./app.db",
+        ],
+    )
+    def test_result_resolves_to_a_real_dialect(self, url: str) -> None:
+        """The production failure was NoSuchModuleError raised from dialect lookup."""
+        make_url(make_async_url(url)).get_dialect()


### PR DESCRIPTION
## Why

Railway's pgvector service hands out `DATABASE_URL` with the legacy **`postgres://`** scheme; the old Postgres service used `postgresql://`. SQLAlchemy dropped the `postgres` dialect alias in 1.4, and nothing here normalized it — so pointing the app at pgvector took production down with:

```
sqlalchemy.exc.NoSuchModuleError: Can't load plugin: sqlalchemy.dialects:postgres
```

It surfaced from `alembic upgrade head`, which the Dockerfile CMD runs before uvicorn, so the container crash-looped instead of starting degraded. Railway still reported the deployment as `SUCCESS` — that's a *build* status — which made it easy to misread as a healthy deploy.

## What

Normalize the scheme at both edges that build an engine URL:

- **`Settings`** — a `DATABASE_URL` validator, covering the engine and SAQ.
- **`alembic/env.py`** — reads `os.getenv("DATABASE_URL")` directly and so never passes through `Settings`. This is the path that actually crashed.

SAQ needed no change; `Queue.from_url` dispatches on `scheme.startswith("postgres")` and already accepted both spellings.

`_make_async_url` → `make_async_url`, now that it's covered directly.

## Verification

Against a real local Postgres, with `DATABASE_URL=postgres://…`:

| | `alembic current` |
|---|---|
| before | `NoSuchModuleError: Can't load plugin: sqlalchemy.dialects:postgres` |
| after | loads the dialect, connects, reads `alembic_version` |

12 new unit tests in `tests/unit/test_database_url.py` cover the normalizer, the `Settings` validator, and `make_async_url` — including that only the *scheme* is rewritten (a password may itself contain `postgres://`) and that the result resolves to a real SQLAlchemy dialect, which is the assertion that reproduces the outage. Reverting the normalizer fails 5 of them.

Full suite: 651 passed. pyright, ruff, ruff format and import-linter all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)