### PR TITLE
Embed content automatically on create and edit

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -138,6 +138,27 @@ ALLOW_USER_REGISTRATIONS=false
 # AI_MODEL_NAME=minimax/minimax-m2.5   # or any OpenRouter model slug
 # OPENROUTER_API_KEY=<apikey here>
 
+# Semantic search (optional). Off unless EMBEDDING_PROVIDER is set, and
+# independent of the AI_* settings above — embeddings and text generation can
+# use different providers.
+
+# Local, via Ollama (EMBEDDING_BASE_URL required)
+# EMBEDDING_PROVIDER=ollama
+# EMBEDDING_MODEL_NAME=bge-m3
+# EMBEDDING_BASE_URL=http://localhost:11434/v1
+
+# Hosted, via OpenRouter (reuses OPENROUTER_API_KEY above; EMBEDDING_BASE_URL
+# optional, defaults to https://openrouter.ai/api/v1)
+# EMBEDDING_PROVIDER=openrouter
+# EMBEDDING_MODEL_NAME=baai/bge-m3
+
+# Stored with every vector — bump it to force a re-embed on the next backfill.
+# EMBEDDING_MODEL_VERSION=1
+
+# The vector width is fixed at 1024 (bge-m3) by the database column, so a model
+# of another dimension means a migration plus a full re-embed, not a setting
+# change. Requires pgvector 0.8+ (the bundled pgvector/pgvector:pg18 ships 0.8.6).
+
 # Background worker
 # By default the app runs the SAQ worker in-process (embedded mode).
 # Set EMBEDDED_WORKER=false to disable it and run a separate worker container instead.

--- a/backend/.jscpd.json
+++ b/backend/.jscpd.json
@@ -12,5 +12,5 @@
   "minLines": 5,
   "minTokens": 50,
   "reporters": ["ai", "threshold"],
-  "threshold": 2.66
+  "threshold": 2.6
 }

--- a/backend/src/application/notes/commands/create_note_use_case.py
+++ b/backend/src/application/notes/commands/create_note_use_case.py
@@ -77,8 +77,6 @@ class CreateNoteUseCase:
         )
         note = await self.note_repository.save(note)
 
-        # After the save, never before: the repository commits, so a job picked
-        # up the instant it is enqueued still reads the note that was written.
         await self._embedding_enqueuer.enqueue_for(ContentType.NOTE, note.id.value, user_id)
 
         logger.info("created_note", note_id=note.id.value, book_id=book_id)

--- a/backend/src/application/notes/commands/create_note_use_case.py
+++ b/backend/src/application/notes/commands/create_note_use_case.py
@@ -8,6 +8,8 @@ from src.application.library.protocols.chapter_repository import ChapterReposito
 from src.application.notes.commands.helpers import parse_note_kind, validate_link_targets
 from src.application.notes.protocols.note_repository import NoteRepositoryProtocol
 from src.application.reading.protocols.highlight_repository import HighlightRepositoryProtocol
+from src.application.semantic.content_type import ContentType
+from src.application.semantic.protocols.embedding_enqueuer import EmbeddingEnqueuerProtocol
 from src.application.tagging.protocols.tag_repository import (
     TagRepositoryProtocol,
 )
@@ -27,12 +29,14 @@ class CreateNoteUseCase:
         chapter_repository: ChapterRepositoryProtocol,
         highlight_repository: HighlightRepositoryProtocol,
         tag_repository: TagRepositoryProtocol,
+        embedding_enqueuer: EmbeddingEnqueuerProtocol,
     ) -> None:
         self.note_repository = note_repository
         self.book_repository = book_repository
         self.chapter_repository = chapter_repository
         self.highlight_repository = highlight_repository
         self.tag_repository = tag_repository
+        self._embedding_enqueuer = embedding_enqueuer
 
     async def create_note(
         self,
@@ -72,6 +76,10 @@ class CreateNoteUseCase:
             tag_ids=tag_ids,
         )
         note = await self.note_repository.save(note)
+
+        # After the save, never before: the repository commits, so a job picked
+        # up the instant it is enqueued still reads the note that was written.
+        await self._embedding_enqueuer.enqueue_for(ContentType.NOTE, note.id.value, user_id)
 
         logger.info("created_note", note_id=note.id.value, book_id=book_id)
         return note

--- a/backend/src/application/notes/commands/update_note_use_case.py
+++ b/backend/src/application/notes/commands/update_note_use_case.py
@@ -6,6 +6,8 @@ from src.application.library.protocols.chapter_repository import ChapterReposito
 from src.application.notes.commands.helpers import parse_note_kind, validate_link_targets
 from src.application.notes.protocols.note_repository import NoteRepositoryProtocol
 from src.application.reading.protocols.highlight_repository import HighlightRepositoryProtocol
+from src.application.semantic.content_type import ContentType
+from src.application.semantic.protocols.embedding_enqueuer import EmbeddingEnqueuerProtocol
 from src.application.tagging.protocols.tag_repository import (
     TagRepositoryProtocol,
 )
@@ -25,11 +27,13 @@ class UpdateNoteUseCase:
         chapter_repository: ChapterRepositoryProtocol,
         highlight_repository: HighlightRepositoryProtocol,
         tag_repository: TagRepositoryProtocol,
+        embedding_enqueuer: EmbeddingEnqueuerProtocol,
     ) -> None:
         self.note_repository = note_repository
         self.chapter_repository = chapter_repository
         self.highlight_repository = highlight_repository
         self.tag_repository = tag_repository
+        self._embedding_enqueuer = embedding_enqueuer
 
     async def update_note(
         self,
@@ -66,6 +70,10 @@ class UpdateNoteUseCase:
             tag_ids=tag_ids,
         )
         note = await self.note_repository.save(note)
+
+        # After the save, so the re-embedding reads the edited text rather than
+        # the row it is replacing.
+        await self._embedding_enqueuer.enqueue_for(ContentType.NOTE, note.id.value, user_id)
 
         logger.info("updated_note", note_id=note_id)
         return note

--- a/backend/src/application/notes/commands/update_note_use_case.py
+++ b/backend/src/application/notes/commands/update_note_use_case.py
@@ -71,8 +71,6 @@ class UpdateNoteUseCase:
         )
         note = await self.note_repository.save(note)
 
-        # After the save, so the re-embedding reads the edited text rather than
-        # the row it is replacing.
         await self._embedding_enqueuer.enqueue_for(ContentType.NOTE, note.id.value, user_id)
 
         logger.info("updated_note", note_id=note_id)

--- a/backend/src/application/reading/commands/chapter_digest/generate_chapter_digest_use_case.py
+++ b/backend/src/application/reading/commands/chapter_digest/generate_chapter_digest_use_case.py
@@ -23,6 +23,8 @@ from src.application.reading.protocols.chapter_digest_repository import (
 from src.application.reading.protocols.ebook_text_extraction_service import (
     EbookTextExtractionServiceProtocol,
 )
+from src.application.semantic.content_type import ContentType
+from src.application.semantic.protocols.embedding_enqueuer import EmbeddingEnqueuerProtocol
 from src.domain.common.exceptions import DomainError
 from src.domain.common.value_objects.ids import ChapterId, UserId
 from src.domain.reading.entities.chapter_digest import (
@@ -44,6 +46,7 @@ class GenerateChapterDigestUseCase:
         book_repo: BookRepositoryProtocol,
         file_repo: FileRepositoryProtocol,
         ai_digest_service: AIDigestServiceProtocol,
+        embedding_enqueuer: EmbeddingEnqueuerProtocol,
     ) -> None:
         self.digest_repo = digest_repo
         self.chapter_repo = chapter_repo
@@ -51,6 +54,7 @@ class GenerateChapterDigestUseCase:
         self.book_repo = book_repo
         self.file_repo = file_repo
         self.ai_digest_service = ai_digest_service
+        self._embedding_enqueuer = embedding_enqueuer
 
     async def generate_digest(self, chapter_id: ChapterId, user_id: UserId) -> ChapterDigest:
         """Generate a new digest for a chapter."""
@@ -119,4 +123,13 @@ class GenerateChapterDigestUseCase:
             chapter_id=chapter_id.value,
             keypoints_count=len(ai_result.keypoints),
         )
-        return await self.digest_repo.save(entity)
+        saved = await self.digest_repo.save(entity)
+
+        # The digest's id only exists after the save, and its text is what gets
+        # embedded -- summary and keypoints, which is why answering the digest's
+        # questions later does not re-enqueue.
+        await self._embedding_enqueuer.enqueue_for(
+            ContentType.DIGEST, saved.id.value, user_id.value
+        )
+
+        return saved

--- a/backend/src/application/reading/commands/chapter_digest/generate_chapter_digest_use_case.py
+++ b/backend/src/application/reading/commands/chapter_digest/generate_chapter_digest_use_case.py
@@ -125,9 +125,6 @@ class GenerateChapterDigestUseCase:
         )
         saved = await self.digest_repo.save(entity)
 
-        # The digest's id only exists after the save, and its text is what gets
-        # embedded -- summary and keypoints, which is why answering the digest's
-        # questions later does not re-enqueue.
         await self._embedding_enqueuer.enqueue_for(
             ContentType.DIGEST, saved.id.value, user_id.value
         )

--- a/backend/src/application/reading/commands/highlights/highlight_upload_use_case.py
+++ b/backend/src/application/reading/commands/highlights/highlight_upload_use_case.py
@@ -19,6 +19,8 @@ from src.application.reading.protocols.highlight_repository import (
 from src.application.reading.protocols.highlight_style_repository import (
     HighlightStyleRepositoryProtocol,
 )
+from src.application.semantic.content_type import ContentType
+from src.application.semantic.protocols.embedding_enqueuer import EmbeddingEnqueuerProtocol
 from src.domain.common.value_objects import ChapterId, UserId, XPointRange
 from src.domain.common.value_objects.position import Position
 from src.domain.reading.entities.highlight import Highlight
@@ -56,6 +58,7 @@ class HighlightUploadUseCase:
         position_index_service: PositionIndexServiceProtocol,
         file_repository: FileRepositoryProtocol,
         highlight_style_repository: HighlightStyleRepositoryProtocol,
+        embedding_enqueuer: EmbeddingEnqueuerProtocol,
     ) -> None:
         """
         Initialize use case with dependencies.
@@ -68,6 +71,7 @@ class HighlightUploadUseCase:
             position_index_service: Service for building position indices from EPUBs
             file_repository: Repository for file operations
             highlight_style_repository: Repository for highlight style persistence
+            embedding_enqueuer: Seam for enqueuing embedding jobs for new highlights
         """
         self.highlight_repository = highlight_repository
         self.book_repository = book_repository
@@ -76,6 +80,7 @@ class HighlightUploadUseCase:
         self.position_index_service = position_index_service
         self.file_repository = file_repository
         self.highlight_style_repository = highlight_style_repository
+        self._embedding_enqueuer = embedding_enqueuer
 
     async def upload_highlights(
         self,
@@ -201,7 +206,16 @@ class HighlightUploadUseCase:
 
         # Step 5: Bulk save unique highlights
         if unique:
-            await self.highlight_repository.bulk_save(unique)
+            saved = await self.highlight_repository.bulk_save(unique)
+            # Only the ids the save actually produced -- the duplicates were
+            # already embedded when they first arrived, and a KOReader sync
+            # resends the whole book every time.
+            await self._embedding_enqueuer.enqueue_many(
+                ContentType.HIGHLIGHT,
+                [highlight.id.value for highlight in saved],
+                user_id,
+                reference_id=str(book_id.value),
+            )
 
         logger.info(
             "upload_complete",

--- a/backend/src/application/reading/commands/highlights/highlight_upload_use_case.py
+++ b/backend/src/application/reading/commands/highlights/highlight_upload_use_case.py
@@ -207,9 +207,6 @@ class HighlightUploadUseCase:
         # Step 5: Bulk save unique highlights
         if unique:
             saved = await self.highlight_repository.bulk_save(unique)
-            # Only the ids the save actually produced -- the duplicates were
-            # already embedded when they first arrived, and a KOReader sync
-            # resends the whole book every time.
             await self._embedding_enqueuer.enqueue_many(
                 ContentType.HIGHLIGHT,
                 [highlight.id.value for highlight in saved],

--- a/backend/src/application/semantic/batching.py
+++ b/backend/src/application/semantic/batching.py
@@ -1,16 +1,9 @@
 """How embedding work is cut into jobs and handed to the queue as a tracked batch.
 
-Two paths enqueue embeddings -- the backfill reconciles a whole library, the
-live enqueuer cuts a highlight upload -- and they must agree on all of it: the
-slice size, because a slice is what the worker task takes; the enqueue kwargs,
-because they are a contract with ``generate_content_embeddings``; and the
-bookkeeping, because a batch reporting "completed" while slices were silently
-dropped is worse than one reporting failures.
-
-What the two paths do *not* share is what to do when nothing lands at all. The
-backfill raises, so the user learns the button did nothing; the live enqueuer
-returns quietly, because it is a side effect of a write that already succeeded.
-So this returns the batch and lets each caller read ``job_keys`` and decide.
+Shared by the backfill and the live enqueuer so the slice size, the enqueue
+kwargs (a contract with ``generate_content_embeddings``) and the batch
+bookkeeping stay in one place. The two differ only in what to do when nothing
+lands, so this returns the batch and lets each caller read ``job_keys``.
 """
 
 from itertools import batched
@@ -25,14 +18,10 @@ from src.domain.jobs.entities.job_batch import JobBatch, JobBatchType
 
 logger = structlog.get_logger(__name__)
 
-#: How many content units one embedding job handles.
-#:
-#: A job per unit meant a queue round trip per unit inside this request *and* a
-#: provider round trip per unit in the worker; a slice amortises both. Well
-#: below the client's own per-request cap (96, OpenRouter's limit, which the
-#: client chunks at independently and which is not this layer's business):
-#: a slice of long notes is a large payload to ask a local Ollama GPU to hold at
-#: once, and 32 already removes 31 of every 32 requests.
+#: How many content units one embedding job handles. A slice amortises both the
+#: queue and the provider round trip. Kept well below the client's own 96-unit
+#: cap, which it chunks at independently: a slice of long notes is a large
+#: payload for a local Ollama GPU, and 32 already removes 31 of every 32 calls.
 EMBEDDING_SLICE_SIZE = 32
 
 _TASK = "generate_content_embeddings"
@@ -54,11 +43,9 @@ async def enqueue_embedding_batch(
 ) -> JobBatch:
     """Open a batch, enqueue one job per slice, and persist what actually landed.
 
-    Stops at the first slice that fails to enqueue: a queue that just rejected
-    one job is unlikely to accept the next, and continuing would spend the
-    request's remaining time finding that out. The batch is returned either way
-    -- with empty ``job_keys`` when nothing landed, which is the caller's signal
-    that it got nowhere.
+    Stops at the first failed enqueue -- a queue that just rejected one job is
+    unlikely to accept the next. Empty ``job_keys`` on the returned batch is the
+    caller's signal that nothing landed.
     """
     batch = JobBatch.create(
         user_id=user_id,
@@ -105,9 +92,8 @@ async def enqueue_embedding_job(
 ) -> None:
     """Enqueue one slice as a bare job, outside any batch.
 
-    Same task and same kwargs as the batched path minus ``batch_id``, which the
-    task takes as optional precisely so a single edit does not need a batch row
-    to report the progress of its one job.
+    Same task and kwargs as the batched path minus ``batch_id``, which the task
+    takes as optional so a single edit needs no batch row.
     """
     await queue_service.enqueue(
         _TASK,

--- a/backend/src/application/semantic/batching.py
+++ b/backend/src/application/semantic/batching.py
@@ -1,16 +1,29 @@
-"""How embedding work is cut into jobs, and how the ones never enqueued are counted.
+"""How embedding work is cut into jobs and handed to the queue as a tracked batch.
 
 Two paths enqueue embeddings -- the backfill reconciles a whole library, the
-live enqueuer cuts a highlight upload -- and they have to agree on both halves
-of this. On the slice size, because a slice is what the worker task takes; on
-the accounting, because a batch reporting "completed" while slices were silently
+live enqueuer cuts a highlight upload -- and they must agree on all of it: the
+slice size, because a slice is what the worker task takes; the enqueue kwargs,
+because they are a contract with ``generate_content_embeddings``; and the
+bookkeeping, because a batch reporting "completed" while slices were silently
 dropped is worse than one reporting failures.
+
+What the two paths do *not* share is what to do when nothing lands at all. The
+backfill raises, so the user learns the button did nothing; the live enqueuer
+returns quietly, because it is a side effect of a write that already succeeded.
+So this returns the batch and lets each caller read ``job_keys`` and decide.
 """
 
 from itertools import batched
 
+import structlog
+
 from src.application.jobs.protocols.job_batch_repository import JobBatchRepositoryProtocol
-from src.domain.jobs.entities.job_batch import JobBatch
+from src.application.jobs.protocols.job_queue_service import JobQueueServiceProtocol
+from src.application.semantic.content_type import ContentType
+from src.domain.common.value_objects.ids import UserId
+from src.domain.jobs.entities.job_batch import JobBatch, JobBatchType
+
+logger = structlog.get_logger(__name__)
 
 #: How many content units one embedding job handles.
 #:
@@ -22,23 +35,85 @@ from src.domain.jobs.entities.job_batch import JobBatch
 #: once, and 32 already removes 31 of every 32 requests.
 EMBEDDING_SLICE_SIZE = 32
 
+_TASK = "generate_content_embeddings"
+_RETRIES = 3
+_TIMEOUT_SECONDS = 300
+
 
 def slice_ids(content_ids: list[int]) -> list[list[int]]:
     """Cut one content type's ids into job-sized slices."""
     return [list(chunk) for chunk in batched(content_ids, EMBEDDING_SLICE_SIZE)]
 
 
-async def record_dropped_slices(
-    batch: JobBatch, expected_jobs: int, batch_repo: JobBatchRepositoryProtocol
+async def enqueue_embedding_batch(
+    slices: list[tuple[ContentType, list[int]]],
+    user_id: UserId,
+    reference_id: str,
+    queue_service: JobQueueServiceProtocol,
+    batch_repo: JobBatchRepositoryProtocol,
 ) -> JobBatch:
-    """Mark the slices an enqueue loop never reached as failed, then persist.
+    """Open a batch, enqueue one job per slice, and persist what actually landed.
 
-    Deliberately not ``total_jobs = len(job_keys)``. Shrinking the total let a
-    backfill of 500 slices which broke at slice 3 terminate as "completed,
-    total_jobs=3", with nothing to say 497 were dropped. Counting them as
-    failures keeps the batch honest and still lets it reach a terminal status
-    once the enqueued jobs report -- COMPLETED_WITH_ERRORS instead of COMPLETED.
+    Stops at the first slice that fails to enqueue: a queue that just rejected
+    one job is unlikely to accept the next, and continuing would spend the
+    request's remaining time finding that out. The batch is returned either way
+    -- with empty ``job_keys`` when nothing landed, which is the caller's signal
+    that it got nowhere.
     """
-    for _ in range(expected_jobs - len(batch.job_keys)):
-        batch.mark_job_failed()
+    batch = JobBatch.create(
+        user_id=user_id,
+        batch_type=JobBatchType.CONTENT_EMBEDDING,
+        reference_id=reference_id,
+        total_jobs=len(slices),
+    )
+    batch = await batch_repo.save(batch)
+
+    for content_type, content_ids in slices:
+        try:
+            job_key = await queue_service.enqueue(
+                _TASK,
+                retries=_RETRIES,
+                timeout_seconds=_TIMEOUT_SECONDS,
+                batch_id=batch.id.value,
+                content_type=content_type.value,
+                content_ids=content_ids,
+                user_id=user_id.value,
+            )
+            batch.add_job_key(job_key)
+        except Exception:
+            logger.exception(
+                "failed_to_enqueue_embedding_job",
+                content_type=content_type.value,
+                content_ids=content_ids,
+                batch_id=batch.id.value,
+            )
+            break
+
+    if not batch.job_keys:
+        batch.cancel()
+        return await batch_repo.save(batch)
+
+    batch.mark_unenqueued_jobs_failed()
     return await batch_repo.save(batch)
+
+
+async def enqueue_embedding_job(
+    content_type: ContentType,
+    content_ids: list[int],
+    user_id: int,
+    queue_service: JobQueueServiceProtocol,
+) -> None:
+    """Enqueue one slice as a bare job, outside any batch.
+
+    Same task and same kwargs as the batched path minus ``batch_id``, which the
+    task takes as optional precisely so a single edit does not need a batch row
+    to report the progress of its one job.
+    """
+    await queue_service.enqueue(
+        _TASK,
+        retries=_RETRIES,
+        timeout_seconds=_TIMEOUT_SECONDS,
+        content_type=content_type.value,
+        content_ids=content_ids,
+        user_id=user_id,
+    )

--- a/backend/src/application/semantic/batching.py
+++ b/backend/src/application/semantic/batching.py
@@ -1,0 +1,44 @@
+"""How embedding work is cut into jobs, and how the ones never enqueued are counted.
+
+Two paths enqueue embeddings -- the backfill reconciles a whole library, the
+live enqueuer cuts a highlight upload -- and they have to agree on both halves
+of this. On the slice size, because a slice is what the worker task takes; on
+the accounting, because a batch reporting "completed" while slices were silently
+dropped is worse than one reporting failures.
+"""
+
+from itertools import batched
+
+from src.application.jobs.protocols.job_batch_repository import JobBatchRepositoryProtocol
+from src.domain.jobs.entities.job_batch import JobBatch
+
+#: How many content units one embedding job handles.
+#:
+#: A job per unit meant a queue round trip per unit inside this request *and* a
+#: provider round trip per unit in the worker; a slice amortises both. Well
+#: below the client's own per-request cap (96, OpenRouter's limit, which the
+#: client chunks at independently and which is not this layer's business):
+#: a slice of long notes is a large payload to ask a local Ollama GPU to hold at
+#: once, and 32 already removes 31 of every 32 requests.
+EMBEDDING_SLICE_SIZE = 32
+
+
+def slice_ids(content_ids: list[int]) -> list[list[int]]:
+    """Cut one content type's ids into job-sized slices."""
+    return [list(chunk) for chunk in batched(content_ids, EMBEDDING_SLICE_SIZE)]
+
+
+async def record_dropped_slices(
+    batch: JobBatch, expected_jobs: int, batch_repo: JobBatchRepositoryProtocol
+) -> JobBatch:
+    """Mark the slices an enqueue loop never reached as failed, then persist.
+
+    Deliberately not ``total_jobs = len(job_keys)``. Shrinking the total let a
+    backfill of 500 slices which broke at slice 3 terminate as "completed,
+    total_jobs=3", with nothing to say 497 were dropped. Counting them as
+    failures keeps the batch honest and still lets it reach a terminal status
+    once the enqueued jobs report -- COMPLETED_WITH_ERRORS instead of COMPLETED.
+    """
+    for _ in range(expected_jobs - len(batch.job_keys)):
+        batch.mark_job_failed()
+    return await batch_repo.save(batch)

--- a/backend/src/application/semantic/commands/enqueue_content_embeddings_use_case.py
+++ b/backend/src/application/semantic/commands/enqueue_content_embeddings_use_case.py
@@ -19,7 +19,7 @@ logger = structlog.get_logger(__name__)
 def _slices(items: list[PendingUnit]) -> list[tuple[ContentType, list[int]]]:
     """Group pending units by content type, then cut each group into job-sized slices.
 
-    One slice never mixes types: the job resolves its ids through a single
+    One slice never mixes types -- the job resolves its ids through a single
     ``get_embeddable_many`` call, which reads one type's table.
     """
     by_type: dict[ContentType, list[int]] = {}
@@ -55,7 +55,6 @@ class EnqueueContentEmbeddingsUseCase:
             user_id.value, book_id.value if book_id else None
         )
         if not items_to_generate_embeddings:
-            # Everything is already indexed.
             return None
 
         reference_id = str(book_id.value) if book_id else f"user:{user_id.value}"
@@ -67,8 +66,7 @@ class EnqueueContentEmbeddingsUseCase:
             batch_repo=self._batch_repo,
         )
 
-        # Unlike the live enqueuer, this is a button the user pressed: getting
-        # nowhere has to be reported, not logged and swallowed.
+        # A button the user pressed: getting nowhere has to be reported.
         if not batch.job_keys:
             raise DomainError("Failed to enqueue any jobs for content embedding")
 

--- a/backend/src/application/semantic/commands/enqueue_content_embeddings_use_case.py
+++ b/backend/src/application/semantic/commands/enqueue_content_embeddings_use_case.py
@@ -6,12 +6,12 @@ from src.application.common.ownership import require_book
 from src.application.jobs.protocols.job_batch_repository import JobBatchRepositoryProtocol
 from src.application.jobs.protocols.job_queue_service import JobQueueServiceProtocol
 from src.application.library.protocols.book_repository import BookRepositoryProtocol
-from src.application.semantic.batching import record_dropped_slices, slice_ids
+from src.application.semantic.batching import enqueue_embedding_batch, slice_ids
 from src.application.semantic.content_type import ContentType
 from src.application.semantic.protocols.content_source import ContentSourceProtocol, PendingUnit
 from src.domain.common.exceptions import DomainError
 from src.domain.common.value_objects.ids import BookId, UserId
-from src.domain.jobs.entities.job_batch import JobBatch, JobBatchType
+from src.domain.jobs.entities.job_batch import JobBatch
 
 logger = structlog.get_logger(__name__)
 
@@ -58,44 +58,19 @@ class EnqueueContentEmbeddingsUseCase:
             # Everything is already indexed.
             return None
 
-        slices = _slices(items_to_generate_embeddings)
-
         reference_id = str(book_id.value) if book_id else f"user:{user_id.value}"
-        batch = JobBatch.create(
+        batch = await enqueue_embedding_batch(
+            _slices(items_to_generate_embeddings),
             user_id=user_id,
-            batch_type=JobBatchType.CONTENT_EMBEDDING,
             reference_id=reference_id,
-            total_jobs=len(slices),
+            queue_service=self._queue_service,
+            batch_repo=self._batch_repo,
         )
-        batch = await self._batch_repo.save(batch)
 
-        for content_type, content_ids in slices:
-            try:
-                job_key = await self._queue_service.enqueue(
-                    "generate_content_embeddings",
-                    retries=3,
-                    timeout_seconds=300,
-                    batch_id=batch.id.value,
-                    content_type=content_type.value,
-                    content_ids=content_ids,
-                    user_id=user_id.value,
-                )
-                batch.add_job_key(job_key)
-            except Exception:
-                logger.exception(
-                    "failed_to_enqueue_job",
-                    content_type=content_type.value,
-                    content_ids=content_ids,
-                    batch_id=batch.id.value,
-                )
-                break
-
+        # Unlike the live enqueuer, this is a button the user pressed: getting
+        # nowhere has to be reported, not logged and swallowed.
         if not batch.job_keys:
-            batch.cancel()
-            await self._batch_repo.save(batch)
             raise DomainError("Failed to enqueue any jobs for content embedding")
-
-        batch = await record_dropped_slices(batch, len(slices), self._batch_repo)
 
         logger.info(
             "content_embedding_batch_enqueued",

--- a/backend/src/application/semantic/commands/enqueue_content_embeddings_use_case.py
+++ b/backend/src/application/semantic/commands/enqueue_content_embeddings_use_case.py
@@ -1,13 +1,12 @@
 """Use case for enqueuing a backfill batch of content embeddings."""
 
-from itertools import batched
-
 import structlog
 
 from src.application.common.ownership import require_book
 from src.application.jobs.protocols.job_batch_repository import JobBatchRepositoryProtocol
 from src.application.jobs.protocols.job_queue_service import JobQueueServiceProtocol
 from src.application.library.protocols.book_repository import BookRepositoryProtocol
+from src.application.semantic.batching import record_dropped_slices, slice_ids
 from src.application.semantic.content_type import ContentType
 from src.application.semantic.protocols.content_source import ContentSourceProtocol, PendingUnit
 from src.domain.common.exceptions import DomainError
@@ -15,16 +14,6 @@ from src.domain.common.value_objects.ids import BookId, UserId
 from src.domain.jobs.entities.job_batch import JobBatch, JobBatchType
 
 logger = structlog.get_logger(__name__)
-
-#: How many content units one embedding job handles.
-#:
-#: A job per unit meant a queue round trip per unit inside this request *and* a
-#: provider round trip per unit in the worker; a slice amortises both. Well
-#: below the client's own per-request cap (96, OpenRouter's limit, which the
-#: client chunks at independently and which is not this layer's business):
-#: a slice of long notes is a large payload to ask a local Ollama GPU to hold at
-#: once, and 32 already removes 31 of every 32 requests.
-EMBEDDING_SLICE_SIZE = 32
 
 
 def _slices(items: list[PendingUnit]) -> list[tuple[ContentType, list[int]]]:
@@ -37,9 +26,9 @@ def _slices(items: list[PendingUnit]) -> list[tuple[ContentType, list[int]]]:
     for item in items:
         by_type.setdefault(item.content_type, []).append(item.content_id)
     return [
-        (content_type, list(chunk))
+        (content_type, chunk)
         for content_type, content_ids in by_type.items()
-        for chunk in batched(content_ids, EMBEDDING_SLICE_SIZE)
+        for chunk in slice_ids(content_ids)
     ]
 
 
@@ -106,16 +95,7 @@ class EnqueueContentEmbeddingsUseCase:
             await self._batch_repo.save(batch)
             raise DomainError("Failed to enqueue any jobs for content embedding")
 
-        # Slices the loop never reached will never be embedded, so record them as
-        # failures rather than shrinking total_jobs to what was enqueued: that
-        # let a backfill of 500 slices which broke at slice 3 terminate as
-        # "completed, total_jobs=3", with nothing to say 497 were dropped. The
-        # batch still reaches a terminal status once the enqueued jobs report —
-        # COMPLETED_WITH_ERRORS instead of COMPLETED.
-        for _ in range(len(slices) - len(batch.job_keys)):
-            batch.mark_job_failed()
-
-        await self._batch_repo.save(batch)
+        batch = await record_dropped_slices(batch, len(slices), self._batch_repo)
 
         logger.info(
             "content_embedding_batch_enqueued",

--- a/backend/src/application/semantic/protocols/embedding_enqueuer.py
+++ b/backend/src/application/semantic/protocols/embedding_enqueuer.py
@@ -1,9 +1,8 @@
 """Port for enqueuing embedding jobs from source-module write use cases.
 
-This is the one seam source modules (notes, reading) depend on to trigger
-embedding. It no-ops when embeddings are disabled and never raises into the
-calling write path -- a failure to enqueue must not fail a note save or a
-highlight upload.
+The one seam notes and reading depend on to trigger embedding. Implementations
+must no-op when embeddings are disabled and never raise into the write path --
+a failed enqueue must not fail a note save or a highlight upload.
 """
 
 from typing import Protocol

--- a/backend/src/application/semantic/protocols/embedding_enqueuer.py
+++ b/backend/src/application/semantic/protocols/embedding_enqueuer.py
@@ -1,0 +1,29 @@
+"""Port for enqueuing embedding jobs from source-module write use cases.
+
+This is the one seam source modules (notes, reading) depend on to trigger
+embedding. It no-ops when embeddings are disabled and never raises into the
+calling write path -- a failure to enqueue must not fail a note save or a
+highlight upload.
+"""
+
+from typing import Protocol
+
+from src.application.semantic.content_type import ContentType
+
+
+class EmbeddingEnqueuerProtocol(Protocol):
+    """Enqueues embedding jobs for content units."""
+
+    async def enqueue_for(self, content_type: ContentType, content_id: int, user_id: int) -> None:
+        """Enqueue a single content unit for (re-)embedding."""
+        ...
+
+    async def enqueue_many(
+        self,
+        content_type: ContentType,
+        content_ids: list[int],
+        user_id: int,
+        reference_id: str,
+    ) -> None:
+        """Enqueue a batch of content units for (re-)embedding."""
+        ...

--- a/backend/src/application/semantic/services/__init__.py
+++ b/backend/src/application/semantic/services/__init__.py
@@ -1,0 +1,1 @@
+"""Application-layer services for the semantic subdomain."""

--- a/backend/src/application/semantic/services/embedding_enqueuer.py
+++ b/backend/src/application/semantic/services/embedding_enqueuer.py
@@ -1,0 +1,149 @@
+"""Application service that enqueues embedding jobs, gated by the feature flag.
+
+Called from source-module write use cases as a fire-and-forget side effect of a
+save. It no-ops when embeddings are disabled and swallows enqueue failures -- a
+missed embedding is reconciled later by the backfill path, and must never fail
+the user's create or upload.
+
+Callers invoke it *after* the repository save, not before: the repositories
+commit inside ``save``/``bulk_save``, so a job that starts running the instant
+it is enqueued still reads committed content rather than the pre-edit row.
+"""
+
+import structlog
+
+from src.application.jobs.protocols.job_batch_repository import JobBatchRepositoryProtocol
+from src.application.jobs.protocols.job_queue_service import JobQueueServiceProtocol
+from src.application.semantic.batching import record_dropped_slices, slice_ids
+from src.application.semantic.content_type import ContentType
+from src.config import Settings
+from src.domain.common.value_objects.ids import UserId
+from src.domain.jobs.entities.job_batch import JobBatch, JobBatchType
+
+logger = structlog.get_logger(__name__)
+
+_TASK = "generate_content_embeddings"
+_RETRIES = 3
+_TIMEOUT_SECONDS = 300
+
+
+class EmbeddingEnqueuer:
+    """Enqueues embedding jobs for content units, gated by ``embeddings_enabled``."""
+
+    def __init__(
+        self,
+        queue_service: JobQueueServiceProtocol,
+        batch_repo: JobBatchRepositoryProtocol,
+        settings: Settings,
+    ) -> None:
+        self._queue_service = queue_service
+        self._batch_repo = batch_repo
+        self._settings = settings
+
+    async def enqueue_for(self, content_type: ContentType, content_id: int, user_id: int) -> None:
+        """Enqueue one unit as a bare job -- no batch.
+
+        A single edit has no progress worth reporting, and a JobBatch per note
+        save would put a row in the batch table for every keystroke-sized
+        change. The worker task's ``batch_id`` is optional for exactly this.
+        """
+        if not self._settings.embeddings_enabled:
+            return
+
+        try:
+            await self._queue_service.enqueue(
+                _TASK,
+                retries=_RETRIES,
+                timeout_seconds=_TIMEOUT_SECONDS,
+                content_type=content_type.value,
+                content_ids=[content_id],
+                user_id=user_id,
+            )
+        except Exception:
+            logger.exception(
+                "failed_to_enqueue_embedding",
+                content_type=content_type.value,
+                content_id=content_id,
+            )
+
+    async def enqueue_many(
+        self,
+        content_type: ContentType,
+        content_ids: list[int],
+        user_id: int,
+        reference_id: str,
+    ) -> None:
+        """Enqueue many units of one type as a tracked batch of slices.
+
+        A highlight upload can carry hundreds of units, so this is the one write
+        path where progress is worth reporting -- and where the slice size
+        actually bites.
+        """
+        if not self._settings.embeddings_enabled or not content_ids:
+            return
+
+        try:
+            await self._enqueue_batch(content_type, content_ids, user_id, reference_id)
+        except Exception:
+            # The inner loop already tolerates a failing enqueue; this catches
+            # everything around it (persisting the batch, above all), because
+            # the caller's write has committed and must not be reported failed.
+            logger.exception(
+                "failed_to_enqueue_embedding_batch",
+                content_type=content_type.value,
+                reference_id=reference_id,
+            )
+
+    async def _enqueue_batch(
+        self,
+        content_type: ContentType,
+        content_ids: list[int],
+        user_id: int,
+        reference_id: str,
+    ) -> None:
+        slices = slice_ids(content_ids)
+        batch = JobBatch.create(
+            user_id=UserId(user_id),
+            batch_type=JobBatchType.CONTENT_EMBEDDING,
+            reference_id=reference_id,
+            total_jobs=len(slices),
+        )
+        batch = await self._batch_repo.save(batch)
+
+        for content_slice in slices:
+            try:
+                job_key = await self._queue_service.enqueue(
+                    _TASK,
+                    retries=_RETRIES,
+                    timeout_seconds=_TIMEOUT_SECONDS,
+                    batch_id=batch.id.value,
+                    content_type=content_type.value,
+                    content_ids=content_slice,
+                    user_id=user_id,
+                )
+                batch.add_job_key(job_key)
+            except Exception:
+                logger.exception(
+                    "failed_to_enqueue_embedding",
+                    content_type=content_type.value,
+                    content_ids=content_slice,
+                    batch_id=batch.id.value,
+                )
+                break
+
+        if not batch.job_keys:
+            # Unlike the backfill, which raises so the user learns the button did
+            # nothing, this is a side effect of a write that already succeeded.
+            batch.cancel()
+            await self._batch_repo.save(batch)
+            return
+
+        batch = await record_dropped_slices(batch, len(slices), self._batch_repo)
+
+        logger.info(
+            "content_embedding_batch_enqueued",
+            batch_id=batch.id.value,
+            reference_id=reference_id,
+            content_type=content_type.value,
+            total_jobs=batch.total_jobs,
+        )

--- a/backend/src/application/semantic/services/embedding_enqueuer.py
+++ b/backend/src/application/semantic/services/embedding_enqueuer.py
@@ -1,17 +1,12 @@
 """Application service that enqueues embedding jobs, gated by the feature flag.
 
-Called from source-module write use cases as a fire-and-forget side effect of a
-save. It no-ops when embeddings are disabled and swallows enqueue failures -- a
-missed embedding is reconciled later by the backfill path, and must never fail
-the user's create or upload.
+A fire-and-forget side effect of a write: it no-ops when embeddings are
+disabled and swallows enqueue failures, since the backfill reconciles a missed
+embedding later and a create or upload must never fail over one.
 
-Callers invoke it *after* the repository save, not before: the repositories
-commit inside ``save``/``bulk_save``, so a job that starts running the instant
-it is enqueued still reads committed content rather than the pre-edit row.
-
-The mechanics of talking to the queue live in ``batching`` alongside the
-backfill's; what is here is only this path's policy -- gated, batched only when
-there is progress worth tracking, and silent on failure.
+Call it *after* the repository save -- the repositories commit inside
+``save``/``bulk_save``, so a job starting immediately still reads the new row.
+The queue mechanics live in ``batching``; only this path's policy is here.
 """
 
 import structlog
@@ -46,9 +41,8 @@ class EmbeddingEnqueuer:
     async def enqueue_for(self, content_type: ContentType, content_id: int, user_id: int) -> None:
         """Enqueue one unit as a bare job -- no batch.
 
-        A single edit has no progress worth reporting, and a JobBatch per note
-        save would put a row in the batch table for every keystroke-sized
-        change. The worker task's ``batch_id`` is optional for exactly this.
+        A single edit has no progress worth reporting, and a batch row per note
+        save would mean one row per keystroke-sized change.
         """
         if not self._settings.embeddings_enabled:
             return
@@ -71,9 +65,8 @@ class EmbeddingEnqueuer:
     ) -> None:
         """Enqueue many units of one type as a tracked batch of slices.
 
-        A highlight upload can carry hundreds of units, so this is the one write
-        path where progress is worth reporting -- and where the slice size
-        actually bites.
+        A highlight upload can carry hundreds of units -- the one write path
+        where progress is worth reporting.
         """
         if not self._settings.embeddings_enabled or not content_ids:
             return
@@ -87,10 +80,8 @@ class EmbeddingEnqueuer:
                 batch_repo=self._batch_repo,
             )
         except Exception:
-            # enqueue_embedding_batch tolerates a failing enqueue on its own;
-            # this catches everything around it -- persisting the batch, above
-            # all -- because the caller's write has committed and must not be
-            # reported failed.
+            # enqueue_embedding_batch already tolerates a failing enqueue; this
+            # catches everything around it, above all persisting the batch.
             logger.exception(
                 "failed_to_enqueue_embedding_batch",
                 content_type=content_type.value,
@@ -98,8 +89,8 @@ class EmbeddingEnqueuer:
             )
             return
 
-        # Getting nowhere is already logged per slice, and the batch it leaves
-        # behind is CANCELLED. Nothing to raise about: the highlights are saved.
+        # Getting nowhere is already logged per slice and leaves a CANCELLED
+        # batch -- nothing to raise about, the highlights are saved.
         if batch.job_keys:
             logger.info(
                 "content_embedding_batch_enqueued",

--- a/backend/src/application/semantic/services/embedding_enqueuer.py
+++ b/backend/src/application/semantic/services/embedding_enqueuer.py
@@ -8,23 +8,26 @@ the user's create or upload.
 Callers invoke it *after* the repository save, not before: the repositories
 commit inside ``save``/``bulk_save``, so a job that starts running the instant
 it is enqueued still reads committed content rather than the pre-edit row.
+
+The mechanics of talking to the queue live in ``batching`` alongside the
+backfill's; what is here is only this path's policy -- gated, batched only when
+there is progress worth tracking, and silent on failure.
 """
 
 import structlog
 
 from src.application.jobs.protocols.job_batch_repository import JobBatchRepositoryProtocol
 from src.application.jobs.protocols.job_queue_service import JobQueueServiceProtocol
-from src.application.semantic.batching import record_dropped_slices, slice_ids
+from src.application.semantic.batching import (
+    enqueue_embedding_batch,
+    enqueue_embedding_job,
+    slice_ids,
+)
 from src.application.semantic.content_type import ContentType
 from src.config import Settings
 from src.domain.common.value_objects.ids import UserId
-from src.domain.jobs.entities.job_batch import JobBatch, JobBatchType
 
 logger = structlog.get_logger(__name__)
-
-_TASK = "generate_content_embeddings"
-_RETRIES = 3
-_TIMEOUT_SECONDS = 300
 
 
 class EmbeddingEnqueuer:
@@ -51,14 +54,7 @@ class EmbeddingEnqueuer:
             return
 
         try:
-            await self._queue_service.enqueue(
-                _TASK,
-                retries=_RETRIES,
-                timeout_seconds=_TIMEOUT_SECONDS,
-                content_type=content_type.value,
-                content_ids=[content_id],
-                user_id=user_id,
-            )
+            await enqueue_embedding_job(content_type, [content_id], user_id, self._queue_service)
         except Exception:
             logger.exception(
                 "failed_to_enqueue_embedding",
@@ -83,67 +79,32 @@ class EmbeddingEnqueuer:
             return
 
         try:
-            await self._enqueue_batch(content_type, content_ids, user_id, reference_id)
+            batch = await enqueue_embedding_batch(
+                [(content_type, content_slice) for content_slice in slice_ids(content_ids)],
+                user_id=UserId(user_id),
+                reference_id=reference_id,
+                queue_service=self._queue_service,
+                batch_repo=self._batch_repo,
+            )
         except Exception:
-            # The inner loop already tolerates a failing enqueue; this catches
-            # everything around it (persisting the batch, above all), because
-            # the caller's write has committed and must not be reported failed.
+            # enqueue_embedding_batch tolerates a failing enqueue on its own;
+            # this catches everything around it -- persisting the batch, above
+            # all -- because the caller's write has committed and must not be
+            # reported failed.
             logger.exception(
                 "failed_to_enqueue_embedding_batch",
                 content_type=content_type.value,
                 reference_id=reference_id,
             )
-
-    async def _enqueue_batch(
-        self,
-        content_type: ContentType,
-        content_ids: list[int],
-        user_id: int,
-        reference_id: str,
-    ) -> None:
-        slices = slice_ids(content_ids)
-        batch = JobBatch.create(
-            user_id=UserId(user_id),
-            batch_type=JobBatchType.CONTENT_EMBEDDING,
-            reference_id=reference_id,
-            total_jobs=len(slices),
-        )
-        batch = await self._batch_repo.save(batch)
-
-        for content_slice in slices:
-            try:
-                job_key = await self._queue_service.enqueue(
-                    _TASK,
-                    retries=_RETRIES,
-                    timeout_seconds=_TIMEOUT_SECONDS,
-                    batch_id=batch.id.value,
-                    content_type=content_type.value,
-                    content_ids=content_slice,
-                    user_id=user_id,
-                )
-                batch.add_job_key(job_key)
-            except Exception:
-                logger.exception(
-                    "failed_to_enqueue_embedding",
-                    content_type=content_type.value,
-                    content_ids=content_slice,
-                    batch_id=batch.id.value,
-                )
-                break
-
-        if not batch.job_keys:
-            # Unlike the backfill, which raises so the user learns the button did
-            # nothing, this is a side effect of a write that already succeeded.
-            batch.cancel()
-            await self._batch_repo.save(batch)
             return
 
-        batch = await record_dropped_slices(batch, len(slices), self._batch_repo)
-
-        logger.info(
-            "content_embedding_batch_enqueued",
-            batch_id=batch.id.value,
-            reference_id=reference_id,
-            content_type=content_type.value,
-            total_jobs=batch.total_jobs,
-        )
+        # Getting nowhere is already logged per slice, and the batch it leaves
+        # behind is CANCELLED. Nothing to raise about: the highlights are saved.
+        if batch.job_keys:
+            logger.info(
+                "content_embedding_batch_enqueued",
+                batch_id=batch.id.value,
+                reference_id=reference_id,
+                content_type=content_type.value,
+                total_jobs=batch.total_jobs,
+            )

--- a/backend/src/containers/notes.py
+++ b/backend/src/containers/notes.py
@@ -16,6 +16,7 @@ class NotesContainer(containers.DeclarativeContainer):
     chapter_repository = providers.Dependency()
     highlight_repository = providers.Dependency()
     tag_repository = providers.Dependency()
+    embedding_enqueuer = providers.Dependency()
 
     # Read models: the query adapter (a port implementation) plus the read use
     # cases that routers call, mirroring how commands are exposed.
@@ -28,6 +29,7 @@ class NotesContainer(containers.DeclarativeContainer):
         chapter_repository=chapter_repository,
         highlight_repository=highlight_repository,
         tag_repository=tag_repository,
+        embedding_enqueuer=embedding_enqueuer,
     )
     get_note_use_case = providers.Factory(
         GetNoteUseCase,
@@ -44,6 +46,7 @@ class NotesContainer(containers.DeclarativeContainer):
         chapter_repository=chapter_repository,
         highlight_repository=highlight_repository,
         tag_repository=tag_repository,
+        embedding_enqueuer=embedding_enqueuer,
     )
     delete_note_use_case = providers.Factory(
         DeleteNoteUseCase,

--- a/backend/src/containers/reading.py
+++ b/backend/src/containers/reading.py
@@ -86,6 +86,7 @@ class ReadingContainer(containers.DeclarativeContainer):
     epub_position_index_service = providers.Dependency()
     ebook_text_extraction_service = providers.Dependency()
     ai_service = providers.Dependency()
+    embedding_enqueuer = providers.Dependency()
 
     # Query services (read models)
     bookmark_query = providers.Dependency()
@@ -130,6 +131,7 @@ class ReadingContainer(containers.DeclarativeContainer):
         position_index_service=epub_position_index_service,
         file_repository=file_repository,
         highlight_style_repository=highlight_style_repository,
+        embedding_enqueuer=embedding_enqueuer,
     )
 
     # Tag associations
@@ -214,6 +216,7 @@ class ReadingContainer(containers.DeclarativeContainer):
         book_repo=book_repository,
         file_repo=file_repository,
         ai_digest_service=ai_service,
+        embedding_enqueuer=embedding_enqueuer,
     )
     update_digest_answers_use_case = providers.Factory(
         UpdateDigestAnswersUseCase,

--- a/backend/src/containers/root.py
+++ b/backend/src/containers/root.py
@@ -27,11 +27,9 @@ class RootContainer(containers.DeclarativeContainer):
 
     shared = providers.Container(SharedContainer, db=db, settings=settings)
 
-    # Declared before the sub-containers that consume it. The SAQ queue is
-    # process-wide and overridden in main.py once it is connected; the embedding
-    # enqueuer is the one seam source-module write use cases call to trigger
-    # embedding, so it lives here, where it can see both the queue and the
-    # shared batch repository.
+    # Declared before the sub-containers that consume it. The enqueuer lives at
+    # the root because it needs both the process-wide queue (overridden in
+    # main.py once connected) and the shared batch repository.
     job_queue_service = providers.Dependency()
 
     embedding_enqueuer = providers.Factory(

--- a/backend/src/containers/root.py
+++ b/backend/src/containers/root.py
@@ -1,5 +1,6 @@
 from dependency_injector import containers, providers
 
+from src.application.semantic.services.embedding_enqueuer import EmbeddingEnqueuer
 from src.config import get_settings
 from src.containers.identity import IdentityContainer
 from src.containers.jobs import JobsContainer
@@ -25,6 +26,20 @@ class RootContainer(containers.DeclarativeContainer):
     settings = providers.Object(get_settings())
 
     shared = providers.Container(SharedContainer, db=db, settings=settings)
+
+    # Declared before the sub-containers that consume it. The SAQ queue is
+    # process-wide and overridden in main.py once it is connected; the embedding
+    # enqueuer is the one seam source-module write use cases call to trigger
+    # embedding, so it lives here, where it can see both the queue and the
+    # shared batch repository.
+    job_queue_service = providers.Dependency()
+
+    embedding_enqueuer = providers.Factory(
+        EmbeddingEnqueuer,
+        queue_service=job_queue_service,
+        batch_repo=shared.job_batch_repository,
+        settings=settings,
+    )
 
     identity = providers.Container(
         IdentityContainer,
@@ -56,6 +71,7 @@ class RootContainer(containers.DeclarativeContainer):
         highlight_search_query=shared.highlight_search_query,
         reading_session_query=shared.reading_session_query,
         ereader_digest_query=shared.ereader_digest_query,
+        embedding_enqueuer=embedding_enqueuer,
     )
 
     tagging = providers.Container(
@@ -101,6 +117,7 @@ class RootContainer(containers.DeclarativeContainer):
         highlight_repository=shared.highlight_repository,
         tag_repository=shared.tag_repository,
         note_query=shared.note_query,
+        embedding_enqueuer=embedding_enqueuer,
     )
 
     reflection = providers.Container(
@@ -109,8 +126,6 @@ class RootContainer(containers.DeclarativeContainer):
         book_repository=shared.book_repository,
         note_repository=shared.note_repository,
     )
-
-    job_queue_service = providers.Dependency()
 
     jobs = providers.Container(
         JobsContainer,

--- a/backend/src/domain/jobs/entities/job_batch.py
+++ b/backend/src/domain/jobs/entities/job_batch.py
@@ -78,6 +78,19 @@ class JobBatch(Entity[JobBatchId]):
         self.failed_jobs += 1
         self._recompute_status()
 
+    def mark_unenqueued_jobs_failed(self) -> None:
+        """Count the jobs an enqueue loop never reached as failures.
+
+        Deliberately not ``total_jobs = len(job_keys)``. Shrinking the total let
+        a batch of 500 which broke at job 3 terminate as "completed,
+        total_jobs=3", with nothing to say the other 497 were dropped. Counting
+        them as failures keeps the total honest and still lets the batch reach a
+        terminal status once the enqueued jobs report -- COMPLETED_WITH_ERRORS
+        instead of COMPLETED.
+        """
+        for _ in range(self.total_jobs - len(self.job_keys)):
+            self.mark_job_failed()
+
     def cancel(self) -> None:
         terminal = {
             JobBatchStatus.COMPLETED,

--- a/backend/src/domain/jobs/entities/job_batch.py
+++ b/backend/src/domain/jobs/entities/job_batch.py
@@ -81,12 +81,10 @@ class JobBatch(Entity[JobBatchId]):
     def mark_unenqueued_jobs_failed(self) -> None:
         """Count the jobs an enqueue loop never reached as failures.
 
-        Deliberately not ``total_jobs = len(job_keys)``. Shrinking the total let
-        a batch of 500 which broke at job 3 terminate as "completed,
-        total_jobs=3", with nothing to say the other 497 were dropped. Counting
-        them as failures keeps the total honest and still lets the batch reach a
-        terminal status once the enqueued jobs report -- COMPLETED_WITH_ERRORS
-        instead of COMPLETED.
+        Deliberately not ``total_jobs = len(job_keys)``: shrinking the total let
+        a batch of 500 that broke at job 3 terminate as "completed,
+        total_jobs=3". Failures keep the total honest and still reach a terminal
+        status -- COMPLETED_WITH_ERRORS rather than COMPLETED.
         """
         for _ in range(self.total_jobs - len(self.job_keys)):
             self.mark_job_failed()

--- a/backend/src/infrastructure/jobs/tasks/embedding_task_handler.py
+++ b/backend/src/infrastructure/jobs/tasks/embedding_task_handler.py
@@ -24,7 +24,7 @@ class EmbeddingTaskHandler:
         *,
         content_type: ContentType,
         content_ids: list[int],
-        batch_id: int,
+        batch_id: int | None = None,
     ) -> None:
         log = logger.bind(
             batch_id=batch_id,

--- a/backend/src/worker.py
+++ b/backend/src/worker.py
@@ -80,9 +80,8 @@ def _build_file_repo() -> S3FileRepository | FileRepository:
 def _build_embedding_enqueuer(db: AsyncSession) -> EmbeddingEnqueuerProtocol:
     """Build an EmbeddingEnqueuer wired onto the worker's own SAQ queue.
 
-    A digest is generated here rather than in a request, so the enqueue that
-    follows it has to happen here too -- the API container's enqueuer is not
-    reachable from a worker process.
+    Digests are generated here rather than in a request, so the API container's
+    enqueuer is out of reach.
     """
     from src.application.semantic.services.embedding_enqueuer import (  # noqa: PLC0415
         EmbeddingEnqueuer,
@@ -191,9 +190,8 @@ async def generate_content_embeddings(
     ``user_id`` is carried for symmetry with the other batch tasks and the
     ``after_process`` progress hook even though the use case does not need it.
 
-    ``batch_id`` is optional because a live enqueue on a single note or digest
-    edit has no batch: one job, nothing to report progress against. Only the
-    backfill and the highlight-upload path cut work into slices worth tracking.
+    ``batch_id`` is optional: a live enqueue on a single edit is one job, with
+    no progress to report against.
     """
     if _session_factory is None:
         raise RuntimeError("Worker not initialized")
@@ -257,12 +255,10 @@ class EmbeddedWorker(Worker[Context]):
 def create_embedded_worker(queue: Queue, concurrency: int = 2) -> EmbeddedWorker:
     """Create a Worker instance for running inside the app process.
 
-    Binds the app's already-connected queue as this module's queue. A task that
-    enqueues follow-up work reaches for ``_get_queue()``, and in embedded mode
-    nothing else ever populates it: the lazy branch would build a *second*
-    ``Queue`` whose pool is opened only by ``connect()``, so every such enqueue
-    would fail on a closed pool. The embedding enqueuer swallows enqueue
-    failures by design, which is exactly what would have made that silent.
+    Binds the app's connected queue as this module's ``_queue``: otherwise
+    ``_get_queue()`` would lazily build a second, never-connected one and every
+    task-side enqueue would fail on a closed pool -- silently, since the
+    embedding enqueuer swallows enqueue failures.
     """
     global _queue  # noqa: PLW0603
     _queue = queue

--- a/backend/src/worker.py
+++ b/backend/src/worker.py
@@ -255,7 +255,18 @@ class EmbeddedWorker(Worker[Context]):
 
 
 def create_embedded_worker(queue: Queue, concurrency: int = 2) -> EmbeddedWorker:
-    """Create a Worker instance for running inside the app process."""
+    """Create a Worker instance for running inside the app process.
+
+    Binds the app's already-connected queue as this module's queue. A task that
+    enqueues follow-up work reaches for ``_get_queue()``, and in embedded mode
+    nothing else ever populates it: the lazy branch would build a *second*
+    ``Queue`` whose pool is opened only by ``connect()``, so every such enqueue
+    would fail on a closed pool. The embedding enqueuer swallows enqueue
+    failures by design, which is exactly what would have made that silent.
+    """
+    global _queue  # noqa: PLW0603
+    _queue = queue
+
     return EmbeddedWorker(
         queue=queue,
         functions=[generate_chapter_digest, generate_content_embeddings],

--- a/backend/src/worker.py
+++ b/backend/src/worker.py
@@ -15,6 +15,7 @@ from saq.types import Context, SettingsDict
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from src.application.semantic.content_type import ContentType
+from src.application.semantic.protocols.embedding_enqueuer import EmbeddingEnqueuerProtocol
 from src.config import get_settings
 from src.database import get_session_factory, initialize_database
 from src.infrastructure.ai.ai_service import AIService
@@ -76,6 +77,25 @@ def _build_file_repo() -> S3FileRepository | FileRepository:
     return FileRepository()
 
 
+def _build_embedding_enqueuer(db: AsyncSession) -> EmbeddingEnqueuerProtocol:
+    """Build an EmbeddingEnqueuer wired onto the worker's own SAQ queue.
+
+    A digest is generated here rather than in a request, so the enqueue that
+    follows it has to happen here too -- the API container's enqueuer is not
+    reachable from a worker process.
+    """
+    from src.application.semantic.services.embedding_enqueuer import (  # noqa: PLC0415
+        EmbeddingEnqueuer,
+    )
+    from src.infrastructure.jobs.saq_job_queue_service import SaqJobQueueService  # noqa: PLC0415
+
+    return EmbeddingEnqueuer(
+        queue_service=SaqJobQueueService(_get_queue()),
+        batch_repo=JobBatchRepository(db=db),
+        settings=_get_app_settings(),
+    )
+
+
 def _build_digest_handler(db: AsyncSession) -> DigestTaskHandler:
     """Build a DigestTaskHandler with a fresh session."""
     from src.application.reading.commands.chapter_digest.generate_chapter_digest_use_case import (  # noqa: PLC0415
@@ -89,6 +109,7 @@ def _build_digest_handler(db: AsyncSession) -> DigestTaskHandler:
         book_repo=BookRepository(db=db),
         file_repo=_build_file_repo(),
         ai_digest_service=AIService(usage_repository=AIUsageRepository(db=db)),
+        embedding_enqueuer=_build_embedding_enqueuer(db),
     )
     return DigestTaskHandler(generate_digest_use_case=use_case)
 
@@ -163,12 +184,16 @@ async def generate_content_embeddings(
     content_type: str,
     content_ids: list[int],
     user_id: int,
-    batch_id: int,
+    batch_id: int | None = None,
 ) -> None:
     """SAQ task: embed a slice of content units of one type.
 
     ``user_id`` is carried for symmetry with the other batch tasks and the
     ``after_process`` progress hook even though the use case does not need it.
+
+    ``batch_id`` is optional because a live enqueue on a single note or digest
+    edit has no batch: one job, nothing to report progress against. Only the
+    backfill and the highlight-upload path cut work into slices worth tracking.
     """
     if _session_factory is None:
         raise RuntimeError("Worker not initialized")

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -284,12 +284,35 @@ async def client(db_session: AsyncSession, test_user: User) -> AsyncGenerator[As
 
     container.shared.file_repository.override(FileRepository())
 
+    # The SAQ queue is wired in the app lifespan, which ASGITransport skips.
+    # Without a stand-in, every write path that enqueues an embedding fails at
+    # DI resolution -- before the enqueuer's own error handling can swallow
+    # anything -- so a note create would 500 in tests and nowhere else.
+    container.job_queue_service.override(contract_checked_queue())
+
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as test_client:
         yield test_client
 
+    container.job_queue_service.reset_override()
     container.shared.file_repository.reset_override()
     app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def job_queue(client: AsyncClient) -> AsyncMock:
+    """The contract-checked queue fake the ``client`` fixture put on the container.
+
+    Reached through the container rather than installed per-suite so there is
+    exactly one fake queue per test: a second override would shadow the first,
+    and assertions would read an empty call list while the enqueues went
+    somewhere else.
+    """
+    from src.core import container  # noqa: PLC0415
+
+    queue = container.job_queue_service()
+    assert isinstance(queue, AsyncMock)
+    return queue
 
 
 @pytest.fixture

--- a/backend/tests/semantic_helpers.py
+++ b/backend/tests/semantic_helpers.py
@@ -7,6 +7,8 @@ here stops the two files repeating each other -- and stops them drifting on what
 """
 
 import hashlib
+from collections.abc import Iterator
+from contextlib import AbstractContextManager, contextmanager
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, patch
 
@@ -23,6 +25,50 @@ from tests.conftest import create_test_highlight
 
 #: Patch target for the feature flag the semantic routers gate on.
 ENABLED = "src.infrastructure.common.dependencies.is_embeddings_enabled"
+
+
+@contextmanager
+def _embedding_provider(provider: str | None) -> Iterator[None]:
+    """Force the *write-path* embedding gate for the duration of the block.
+
+    Deliberately not the same lever as ``ENABLED``. The routers gate on
+    ``is_embeddings_enabled()``, which reads the lru-cached module-level
+    settings; ``EmbeddingEnqueuer`` gates on the ``Settings`` object the DI
+    container holds. Patching the first does nothing to a note save, so a test
+    that used it would assert an enqueue that never happens -- or, worse, pass
+    while asserting one does not.
+
+    Both directions are forced explicitly because the ambient value is not the
+    same everywhere: a developer with EMBEDDING_PROVIDER in a ``.env`` above the
+    repo runs the suite with embeddings on, CI runs it with them off. A test
+    that leant on the default would pass on one and fail on the other.
+    """
+    from src.core import container  # noqa: PLC0415
+
+    container.settings.override(
+        get_settings().model_copy(
+            update={
+                "EMBEDDING_PROVIDER": provider,
+                "EMBEDDING_MODEL_NAME": "test-embedding-model",
+                "EMBEDDING_BASE_URL": "http://localhost:11434",
+            }
+        )
+    )
+    try:
+        yield
+    finally:
+        container.settings.reset_last_overriding()
+
+
+def embeddings_enabled() -> AbstractContextManager[None]:
+    """Write paths enqueue embeddings inside this block."""
+    return _embedding_provider("ollama")
+
+
+def embeddings_disabled() -> AbstractContextManager[None]:
+    """Write paths must not enqueue anything inside this block."""
+    return _embedding_provider(None)
+
 
 _HIGHLIGHT_DATETIME = "2024-01-15 14:30:22"
 

--- a/backend/tests/semantic_helpers.py
+++ b/backend/tests/semantic_helpers.py
@@ -18,7 +18,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from starlette import status
 
 from src.application.semantic.content_type import ContentType
-from src.application.semantic.idempotency import current_model_name
 from src.config import get_settings
 from src.models import Book, Embedding, Highlight
 from tests.conftest import create_test_highlight
@@ -26,22 +25,31 @@ from tests.conftest import create_test_highlight
 #: Patch target for the feature flag the semantic routers gate on.
 ENABLED = "src.infrastructure.common.dependencies.is_embeddings_enabled"
 
+#: The model an "indexed" fixture is indexed under, and the one the gate below
+#: configures. One constant rather than whatever the ambient config happens to
+#: say: an embedding planted under a different model name is model-stale by
+#: definition, so plant and check have to agree or every fixture reads as stale.
+TEST_MODEL_NAME = "test-embedding-model"
+
 
 @contextmanager
 def _embedding_provider(provider: str | None) -> Iterator[None]:
-    """Force the *write-path* embedding gate for the duration of the block.
+    """Force the embedding feature gate on or off for the duration of the block.
 
-    Deliberately not the same lever as ``ENABLED``. The routers gate on
-    ``is_embeddings_enabled()``, which reads the lru-cached module-level
-    settings; ``EmbeddingEnqueuer`` gates on the ``Settings`` object the DI
-    container holds. Patching the first does nothing to a note save, so a test
-    that used it would assert an enqueue that never happens -- or, worse, pass
-    while asserting one does not.
+    Production reads the flag through two doors, and this closes both. The
+    routers gate on ``is_embeddings_enabled()``, which walks the lru-cached
+    module-level settings; ``EmbeddingEnqueuer`` gates on the ``Settings``
+    object the DI container snapshotted at import. Moving only one leaves a test
+    asserting an enqueue that never happens -- or, worse, passing while
+    asserting one does not.
 
     Both directions are forced explicitly because the ambient value is not the
     same everywhere: a developer with EMBEDDING_PROVIDER in a ``.env`` above the
     repo runs the suite with embeddings on, CI runs it with them off. A test
     that leant on the default would pass on one and fail on the other.
+
+    The embedding client is a Singleton, so a cached instance built from the
+    real settings would survive the override and defeat the point.
     """
     from src.core import container  # noqa: PLC0415
 
@@ -49,24 +57,27 @@ def _embedding_provider(provider: str | None) -> Iterator[None]:
         get_settings().model_copy(
             update={
                 "EMBEDDING_PROVIDER": provider,
-                "EMBEDDING_MODEL_NAME": "test-embedding-model",
+                "EMBEDDING_MODEL_NAME": TEST_MODEL_NAME,
                 "EMBEDDING_BASE_URL": "http://localhost:11434",
             }
         )
     )
+    container.shared.reset_singletons()
     try:
-        yield
+        with patch(ENABLED, return_value=provider is not None):
+            yield
     finally:
         container.settings.reset_last_overriding()
+        container.shared.reset_singletons()
 
 
 def embeddings_enabled() -> AbstractContextManager[None]:
-    """Write paths enqueue embeddings inside this block."""
+    """Embeddings are configured inside this block: routers answer, writes enqueue."""
     return _embedding_provider("ollama")
 
 
 def embeddings_disabled() -> AbstractContextManager[None]:
-    """Write paths must not enqueue anything inside this block."""
+    """No embedding provider inside this block: routers refuse, writes enqueue nothing."""
     return _embedding_provider(None)
 
 
@@ -103,7 +114,7 @@ async def index_highlight(
             highlight_id=highlight.id,
             book_id=book.id,
             embedding=vector if vector is not None else [0.1, 0.2],
-            model_name=current_model_name(settings),
+            model_name=TEST_MODEL_NAME,
             model_version=settings.EMBEDDING_MODEL_VERSION,
             content_hash=content_hash(hashed_text if hashed_text is not None else highlight.text),
         )
@@ -135,7 +146,7 @@ async def plant_indexed_highlight(
 
 async def get_search(client: AsyncClient, **params: PrimitiveData) -> Response:
     """GET /semantic/search with the feature flag forced on. Status not asserted."""
-    with patch(ENABLED, return_value=True):
+    with embeddings_enabled():
         return await client.get("/api/v1/semantic/search", params={"q": "idea", **params})
 
 
@@ -148,7 +159,7 @@ async def search_content_ids(client: AsyncClient, **params: PrimitiveData) -> li
 
 async def get_related(client: AsyncClient, **params: PrimitiveData) -> Response:
     """GET /semantic/related with the feature flag forced on."""
-    with patch(ENABLED, return_value=True):
+    with embeddings_enabled():
         return await client.get("/api/v1/semantic/related", params=params)
 
 
@@ -159,7 +170,7 @@ async def backfill_enqueued_ids(client: AsyncClient, queue: AsyncMock) -> set[in
     enqueued -- one per slice, not one per unit -- so callers only have to assert
     *which* units were picked up.
     """
-    with patch(ENABLED, return_value=True):
+    with embeddings_enabled():
         response = await client.post("/api/v1/semantic/backfill")
 
     assert response.status_code == status.HTTP_202_ACCEPTED, response.text

--- a/backend/tests/test_semantic_backfill.py
+++ b/backend/tests/test_semantic_backfill.py
@@ -14,9 +14,7 @@ from tests.semantic_helpers import ENABLED, backfill_enqueued_ids, plant_indexed
 
 #: Patch target for the slice size, so a test can force several slices without
 #: planting 33 highlights to get past the real one.
-SLICE_SIZE = (
-    "src.application.semantic.commands.enqueue_content_embeddings_use_case.EMBEDDING_SLICE_SIZE"
-)
+SLICE_SIZE = "src.application.semantic.batching.EMBEDDING_SLICE_SIZE"
 
 
 @pytest.fixture

--- a/backend/tests/test_semantic_backfill.py
+++ b/backend/tests/test_semantic_backfill.py
@@ -8,7 +8,12 @@ from starlette import status
 
 from src.models import Book, Highlight
 from tests.conftest import create_test_highlight
-from tests.semantic_helpers import ENABLED, backfill_enqueued_ids, plant_indexed_highlight
+from tests.semantic_helpers import (
+    backfill_enqueued_ids,
+    embeddings_disabled,
+    embeddings_enabled,
+    plant_indexed_highlight,
+)
 
 #: Patch target for the slice size, so a test can force several slices without
 #: planting 33 highlights to get past the real one.
@@ -19,7 +24,7 @@ class TestBackfillEndpoint:
     async def test_blocked_when_embeddings_disabled(
         self, client: AsyncClient, job_queue: AsyncMock
     ) -> None:
-        with patch(ENABLED, return_value=False):
+        with embeddings_disabled():
             response = await client.post("/api/v1/semantic/backfill")
 
         assert response.status_code == status.HTTP_403_FORBIDDEN
@@ -32,7 +37,7 @@ class TestBackfillEndpoint:
         test_book: Book,
         test_highlight: Highlight,
     ) -> None:
-        with patch(ENABLED, return_value=True):
+        with embeddings_enabled():
             response = await client.post("/api/v1/semantic/backfill")
 
         assert response.status_code == status.HTTP_202_ACCEPTED
@@ -52,7 +57,7 @@ class TestBackfillEndpoint:
         request. The status is pinned exactly, and so is total_jobs: 200 alone
         would not say which outcome it was.
         """
-        with patch(ENABLED, return_value=True):
+        with embeddings_enabled():
             response = await client.post("/api/v1/semantic/backfill")
 
         assert response.status_code == status.HTTP_200_OK
@@ -110,7 +115,7 @@ class TestBackfillEndpoint:
             )
         job_queue.enqueue.side_effect = ["saq:1", RuntimeError("queue is down")]
 
-        with patch(ENABLED, return_value=True), patch(SLICE_SIZE, 1):
+        with embeddings_enabled(), patch(SLICE_SIZE, 1):
             response = await client.post("/api/v1/semantic/backfill")
 
         assert response.status_code == status.HTTP_202_ACCEPTED

--- a/backend/tests/test_semantic_backfill.py
+++ b/backend/tests/test_semantic_backfill.py
@@ -1,15 +1,13 @@
 """Tests for the POST /semantic/backfill ingestion endpoint."""
 
-from collections.abc import AsyncGenerator
 from unittest.mock import AsyncMock, patch
 
-import pytest
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 from starlette import status
 
 from src.models import Book, Highlight
-from tests.conftest import contract_checked_queue, create_test_highlight
+from tests.conftest import create_test_highlight
 from tests.semantic_helpers import ENABLED, backfill_enqueued_ids, plant_indexed_highlight
 
 #: Patch target for the slice size, so a test can force several slices without
@@ -17,35 +15,20 @@ from tests.semantic_helpers import ENABLED, backfill_enqueued_ids, plant_indexed
 SLICE_SIZE = "src.application.semantic.batching.EMBEDDING_SLICE_SIZE"
 
 
-@pytest.fixture
-async def override_queue() -> AsyncGenerator[AsyncMock, None]:
-    """Override the SAQ queue service (normally wired by the app lifespan).
-
-    Uses the shared contract-checked fake rather than a bare AsyncMock, so a
-    mismatch between this enqueue site and the worker task it names fails here.
-    """
-    from src.core import container  # noqa: PLC0415
-
-    fake = contract_checked_queue()
-    container.job_queue_service.override(fake)
-    yield fake
-    container.job_queue_service.reset_override()
-
-
 class TestBackfillEndpoint:
     async def test_blocked_when_embeddings_disabled(
-        self, client: AsyncClient, override_queue: AsyncMock
+        self, client: AsyncClient, job_queue: AsyncMock
     ) -> None:
         with patch(ENABLED, return_value=False):
             response = await client.post("/api/v1/semantic/backfill")
 
         assert response.status_code == status.HTTP_403_FORBIDDEN
-        override_queue.enqueue.assert_not_called()
+        job_queue.enqueue.assert_not_called()
 
     async def test_enqueues_a_batch_when_enabled(
         self,
         client: AsyncClient,
-        override_queue: AsyncMock,
+        job_queue: AsyncMock,
         test_book: Book,
         test_highlight: Highlight,
     ) -> None:
@@ -57,10 +40,10 @@ class TestBackfillEndpoint:
         assert data["total_jobs"] >= 1
         assert data["batch"]["batch_type"] == "content_embedding"
         assert data["batch"]["status"] == "pending"
-        override_queue.enqueue.assert_awaited()
+        job_queue.enqueue.assert_awaited()
 
     async def test_reports_nothing_to_do_without_failing_the_request(
-        self, client: AsyncClient, override_queue: AsyncMock, db_session: AsyncSession
+        self, client: AsyncClient, job_queue: AsyncMock, db_session: AsyncSession
     ) -> None:
         """Pressing backfill twice is normal, so the second press is not an error.
 
@@ -76,12 +59,12 @@ class TestBackfillEndpoint:
         data = response.json()
         assert data["total_jobs"] == 0
         assert data["batch"] is None
-        override_queue.enqueue.assert_not_called()
+        job_queue.enqueue.assert_not_called()
 
     async def test_packs_units_into_one_job_per_slice(
         self,
         client: AsyncClient,
-        override_queue: AsyncMock,
+        job_queue: AsyncMock,
         db_session: AsyncSession,
         test_book: Book,
     ) -> None:
@@ -100,15 +83,15 @@ class TestBackfillEndpoint:
             )
 
         with patch(SLICE_SIZE, 2):
-            enqueued = await backfill_enqueued_ids(client, override_queue)
+            enqueued = await backfill_enqueued_ids(client, job_queue)
 
         assert len(enqueued) == 5
-        assert override_queue.enqueue.await_count == 3
+        assert job_queue.enqueue.await_count == 3
 
     async def test_records_slices_it_could_not_enqueue_as_failures(
         self,
         client: AsyncClient,
-        override_queue: AsyncMock,
+        job_queue: AsyncMock,
         db_session: AsyncSession,
         test_book: Book,
     ) -> None:
@@ -125,7 +108,7 @@ class TestBackfillEndpoint:
                 text=text,
                 datetime_str="2024-01-15 14:30:22",
             )
-        override_queue.enqueue.side_effect = ["saq:1", RuntimeError("queue is down")]
+        job_queue.enqueue.side_effect = ["saq:1", RuntimeError("queue is down")]
 
         with patch(ENABLED, return_value=True), patch(SLICE_SIZE, 1):
             response = await client.post("/api/v1/semantic/backfill")
@@ -141,7 +124,7 @@ class TestBackfillReconciliation:
     async def test_enqueues_content_whose_hash_drifted_but_not_current_content(
         self,
         client: AsyncClient,
-        override_queue: AsyncMock,
+        job_queue: AsyncMock,
         db_session: AsyncSession,
         test_book: Book,
     ) -> None:
@@ -151,16 +134,16 @@ class TestBackfillReconciliation:
         )
         await plant_indexed_highlight(db_session, test_book, "untouched text")
 
-        assert await backfill_enqueued_ids(client, override_queue) == {drifted.id}
+        assert await backfill_enqueued_ids(client, job_queue) == {drifted.id}
 
     async def test_enqueues_orphaned_embedding_so_it_gets_pruned(
         self,
         client: AsyncClient,
-        override_queue: AsyncMock,
+        job_queue: AsyncMock,
         db_session: AsyncSession,
         test_book: Book,
     ) -> None:
         """An embedding outliving its source is work: the job deletes it."""
         gone = await plant_indexed_highlight(db_session, test_book, "since deleted", deleted=True)
 
-        assert await backfill_enqueued_ids(client, override_queue) == {gone.id}
+        assert await backfill_enqueued_ids(client, job_queue) == {gone.id}

--- a/backend/tests/test_semantic_live_enqueue.py
+++ b/backend/tests/test_semantic_live_enqueue.py
@@ -1,0 +1,343 @@
+"""Tests for embedding jobs enqueued as a side effect of a write.
+
+The subject is the seam, not the embedding: what these pin is *which* units a
+create, an edit or an upload hands to the queue, and -- at least as important --
+that a queue which is off or broken never costs the user their write.
+
+The flag here is ``embeddings_enabled``, the write-path gate, which is a
+different lever from the ``ENABLED`` the router tests patch; see the helper.
+"""
+
+from collections.abc import AsyncGenerator
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from starlette import status
+
+from src import models
+from src.application.ai.ai_usage_context import AIUsageContext
+from src.application.reading.protocols.ai_digest_service import DigestResult
+from src.domain.reading.entities.chapter_digest import DigestQuestion
+from src.models import Book, Chapter, Note
+from tests.conftest import CreateBookFunc, create_test_chapter
+from tests.semantic_helpers import embeddings_disabled, embeddings_enabled
+
+#: Patch target for the slice size, so an upload can be cut into several jobs
+#: without posting 33 highlights.
+SLICE_SIZE = "src.application.semantic.batching.EMBEDDING_SLICE_SIZE"
+
+_EPUB_BYTES = b"PK\x03\x04 not really an epub"
+
+
+def embedding_calls(job_queue: AsyncMock) -> list[dict[str, Any]]:
+    """The kwargs of every embedding enqueue, ignoring any other task."""
+    return [
+        call.kwargs
+        for call in job_queue.enqueue.await_args_list
+        if call.args and call.args[0] == "generate_content_embeddings"
+    ]
+
+
+async def create_note(client: AsyncClient, book: Book) -> dict[str, Any]:
+    response = await client.post(
+        "/api/v1/notes",
+        json={"title": "Guilt", "body": "The axe is a symbol", "book_id": book.id},
+    )
+    assert response.status_code == status.HTTP_201_CREATED, response.text
+    return response.json()["note"]
+
+
+async def upload_highlights(
+    client: AsyncClient, client_book_id: str, *texts: str
+) -> dict[str, Any]:
+    response = await client.post(
+        "/api/v1/highlights/upload",
+        json={
+            "client_book_id": client_book_id,
+            "highlights": [
+                {"text": text, "page": index, "datetime": f"2024-01-15 14:30:{index:02d}"}
+                for index, text in enumerate(texts)
+            ],
+        },
+    )
+    assert response.status_code == status.HTTP_200_OK, response.text
+    return response.json()
+
+
+class TestNoteWrites:
+    async def test_create_enqueues_one_bare_job_for_the_note(
+        self, client: AsyncClient, job_queue: AsyncMock, test_book: Book
+    ) -> None:
+        with embeddings_enabled():
+            note = await create_note(client, test_book)
+
+        assert embedding_calls(job_queue) == [
+            {
+                "retries": 3,
+                "timeout_seconds": 300,
+                "content_type": "note",
+                "content_ids": [note["id"]],
+                "user_id": test_book.user_id,
+            }
+        ]
+
+    async def test_create_does_not_open_a_batch(
+        self, client: AsyncClient, job_queue: AsyncMock, db_session: AsyncSession, test_book: Book
+    ) -> None:
+        """A single edit is one job, so there is no progress to track.
+
+        A JobBatch per note save would put a row in the batch table for every
+        edit, and every one of them would be a batch of one.
+        """
+        with embeddings_enabled():
+            await create_note(client, test_book)
+
+        assert "batch_id" not in embedding_calls(job_queue)[0]
+        batches = (await db_session.execute(select(models.JobBatchModel))).scalars().all()
+        assert batches == []
+
+    async def test_update_re_enqueues_the_edited_note(
+        self, client: AsyncClient, job_queue: AsyncMock, test_book: Book
+    ) -> None:
+        with embeddings_enabled():
+            note = await create_note(client, test_book)
+            response = await client.put(
+                f"/api/v1/notes/{note['id']}",
+                json={"title": "Guilt", "body": "The axe is the point"},
+            )
+
+        assert response.status_code == status.HTTP_200_OK, response.text
+        assert response.json()["note"]["body"] == "The axe is the point"
+        assert [call["content_ids"] for call in embedding_calls(job_queue)] == [
+            [note["id"]],
+            [note["id"]],
+        ]
+
+    async def test_nothing_is_enqueued_while_embeddings_are_disabled(
+        self, client: AsyncClient, job_queue: AsyncMock, db_session: AsyncSession, test_book: Book
+    ) -> None:
+        """A server with no embedding provider: the note is written, just not indexed."""
+        with embeddings_disabled():
+            note = await create_note(client, test_book)
+
+        assert embedding_calls(job_queue) == []
+        stored = (
+            await db_session.execute(select(Note).filter_by(id=note["id"]))
+        ).scalar_one_or_none()
+        assert stored is not None
+
+    async def test_a_broken_queue_does_not_fail_the_write(
+        self, client: AsyncClient, job_queue: AsyncMock, db_session: AsyncSession, test_book: Book
+    ) -> None:
+        """The whole point of the seam: a missed embedding costs a backfill, not a note.
+
+        Backfill reconciles whatever this drops, so swallowing is the correct
+        behaviour rather than a shortcut.
+        """
+        job_queue.enqueue.side_effect = RuntimeError("redis is down")
+
+        with embeddings_enabled():
+            note = await create_note(client, test_book)
+
+        stored = (
+            await db_session.execute(select(Note).filter_by(id=note["id"]))
+        ).scalar_one_or_none()
+        assert stored is not None
+        assert stored.title == "Guilt"
+
+
+class TestHighlightUpload:
+    async def test_enqueues_a_batch_covering_exactly_the_created_highlights(
+        self,
+        client: AsyncClient,
+        job_queue: AsyncMock,
+        db_session: AsyncSession,
+        create_book_via_api: CreateBookFunc,
+    ) -> None:
+        await create_book_via_api({"client_book_id": "book-1", "title": "Crime and Punishment"})
+
+        with embeddings_enabled():
+            result = await upload_highlights(client, "book-1", "first idea", "second idea")
+
+        assert result["highlights_created"] == 2
+        stored_ids = set(
+            (await db_session.execute(select(models.Highlight.id))).scalars().all(),
+        )
+        calls = embedding_calls(job_queue)
+        assert {content_id for call in calls for content_id in call["content_ids"]} == stored_ids
+        assert {call["content_type"] for call in calls} == {"highlight"}
+
+    async def test_skipped_duplicates_are_not_re_enqueued(
+        self, client: AsyncClient, job_queue: AsyncMock, create_book_via_api: CreateBookFunc
+    ) -> None:
+        """A KOReader sync resends the whole book, so this is the common case.
+
+        Enqueuing the deduplicated ids would mean re-embedding every highlight
+        in a book on every sync -- the job would find them current and skip, but
+        only after a queue round trip each.
+        """
+        await create_book_via_api({"client_book_id": "book-1", "title": "Crime and Punishment"})
+
+        with embeddings_enabled():
+            await upload_highlights(client, "book-1", "first idea")
+            job_queue.enqueue.reset_mock()
+            second = await upload_highlights(client, "book-1", "first idea", "second idea")
+
+        assert (second["highlights_created"], second["highlights_skipped"]) == (1, 1)
+        assert len(embedding_calls(job_queue)) == 1
+        assert len(embedding_calls(job_queue)[0]["content_ids"]) == 1
+
+    async def test_batch_is_sized_to_slices_not_units(
+        self,
+        client: AsyncClient,
+        job_queue: AsyncMock,
+        db_session: AsyncSession,
+        create_book_via_api: CreateBookFunc,
+    ) -> None:
+        """Five highlights at two per slice is three jobs, and the batch says three."""
+        await create_book_via_api({"client_book_id": "book-1", "title": "Crime and Punishment"})
+
+        with embeddings_enabled(), patch(SLICE_SIZE, 2):
+            await upload_highlights(client, "book-1", "a", "b", "c", "d", "e")
+
+        calls = embedding_calls(job_queue)
+        assert [len(call["content_ids"]) for call in calls] == [2, 2, 1]
+
+        batch = (await db_session.execute(select(models.JobBatchModel))).scalars().one()
+        assert batch.total_jobs == len(calls)
+        assert batch.batch_type == "content_embedding"
+        assert {call["batch_id"] for call in calls} == {batch.id}
+
+    async def test_a_broken_queue_does_not_fail_the_upload(
+        self,
+        client: AsyncClient,
+        job_queue: AsyncMock,
+        db_session: AsyncSession,
+        create_book_via_api: CreateBookFunc,
+    ) -> None:
+        await create_book_via_api({"client_book_id": "book-1", "title": "Crime and Punishment"})
+        job_queue.enqueue.side_effect = RuntimeError("redis is down")
+
+        with embeddings_enabled():
+            result = await upload_highlights(client, "book-1", "first idea", "second idea")
+
+        assert result["highlights_created"] == 2
+        texts = (await db_session.execute(select(models.Highlight.text))).scalars().all()
+        assert sorted(texts) == ["first idea", "second idea"]
+
+    async def test_an_upload_that_creates_nothing_enqueues_nothing(
+        self, client: AsyncClient, job_queue: AsyncMock, create_book_via_api: CreateBookFunc
+    ) -> None:
+        await create_book_via_api({"client_book_id": "book-1", "title": "Crime and Punishment"})
+
+        with embeddings_enabled():
+            await upload_highlights(client, "book-1", "first idea")
+            job_queue.enqueue.reset_mock()
+            repeat = await upload_highlights(client, "book-1", "first idea")
+
+        assert repeat["highlights_created"] == 0
+        assert embedding_calls(job_queue) == []
+
+
+@pytest.fixture
+async def digest_chapter(
+    db_session: AsyncSession, test_book: Book
+) -> AsyncGenerator[Chapter, None]:
+    """A chapter that ``POST /chapters/{id}/digest/generate`` can actually digest.
+
+    Needs an EPUB-backed book and chapter positions; the AI call and the text
+    extraction are faked on the container so the endpoint is exercised without a
+    model or a real EPUB.
+    """
+    from src.core import container  # noqa: PLC0415
+
+    test_book.file_type = "epub"
+    test_book.ebook_file = "book.epub"
+    chapter = await create_test_chapter(db_session, test_book, "Part One", chapter_number=1)
+    chapter.start_xpoint = "/body/DocFragment[1]"
+    chapter.end_xpoint = "/body/DocFragment[2]"
+    await db_session.commit()
+
+    extraction = AsyncMock()
+    # Comfortably past the use case's 50-character floor for "worth digesting".
+    extraction.extract_chapter_text = lambda **_: (
+        "Raskolnikov paces his garret and talks himself into the theory that "
+        "some men are permitted to step over the line."
+    )
+
+    ai_service = AsyncMock()
+
+    async def generate_digest(content: str, usage_context: AIUsageContext) -> DigestResult:
+        return DigestResult(
+            summary="Raskolnikov commits the murder",
+            keypoints=["Poverty", "Theory of the extraordinary man"],
+            questions=[DigestQuestion(question="Why?", answer="Pride")],
+        )
+
+    ai_service.generate_digest = generate_digest
+
+    file_repo = AsyncMock()
+    file_repo.get_epub = AsyncMock(return_value=_EPUB_BYTES)
+
+    container.shared.ebook_text_extraction_service.override(extraction)
+    container.shared.ai_service.override(ai_service)
+    container.shared.file_repository.override(file_repo)
+    yield chapter
+    container.shared.file_repository.reset_last_overriding()
+    container.shared.ai_service.reset_last_overriding()
+    container.shared.ebook_text_extraction_service.reset_last_overriding()
+
+
+async def generate_digest(client: AsyncClient, chapter: Chapter) -> dict[str, Any]:
+    with patch("src.infrastructure.common.dependencies.is_ai_enabled", return_value=True):
+        response = await client.post(f"/api/v1/chapters/{chapter.id}/digest/generate")
+    assert response.status_code == status.HTTP_201_CREATED, response.text
+    return response.json()
+
+
+class TestDigestGeneration:
+    async def test_enqueues_the_generated_digest(
+        self, client: AsyncClient, job_queue: AsyncMock, digest_chapter: Chapter, test_book: Book
+    ) -> None:
+        with embeddings_enabled():
+            digest = await generate_digest(client, digest_chapter)
+
+        assert digest["summary"] == "Raskolnikov commits the murder"
+        assert embedding_calls(job_queue) == [
+            {
+                "retries": 3,
+                "timeout_seconds": 300,
+                "content_type": "digest",
+                "content_ids": [digest["id"]],
+                "user_id": test_book.user_id,
+            }
+        ]
+
+    async def test_answering_the_questions_does_not_re_enqueue(
+        self, client: AsyncClient, job_queue: AsyncMock, digest_chapter: Chapter
+    ) -> None:
+        """Only summary and keypoints are embedded, so an answer cannot stale it."""
+        with embeddings_enabled():
+            await generate_digest(client, digest_chapter)
+            job_queue.enqueue.reset_mock()
+            response = await client.put(
+                f"/api/v1/chapters/{digest_chapter.id}/digest/answers",
+                json={"answers": [{"question_index": 0, "user_answer": "Poverty"}]},
+            )
+
+        assert response.status_code == status.HTTP_200_OK, response.text
+        assert embedding_calls(job_queue) == []
+
+    async def test_a_broken_queue_does_not_fail_the_generation(
+        self, client: AsyncClient, job_queue: AsyncMock, digest_chapter: Chapter
+    ) -> None:
+        job_queue.enqueue.side_effect = RuntimeError("redis is down")
+
+        with embeddings_enabled():
+            digest = await generate_digest(client, digest_chapter)
+
+        assert digest["keypoints"] == ["Poverty", "Theory of the extraordinary man"]

--- a/backend/tests/test_semantic_live_enqueue.py
+++ b/backend/tests/test_semantic_live_enqueue.py
@@ -4,13 +4,13 @@ The subject is the seam, not the embedding: what these pin is *which* units a
 create, an edit or an upload hands to the queue, and -- at least as important --
 that a queue which is off or broken never costs the user their write.
 
-The flag here is ``embeddings_enabled``, the write-path gate, which is a
-different lever from the ``ENABLED`` the router tests patch; see the helper.
+``embeddings_enabled`` / ``embeddings_disabled`` move the feature gate, which
+production reads through two doors; the helper closes both.
 """
 
 from collections.abc import AsyncGenerator
 from typing import Any
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from httpx import AsyncClient
@@ -19,7 +19,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from starlette import status
 
 from src import models
-from src.application.ai.ai_usage_context import AIUsageContext
 from src.application.reading.protocols.ai_digest_service import DigestResult
 from src.domain.reading.entities.chapter_digest import DigestQuestion
 from src.models import Book, Chapter, Note
@@ -29,8 +28,6 @@ from tests.semantic_helpers import embeddings_disabled, embeddings_enabled
 #: Patch target for the slice size, so an upload can be cut into several jobs
 #: without posting 33 highlights.
 SLICE_SIZE = "src.application.semantic.batching.EMBEDDING_SLICE_SIZE"
-
-_EPUB_BYTES = b"PK\x03\x04 not really an epub"
 
 
 def embedding_calls(job_queue: AsyncMock) -> list[dict[str, Any]]:
@@ -70,8 +67,14 @@ async def upload_highlights(
 
 class TestNoteWrites:
     async def test_create_enqueues_one_bare_job_for_the_note(
-        self, client: AsyncClient, job_queue: AsyncMock, test_book: Book
+        self, client: AsyncClient, job_queue: AsyncMock, db_session: AsyncSession, test_book: Book
     ) -> None:
+        """One job, and no batch: a single edit has no progress worth tracking.
+
+        The kwargs are pinned by equality, so the absent ``batch_id`` is part of
+        the assertion -- a JobBatch per note save would put a row in the batch
+        table for every edit, each of them a batch of one.
+        """
         with embeddings_enabled():
             note = await create_note(client, test_book)
 
@@ -84,19 +87,6 @@ class TestNoteWrites:
                 "user_id": test_book.user_id,
             }
         ]
-
-    async def test_create_does_not_open_a_batch(
-        self, client: AsyncClient, job_queue: AsyncMock, db_session: AsyncSession, test_book: Book
-    ) -> None:
-        """A single edit is one job, so there is no progress to track.
-
-        A JobBatch per note save would put a row in the batch table for every
-        edit, and every one of them would be a batch of one.
-        """
-        with embeddings_enabled():
-            await create_note(client, test_book)
-
-        assert "batch_id" not in embedding_calls(job_queue)[0]
         batches = (await db_session.execute(select(models.JobBatchModel))).scalars().all()
         assert batches == []
 
@@ -262,26 +252,24 @@ async def digest_chapter(
     chapter.end_xpoint = "/body/DocFragment[2]"
     await db_session.commit()
 
-    extraction = AsyncMock()
-    # Comfortably past the use case's 50-character floor for "worth digesting".
-    extraction.extract_chapter_text = lambda **_: (
+    # MagicMock, not AsyncMock: extract_chapter_text is a synchronous protocol
+    # method, and the text is comfortably past the use case's 50-character floor
+    # for "worth digesting".
+    extraction = MagicMock()
+    extraction.extract_chapter_text.return_value = (
         "Raskolnikov paces his garret and talks himself into the theory that "
         "some men are permitted to step over the line."
     )
 
     ai_service = AsyncMock()
-
-    async def generate_digest(content: str, usage_context: AIUsageContext) -> DigestResult:
-        return DigestResult(
-            summary="Raskolnikov commits the murder",
-            keypoints=["Poverty", "Theory of the extraordinary man"],
-            questions=[DigestQuestion(question="Why?", answer="Pride")],
-        )
-
-    ai_service.generate_digest = generate_digest
+    ai_service.generate_digest.return_value = DigestResult(
+        summary="Raskolnikov commits the murder",
+        keypoints=["Poverty", "Theory of the extraordinary man"],
+        questions=[DigestQuestion(question="Why?", answer="Pride")],
+    )
 
     file_repo = AsyncMock()
-    file_repo.get_epub = AsyncMock(return_value=_EPUB_BYTES)
+    file_repo.get_epub.return_value = b"PK\x03\x04 not really an epub"
 
     container.shared.ebook_text_extraction_service.override(extraction)
     container.shared.ai_service.override(ai_service)
@@ -292,7 +280,7 @@ async def digest_chapter(
     container.shared.ebook_text_extraction_service.reset_last_overriding()
 
 
-async def generate_digest(client: AsyncClient, chapter: Chapter) -> dict[str, Any]:
+async def generate_chapter_digest(client: AsyncClient, chapter: Chapter) -> dict[str, Any]:
     with patch("src.infrastructure.common.dependencies.is_ai_enabled", return_value=True):
         response = await client.post(f"/api/v1/chapters/{chapter.id}/digest/generate")
     assert response.status_code == status.HTTP_201_CREATED, response.text
@@ -304,7 +292,7 @@ class TestDigestGeneration:
         self, client: AsyncClient, job_queue: AsyncMock, digest_chapter: Chapter, test_book: Book
     ) -> None:
         with embeddings_enabled():
-            digest = await generate_digest(client, digest_chapter)
+            digest = await generate_chapter_digest(client, digest_chapter)
 
         assert digest["summary"] == "Raskolnikov commits the murder"
         assert embedding_calls(job_queue) == [
@@ -322,7 +310,7 @@ class TestDigestGeneration:
     ) -> None:
         """Only summary and keypoints are embedded, so an answer cannot stale it."""
         with embeddings_enabled():
-            await generate_digest(client, digest_chapter)
+            await generate_chapter_digest(client, digest_chapter)
             job_queue.enqueue.reset_mock()
             response = await client.put(
                 f"/api/v1/chapters/{digest_chapter.id}/digest/answers",
@@ -338,6 +326,6 @@ class TestDigestGeneration:
         job_queue.enqueue.side_effect = RuntimeError("redis is down")
 
         with embeddings_enabled():
-            digest = await generate_digest(client, digest_chapter)
+            digest = await generate_chapter_digest(client, digest_chapter)
 
         assert digest["keypoints"] == ["Poverty", "Theory of the extraordinary man"]

--- a/backend/tests/test_semantic_search_api.py
+++ b/backend/tests/test_semantic_search_api.py
@@ -1,45 +1,23 @@
 """Tests for the GET /semantic/search and /semantic/related read endpoints."""
 
-from collections.abc import AsyncGenerator, Generator
+from collections.abc import AsyncGenerator
 from datetime import UTC, datetime
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock
 
 import pytest
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 from starlette import status
 
-from src.config import get_settings
 from src.infrastructure.semantic.routers.semantic import MAX_QUERY_LENGTH
 from src.models import Book, Highlight, User
 from tests.semantic_helpers import (
-    ENABLED,
+    embeddings_disabled,
     get_related,
     get_search,
     plant_indexed_highlight,
     search_content_ids,
 )
-
-
-@pytest.fixture
-def unconfigured_embeddings() -> Generator[None, None, None]:
-    """Force the container's settings to have no embedding provider.
-
-    Without this the test depends on local config: a developer whose ../.env
-    sets EMBEDDING_PROVIDER would have a client that builds happily, so the
-    disabled path would pass whether or not construction is deferred, and the
-    regression would only appear on CI.
-    """
-    from src.core import container  # noqa: PLC0415
-
-    settings = get_settings().model_copy(update={"EMBEDDING_PROVIDER": None})
-    container.settings.override(settings)
-    # The client is a Singleton, so a cached instance built from the real
-    # settings would survive the override and defeat the point of the fixture.
-    container.shared.reset_singletons()
-    yield
-    container.settings.reset_override()
-    container.shared.reset_singletons()
 
 
 @pytest.fixture
@@ -55,9 +33,7 @@ async def override_embedding_client() -> AsyncGenerator[AsyncMock, None]:
 
 
 class TestSearchEndpoint:
-    async def test_blocked_when_embeddings_disabled(
-        self, client: AsyncClient, unconfigured_embeddings: None
-    ) -> None:
+    async def test_blocked_when_embeddings_disabled(self, client: AsyncClient) -> None:
         """Deliberately does not override the embedding client.
 
         With no provider configured ``build_embedding_client`` raises, and this
@@ -66,7 +42,7 @@ class TestSearchEndpoint:
         ``LazyEmbeddingClient`` buys. Overriding the client would mask it, and
         the endpoint would answer 500 in production while the test passed.
         """
-        with patch(ENABLED, return_value=False):
+        with embeddings_disabled():
             response = await client.get("/api/v1/semantic/search", params={"q": "idea"})
 
         assert response.status_code == status.HTTP_403_FORBIDDEN
@@ -95,7 +71,7 @@ class TestSearchEndpoint:
 
 class TestRelatedEndpoint:
     async def test_blocked_when_embeddings_disabled(self, client: AsyncClient) -> None:
-        with patch(ENABLED, return_value=False):
+        with embeddings_disabled():
             response = await client.get(
                 "/api/v1/semantic/related",
                 params={"content_type": "highlight", "content_id": 1},

--- a/backend/tests/unit/application/semantic/commands/test_enqueue_content_embeddings_use_case.py
+++ b/backend/tests/unit/application/semantic/commands/test_enqueue_content_embeddings_use_case.py
@@ -4,8 +4,8 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from src.application.semantic.batching import EMBEDDING_SLICE_SIZE
 from src.application.semantic.commands.enqueue_content_embeddings_use_case import (
-    EMBEDDING_SLICE_SIZE,
     EnqueueContentEmbeddingsUseCase,
 )
 from src.application.semantic.content_type import ContentType

--- a/backend/tests/unit/infrastructure/jobs/test_embedded_worker_queue.py
+++ b/backend/tests/unit/infrastructure/jobs/test_embedded_worker_queue.py
@@ -1,0 +1,35 @@
+"""The embedded worker's queue must be the one the app connected.
+
+The invariant under test *is* a module-level global, so reaching for it is the
+subject rather than a shortcut around one.
+"""
+
+# pyright: reportPrivateUsage=false
+
+from typing import cast
+from unittest.mock import MagicMock
+
+from saq import Queue
+
+from src import worker
+
+
+def test_embedded_worker_binds_the_app_queue_as_the_module_queue() -> None:
+    """Otherwise a task that enqueues follow-up work builds its own, unconnected queue.
+
+    In embedded mode nothing else populates ``worker._queue``, so the lazy
+    branch of ``_get_queue`` would run and hand back a ``Queue`` whose pool is
+    never opened. Enqueuing on it raises, and the one caller that does this --
+    a chapter digest enqueuing its own embedding -- swallows enqueue failures on
+    purpose. The result would be digests that are silently never indexed, in the
+    default configuration (``EMBEDDED_WORKER`` is true).
+    """
+    app_queue = cast(Queue, MagicMock(spec=Queue))
+    original = worker._queue
+    try:
+        worker._queue = None
+        worker.create_embedded_worker(app_queue, concurrency=1)
+
+        assert worker._get_queue() is app_queue
+    finally:
+        worker._queue = original


### PR DESCRIPTION
Item 1 of #533 — phase D part 1. Until now, new and edited content was invisible to semantic search until someone pressed backfill. This closes that gap for all three content types: notes, highlights and digests.

## The seam

An `EmbeddingEnqueuer` application service behind `EmbeddingEnqueuerProtocol`, called from four write use cases:

| Path | Call |
|---|---|
| note create / update | `enqueue_for(NOTE, …)` — bare job, no batch |
| highlight upload | `enqueue_many(HIGHLIGHT, …)` — tracked batch of slices |
| chapter-digest generation | `enqueue_for(DIGEST, …)` |

It is deliberately weak in both directions: it no-ops when no embedding provider is configured, and it swallows enqueue failures. A queue that is down must not cost a user their note; the backfill sweep reconciles whatever is missed.

This is the first source-module → semantic dependency, so the narrowness is the argument for it: `notes` and `reading` commands import the port and the `ContentType` enum, never the service, the repository or the client. No import-linter contract changes; all five still pass.

Every call site enqueues **after** the repository save. Repositories commit inside `save()`, so a job that starts running immediately still reads committed content rather than the row it is replacing.

A single edit enqueues a bare job — a `JobBatch` per note save would be a batch row per edit, each of one job — which is why the worker task's `batch_id` widens back to `int | None`. `after_process` already tolerated its absence. A highlight upload enqueues only the ids `bulk_save` actually produced: a KOReader sync resends the whole book, so enqueuing the deduplicated ids would re-embed a book on every sync.

Answering a digest's questions does not re-enqueue; only summary and keypoints are embedded.

## Three deviations worth reviewing

**The reference implementation on `semantic-search-embeddings` (`7207ada7`) did not survive contact.** It predates #532's slice model and enqueues `generate_content_embedding` with a single `content_id`. The merged task takes `content_ids: list[int]`. Everything enqueue-shaped was rewritten against the merged signature.

**Failure accounting deviates from that reference on purpose.** It shrank `total_jobs` to what was enqueued; this uses the merged backfill's `mark_job_failed()` instead, so a batch that broke partway cannot terminate as "completed" with nothing to say the rest were dropped. That is what made a shared `record_dropped_slices` possible — so the "decide before extracting" question in #533 no longer applies to the two semantic paths, only to the digest path, which still diverges.

**jscpd did see the third-copy clone** that #533 predicted it could not. Extracting the accounting tail removed it. Ratchet lowered 2.66 → 2.6 (measured 2.5972), in the same change.

The first commit is that extraction on its own, with no behaviour change; the second is the feature.

## Tests

13 API tests in `test_semantic_live_enqueue.py`, through the endpoints. Two fixture changes are load-bearing:

- **The `client` fixture now installs the contract-checked queue fake.** Without it, every write path 500s at DI resolution in tests — before the enqueuer's swallowing can help. The fake also binds each enqueue's kwargs to the real worker task, which is exactly the check that catches `content_id=` against a task taking `content_ids=`. `test_semantic_backfill`'s local fixture folded into a shared `job_queue` one, so there is exactly one fake per test.
- **The write-path gate is `Settings.embeddings_enabled` on the container, not the `is_embeddings_enabled()` the router tests patch.** Different lever — patching the wrong one passes while asserting nothing. `embeddings_enabled()` / `embeddings_disabled()` force it explicitly in both directions, because the ambient value differs between a developer with `EMBEDDING_PROVIDER` in a `.env` and CI. Full suite run both ways: 758 pass in each.

All five call sites were falsifiability-checked — gate removed, slicing removed, swallowing removed, and each enqueue call deleted in turn — each failing exactly the tests that should fail.

This also adds the first API coverage of `POST /chapters/{id}/digest/generate`, which had none.

## Still open on #533

Item 2 (soft-delete cleanup, with the cross-tenant bug), frontend, production wiring, and the digest path's failure-accounting divergence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)