### PR TITLE
Prune a soft-deleted highlight's embedding at the delete site

### DIFF
--- a/backend/src/application/reading/commands/highlights/highlight_delete_use_case.py
+++ b/backend/src/application/reading/commands/highlights/highlight_delete_use_case.py
@@ -1,7 +1,13 @@
+import structlog
+
 from src.application.common.ownership import require_book
 from src.application.reading.protocols.book_repository import BookRepositoryProtocol
 from src.application.reading.protocols.highlight_repository import HighlightRepositoryProtocol
+from src.application.semantic.content_type import ContentType
+from src.application.semantic.protocols.embedding_repository import EmbeddingRepositoryProtocol
 from src.domain.common.value_objects import BookId, HighlightId, UserId
+
+logger = structlog.get_logger(__name__)
 
 
 class HighlightDeleteUseCase:
@@ -9,9 +15,11 @@ class HighlightDeleteUseCase:
         self,
         book_repository: BookRepositoryProtocol,
         highlight_repository: HighlightRepositoryProtocol,
+        embedding_repository: EmbeddingRepositoryProtocol,
     ) -> None:
         self.book_repository = book_repository
         self.highlight_repository = highlight_repository
+        self._embedding_repository = embedding_repository
 
     async def delete_highlights(self, book_id: int, highlight_ids: list[int], user_id: int) -> int:
         """
@@ -44,8 +52,34 @@ class HighlightDeleteUseCase:
         await require_book(self.book_repository, book_id_vo, user_id_vo)
 
         # Soft delete highlights (cascades to bookmarks and flashcards)
-        return await self.highlight_repository.soft_delete_by_ids(
+        deleted_ids = await self.highlight_repository.soft_delete_by_ids(
             highlight_ids=highlight_ids_vo,
             user_id=user_id_vo,
             book_id=book_id_vo,
         )
+
+        await self._delete_embeddings_for(deleted_ids)
+
+        return len(deleted_ids)
+
+    async def _delete_embeddings_for(self, deleted_ids: list[HighlightId]) -> None:
+        """Remove the embeddings of highlights this call actually soft deleted.
+
+        A soft delete is an UPDATE, so no foreign key cascades the embeddings
+        away; they have to be removed here. Only the IDs the repository
+        confirmed -- the requested IDs are unverified and could name another
+        user's highlight, whose embedding must not be touched.
+
+        The soft delete has already committed by now, and the two are not one
+        transaction, so a failure here must not fail the user's delete. Log it
+        and let the backfill sweep reconcile, as the enqueue seam does.
+        """
+        if not deleted_ids:
+            return
+
+        content_ids = [hid.value for hid in deleted_ids]
+        try:
+            # One statement for the whole batch rather than a job each.
+            await self._embedding_repository.delete_for(ContentType.HIGHLIGHT, content_ids)
+        except Exception:
+            logger.exception("failed_to_delete_highlight_embeddings", highlight_ids=content_ids)

--- a/backend/src/application/reading/protocols/highlight_repository.py
+++ b/backend/src/application/reading/protocols/highlight_repository.py
@@ -42,7 +42,14 @@ class HighlightRepositoryProtocol(Protocol):
         highlight_ids: list[HighlightId],
         user_id: UserId,
         book_id: BookId,
-    ) -> int: ...
+    ) -> list[HighlightId]:
+        """Soft delete the given highlights, returning the IDs actually deleted.
+
+        The requested IDs are unverified caller input; only the returned ones
+        passed the user and book check, so only those may drive cleanup of data
+        derived from a highlight.
+        """
+        ...
 
     # Tag associations (owned by reading; tags themselves live in the tagging module)
 

--- a/backend/src/containers/reading.py
+++ b/backend/src/containers/reading.py
@@ -87,6 +87,7 @@ class ReadingContainer(containers.DeclarativeContainer):
     ebook_text_extraction_service = providers.Dependency()
     ai_service = providers.Dependency()
     embedding_enqueuer = providers.Dependency()
+    embedding_repository = providers.Dependency()
 
     # Query services (read models)
     bookmark_query = providers.Dependency()
@@ -121,6 +122,7 @@ class ReadingContainer(containers.DeclarativeContainer):
         HighlightDeleteUseCase,
         book_repository=book_repository,
         highlight_repository=highlight_repository,
+        embedding_repository=embedding_repository,
     )
     highlight_upload_use_case = providers.Factory(
         HighlightUploadUseCase,

--- a/backend/src/containers/root.py
+++ b/backend/src/containers/root.py
@@ -70,6 +70,7 @@ class RootContainer(containers.DeclarativeContainer):
         reading_session_query=shared.reading_session_query,
         ereader_digest_query=shared.ereader_digest_query,
         embedding_enqueuer=embedding_enqueuer,
+        embedding_repository=shared.embedding_repository,
     )
 
     tagging = providers.Container(

--- a/backend/src/containers/shared.py
+++ b/backend/src/containers/shared.py
@@ -58,6 +58,7 @@ from src.infrastructure.reflection.repositories.book_reflection_repository impor
 from src.infrastructure.semantic.clients.lazy_embedding_client import LazyEmbeddingClient
 from src.infrastructure.semantic.content.content_source import ContentSource
 from src.infrastructure.semantic.queries.semantic_search_query import SemanticSearchQuery
+from src.infrastructure.semantic.repositories.embedding_repository import EmbeddingRepository
 from src.infrastructure.tagging.repositories import TagRepository
 
 
@@ -175,5 +176,6 @@ class SharedContainer(containers.DeclarativeContainer):
     # the settings check to first use, so resolving an endpoint's dependencies
     # cannot fail before the feature gate answers.
     embedding_client = providers.Singleton(LazyEmbeddingClient, settings=settings)
+    embedding_repository = providers.Factory(EmbeddingRepository, db=db)
     content_source = providers.Factory(ContentSource, db=db, settings=settings)
     semantic_search_query = providers.Factory(SemanticSearchQuery, db=db)

--- a/backend/src/infrastructure/reading/repositories/highlight_repository.py
+++ b/backend/src/infrastructure/reading/repositories/highlight_repository.py
@@ -245,7 +245,7 @@ class HighlightRepository:
         highlight_ids: list[HighlightId],
         user_id: UserId,
         book_id: BookId,
-    ) -> int:
+    ) -> list[HighlightId]:
         """
         Soft delete highlights by IDs with value objects.
 
@@ -257,33 +257,35 @@ class HighlightRepository:
             book_id: Book ID for validation
 
         Returns:
-            Number of highlights soft deleted
+            The IDs actually soft deleted -- those of the requested IDs that
+            belong to this user's book and were still live. Callers cleaning up
+            data derived from a highlight must use these, never the requested
+            IDs, which are unverified and may name another user's highlight.
         """
         # Convert value objects to primitives for query
         highlight_id_values = [hid.value for hid in highlight_ids]
 
-        # Subquery to get valid highlight IDs (belong to book/user, not already deleted)
-        valid_highlight_ids_subquery = (
-            select(HighlightORM.id)
-            .where(
-                HighlightORM.id.in_(highlight_id_values),
-                HighlightORM.book_id == book_id.value,
-                HighlightORM.user_id == user_id.value,
-                HighlightORM.deleted_at.is_(None),
-            )
-            .scalar_subquery()
+        # Resolve the deletable IDs up front rather than as a subquery: the
+        # caller needs them back, and once the UPDATE lands the predicate that
+        # selects them no longer matches.
+        stmt_valid_ids = select(HighlightORM.id).where(
+            HighlightORM.id.in_(highlight_id_values),
+            HighlightORM.book_id == book_id.value,
+            HighlightORM.user_id == user_id.value,
+            HighlightORM.deleted_at.is_(None),
         )
+        valid_ids = list((await self.db.execute(stmt_valid_ids)).scalars().all())
+        if not valid_ids:
+            return []
 
         # Bulk delete all bookmarks for valid highlights
-        stmt_delete_bookmarks = delete(BookmarkORM).where(
-            BookmarkORM.highlight_id.in_(valid_highlight_ids_subquery)
-        )
+        stmt_delete_bookmarks = delete(BookmarkORM).where(BookmarkORM.highlight_id.in_(valid_ids))
         result = await self.db.execute(stmt_delete_bookmarks)
         bookmarks_deleted = getattr(result, "rowcount", 0) or 0
 
         # Bulk delete all flashcards for valid highlights
         stmt_delete_flashcards = delete(FlashcardORM).where(
-            FlashcardORM.highlight_id.in_(valid_highlight_ids_subquery)
+            FlashcardORM.highlight_id.in_(valid_ids)
         )
         result = await self.db.execute(stmt_delete_flashcards)
         flashcards_deleted = getattr(result, "rowcount", 0) or 0
@@ -291,23 +293,17 @@ class HighlightRepository:
         # Bulk soft delete all valid highlights in a single query
         stmt_soft_delete = (
             update(HighlightORM)
-            .where(
-                HighlightORM.id.in_(highlight_id_values),
-                HighlightORM.book_id == book_id.value,
-                HighlightORM.user_id == user_id.value,
-                HighlightORM.deleted_at.is_(None),
-            )
+            .where(HighlightORM.id.in_(valid_ids))
             .values(deleted_at=datetime.now(UTC))
         )
-        result = await self.db.execute(stmt_soft_delete)
-        count = getattr(result, "rowcount", 0) or 0
+        await self.db.execute(stmt_soft_delete)
 
         await self.db.commit()
         logger.info(
-            f"Soft deleted {count} highlights, {bookmarks_deleted} associated bookmarks, "
+            f"Soft deleted {len(valid_ids)} highlights, {bookmarks_deleted} associated bookmarks, "
             f"and {flashcards_deleted} associated flashcards for book_id={book_id.value}, user_id={user_id.value}"
         )
-        return count
+        return [HighlightId(hid) for hid in valid_ids]
 
     async def find_by_book_id(self, book_id: BookId, user_id: UserId) -> list[Highlight]:
         """

--- a/backend/tests/test_books.py
+++ b/backend/tests/test_books.py
@@ -2,6 +2,7 @@
 
 from datetime import UTC, datetime
 from typing import NamedTuple
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from fastapi import status
@@ -10,7 +11,9 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src import models
+from src.infrastructure.semantic.repositories.embedding_repository import EmbeddingRepository
 from tests.conftest import create_test_book, create_test_highlight
+from tests.semantic_helpers import index_highlight, plant_indexed_highlight
 
 # Default user ID used by services (matches conftest default user)
 DEFAULT_USER_ID = 1
@@ -218,6 +221,105 @@ class TestDeleteBook:
 
 class TestDeleteHighlights:
     """Test suite for DELETE /books/:id/highlight endpoint."""
+
+    async def test_soft_deleting_highlights_removes_their_embeddings(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        book_with_highlights: BookWithHighlights,
+    ) -> None:
+        """No FK can reach this: a soft delete is an UPDATE, so nothing cascades.
+
+        The use case has to remove them explicitly, or they linger in the index
+        until the next backfill.
+        """
+        book = book_with_highlights.book
+        deleted, kept = book_with_highlights.highlights
+        for highlight in (deleted, kept):
+            await index_highlight(db_session, book, highlight)
+
+        response = await client.request(
+            "DELETE",
+            f"/api/v1/books/{book.id}/highlight",
+            json={"highlight_ids": [deleted.id]},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        remaining = (await db_session.execute(select(models.Embedding.content_id))).scalars().all()
+        assert list(remaining) == [kept.id]
+
+    async def test_leaves_embeddings_of_highlights_it_did_not_delete(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        book_with_highlights: BookWithHighlights,
+    ) -> None:
+        """The requested ids are unverified input, so only what was deleted may be pruned.
+
+        A stranger's id used to erase their embedding while their highlight
+        stayed live — their content silently vanished from semantic search until
+        a full backfill. An id of one's own from another book did the same.
+        """
+        book = book_with_highlights.book
+        mine, _ = book_with_highlights.highlights
+        await index_highlight(db_session, book, mine)
+
+        victim = models.User(email="victim@test.com")
+        db_session.add(victim)
+        await db_session.commit()
+        await db_session.refresh(victim)
+        their_book = await create_test_book(
+            db_session=db_session, user_id=victim.id, title="Someone else's"
+        )
+        theirs = await plant_indexed_highlight(db_session, their_book, "theirs")
+
+        my_other_book = await create_test_book(
+            db_session=db_session, user_id=DEFAULT_USER_ID, title="My other book"
+        )
+        elsewhere = await plant_indexed_highlight(db_session, my_other_book, "elsewhere")
+
+        response = await client.request(
+            "DELETE",
+            f"/api/v1/books/{book.id}/highlight",
+            json={"highlight_ids": [mine.id, theirs.id, elsewhere.id]},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["deleted_count"] == 1
+        surviving = (await db_session.execute(select(models.Embedding.content_id))).scalars().all()
+        assert set(surviving) == {theirs.id, elsewhere.id}
+        for untouched in (theirs, elsewhere):
+            await db_session.refresh(untouched)
+            assert untouched.deleted_at is None
+
+    async def test_embedding_cleanup_failure_does_not_fail_the_delete(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        book_with_highlights: BookWithHighlights,
+    ) -> None:
+        """The soft delete commits first, and the two are not one transaction.
+
+        Embedding bookkeeping must never fail a user write; the backfill sweep
+        reconciles what this leaves behind.
+        """
+        book = book_with_highlights.book
+        target, _ = book_with_highlights.highlights
+        await index_highlight(db_session, book, target)
+
+        with patch.object(
+            EmbeddingRepository, "delete_for", AsyncMock(side_effect=RuntimeError("boom"))
+        ):
+            response = await client.request(
+                "DELETE",
+                f"/api/v1/books/{book.id}/highlight",
+                json={"highlight_ids": [target.id]},
+            )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["deleted_count"] == 1
+        await db_session.refresh(target)
+        assert target.deleted_at is not None
 
     async def test_delete_highlights_success(
         self,

--- a/docs/adr/0002-semantic-search-embeddings.md
+++ b/docs/adr/0002-semantic-search-embeddings.md
@@ -50,17 +50,31 @@ time.
    lets `ON DELETE CASCADE` clear the highlights, chapters and digests beneath
    it, so no application seam can fire. Typed FK cascade anchors are what prune
    the index (see *Storage*).
-4. **Soft deletes are reconciled by the backfill orphan sweep.** A soft delete
-   is an `UPDATE` of `deleted_at`; the row never leaves the table and no foreign
-   key can see it. Rule 2 means such an embedding is invisible in the meantime,
-   so the sweep is sufficient and nothing has to happen at the delete site.
+4. **Soft deletes are cleaned up at the delete site, with the sweep as the
+   backstop.** A soft delete is an `UPDATE` of `deleted_at`; the row never
+   leaves the table and no foreign key can see it, so it is the one case the
+   database cannot prune. `HighlightDeleteUseCase` therefore removes those
+   embeddings itself — one statement per batch, not a job each. Rule 2 means
+   the embedding is invisible in the meantime, so this is index hygiene rather
+   than a correctness requirement, and rule 1 is why the cleanup only logs on
+   failure: the soft delete has already committed and the two are not one
+   transaction, so raising would fail a delete that succeeded. The backfill
+   orphan sweep still reconciles whatever the cleanup misses.
 
-Consequence worth stating plainly, because it is what keeps this PR small:
-**no existing domain module is touched.** The only cross-module contact is
+   The ids in a delete request are unverified caller input, and `delete_for`
+   filters on `content_type` and id alone, so the cleanup is driven by the ids
+   `soft_delete_by_ids` reports it *actually* deleted. Passing the requested
+   ids instead lets one user prune another's embeddings — their highlight stays
+   live while their content vanishes from search until a full backfill. A
+   `user_id` filter on the delete would not be enough; it cannot see ids of
+   one's own from a different book.
+
+The cross-module cost, stated plainly: **no domain module is touched, but two
+source-module application commands now depend on semantic ports** — the
+enqueuer for writes, the embedding repository for soft-delete cleanup. The only
+other cross-module contact is
 `infrastructure/semantic/content/content_source.py` reading other modules' ORM,
-which ADR-0001 already sanctions. Explicit cleanup at delete sites — the thing
-that would make a source module depend on a semantic port — is deliberately
-deferred (see *Deferred*).
+which ADR-0001 already sanctions.
 
 ## Decision
 
@@ -229,9 +243,9 @@ worker wires DI by hand), registered in both worker-settings function lists.
 stale, optionally scoped to a book), creates a `JobBatch`, and enqueues one job
 per **slice** of work items. Triggered manually via `POST`; it gates nothing — it
 is catch-up for existing content and post-model-swap re-embeds. Batch progress is
-visible for free through the existing batch views. Live enqueue-on-write is
-deferred (see *Deferred*), so until it lands the index is populated by running a
-backfill.
+visible for free through the existing batch views. Live enqueue-on-write has
+since landed alongside it, so backfill is now catch-up and reconciliation rather
+than the only way the index is populated.
 
 A job takes a slice of ids of one content type (32) rather than a single id.
 One job per unit made the unit of work match the unit of failure, which is
@@ -374,20 +388,10 @@ aligning the AI endpoints is a small follow-up, not a reason to propagate it.
 
 ## Deferred
 
-Sequenced deliberately, so each lands as its own reviewable change:
+Sequenced deliberately, so each lands as its own reviewable change. Live
+enqueue-on-write and explicit soft-delete cleanup have since landed; what
+remains:
 
-- **Live enqueue-on-write.** An `EmbeddingEnqueuer` application service called
-  from note create/update, highlight upload and digest generation, so new and
-  edited content is embedded without a manual backfill. It no-ops when the flag
-  is off and swallows enqueue failures — a missed embedding must never fail a
-  user's write. This is the first thing that makes a source module depend on a
-  semantic port.
-- **Explicit soft-delete cleanup.** Removing a soft-deleted highlight's
-  embedding at the delete site rather than waiting for the sweep. This is worth
-  care disproportionate to its size: the ids in a delete request are unverified
-  caller input, so the cleanup must be driven by the ids the repository
-  *actually* deleted, not the ids that were asked for — otherwise one user can
-  prune another's embeddings.
 - **Deterministic job keys** so overlapping backfills collapse (issue #531).
 - **Frontend.** Surfacing search and related content in the UI.
 - **Production wiring.** OpenRouter `baai/bge-m3`, confirming pgvector on


### PR DESCRIPTION
Item 2 of #533. Live enqueue-on-write (item 1) landed in #547; this is the remaining write-path gap, on the delete side.

## Why

A soft delete is an `UPDATE` of `deleted_at`, so the row never leaves the table and the typed FK cascade anchors that prune hard deletes are blind to it. The embedding survived until the next backfill sweep. This removes it where the delete happens, one statement per batch, with the sweep still the backstop.

The read path already hides such an embedding (hydration drops unresolvable hits), so this is index hygiene rather than a correctness fix — except for the part below, which is not.

## The part worth reviewing

The ids in a delete request are **unverified caller input**, and `delete_for` filters on `content_type` + id alone. Driving the cleanup from the requested ids lets one user prune another's embeddings: the delete correctly reports `deleted 0` and leaves their highlight live, but their content vanishes from semantic search until a full backfill. Ids of one's own from a different book do the same — which is why a `user_id` filter on `delete_for` would *not* have been sufficient.

So the cleanup is driven by the ids the repository confirmed it deleted. `soft_delete_by_ids` returns `list[HighlightId]` instead of a count, resolving them with a `SELECT` up front rather than a scalar subquery: the caller needs them back, and once the `UPDATE` lands the predicate that selects them no longer matches. The bookmark and flashcard deletes reuse that same list, so the three statements cannot disagree about scope.

`test_leaves_embeddings_of_highlights_it_did_not_delete` is the guard. Reintroducing the bug (passing the requested ids) fails it with `assert set() == {3, 4}` — both the other user's and the other book's embeddings erased. Verified, not assumed.

The cleanup also never fails the request: the soft delete has already committed and the two are not one transaction, so raising would answer 500 for a delete that succeeded.

## Notes

- No semantic-side code was needed — `delete_for` on `main` is already the plural, one-statement version, and the cascade anchors landed with #532. Smaller than the reference implementation on `semantic-search-embeddings` (`7254ce00`, `21b341e7`).
- `EmbeddingRepository` had no container provider at all; only `worker.py` built one by hand. `SharedContainer` gains one, threaded through to `reading`.
- `reading` now depends on two semantic ports (enqueuer for writes, embedding repository for soft-delete cleanup). ADR-0002 updated: consistency rule 4 previously said nothing has to happen at the delete site, and the Deferred list still carried item 1.
- The existing suite had no test that another user's ids are rejected at all — only the wrong-book case — so this closes a real coverage gap beyond the embedding assertion.

## Verification

761 backend tests pass. `make lint` clean (ruff, pyright, import-linter — all 5 contracts kept, including the new `reading` → `semantic` application edge). jscpd 2.6%, unchanged and still at the ratchet.

Not run: the manual end-to-end check against a live app + worker with embeddings configured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)