### PR TITLE
Sync uv.lock with the widened fastapi bound

### DIFF
--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -674,7 +674,7 @@ requires-dist = [
     { name = "boto3", specifier = ">=1.38.0,<2.0.0" },
     { name = "dependency-injector", specifier = ">=4.49.0,<5.0.0" },
     { name = "ebooklib", specifier = ">=0.20,<1.0" },
-    { name = "fastapi", specifier = ">=0.139.0,<0.141.0" },
+    { name = "fastapi", specifier = ">=0.139.0,<0.142.0" },
     { name = "httpx", specifier = ">=0.28.1,<0.29.0" },
     { name = "pgvector", specifier = ">=0.5.0" },
     { name = "pillow", specifier = ">=11.0.0" },


### PR DESCRIPTION
#519 widened the fastapi specifier in `backend/pyproject.toml` to `<0.142.0` but left the lockfile's `requires-dist` recording the old `<0.141.0`.

One line, metadata only — no resolved package version moves, so there is no install impact. But uv rewrites the line on every `uv run`, so the drift currently shows up as a spurious modified `uv.lock` in everyone's working tree.

Noticed while working on #548.

🤖 Generated with [Claude Code](https://claude.com/claude-code)