### PR TITLE
Allow only one active embedding backfill per user

### DIFF
--- a/backend/.jscpd.json
+++ b/backend/.jscpd.json
@@ -12,5 +12,5 @@
   "minLines": 5,
   "minTokens": 50,
   "reporters": ["ai", "threshold"],
-  "threshold": 2.6
+  "threshold": 2.55
 }

--- a/backend/alembic/versions/063_one_active_backfill_per_user.py
+++ b/backend/alembic/versions/063_one_active_backfill_per_user.py
@@ -1,0 +1,33 @@
+"""Allow only one active content-embedding backfill per user
+
+A partial unique index rather than an application-level check: the guard exists
+to stop a double-tap on the backfill button, and read-then-insert races exactly
+that. Only the backfill type is constrained -- upload-driven CONTENT_EMBEDDING
+batches must never be refused.
+
+Revision ID: 063
+Revises: 062
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "063"
+down_revision: str | Sequence[str] | None = "062"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+INDEX_NAME = "uq_job_batches_active_backfill_per_user"
+
+
+def upgrade() -> None:
+    op.execute(
+        f"CREATE UNIQUE INDEX {INDEX_NAME} ON job_batches (user_id) "
+        "WHERE batch_type = 'content_embedding_backfill' "
+        "AND status IN ('pending', 'running')"
+    )
+
+
+def downgrade() -> None:
+    op.execute(f"DROP INDEX {INDEX_NAME}")

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -3471,7 +3471,7 @@
           "semantic"
         ],
         "summary": "Backfill Embeddings",
-        "description": "Enqueue an embedding batch for the user's content, optionally scoped to a book.\n\nAnswers 202 with the batch to poll through ``GET /jobs/batches/{id}``, or 200\nwith ``total_jobs`` 0 when everything is already indexed. The second is a\nnormal outcome of pressing backfill twice, which is why it is not a 4xx: a\ncaller cannot tell a rejected request from a satisfied one.",
+        "description": "Enqueue an embedding batch for the user's content, optionally scoped to a book.\n\nAnswers 202 with the batch to poll through ``GET /jobs/batches/{id}``, or 200\nwith ``total_jobs`` 0 when everything is already indexed. The second is a\nnormal outcome of pressing backfill twice, which is why it is not a 4xx: a\ncaller cannot tell a rejected request from a satisfied one.\n\n409 when a backfill is already running -- ``GET /semantic/backfill/active``\nnames it, and cancelling it clears the way.",
         "operationId": "backfill_embeddings",
         "security": [
           {
@@ -3517,6 +3517,9 @@
               }
             }
           },
+          "409": {
+            "description": "A backfill is already running; cancel it or wait"
+          },
           "422": {
             "description": "Validation Error",
             "content": {
@@ -3528,6 +3531,41 @@
             }
           }
         }
+      }
+    },
+    "/api/v1/semantic/backfill/active": {
+      "get": {
+        "tags": [
+          "semantic"
+        ],
+        "summary": "Get Active Backfill",
+        "description": "Get the user's running backfill, if any -- what a 409 from POST refers to.",
+        "operationId": "get_active_backfill",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/JobBatchResponse"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "title": "Response Get Active Backfill"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
       }
     },
     "/api/v1/semantic/search": {

--- a/backend/src/application/jobs/queries/get_active_user_batch_use_case.py
+++ b/backend/src/application/jobs/queries/get_active_user_batch_use_case.py
@@ -1,0 +1,16 @@
+"""Read use case for finding a user's active batch of a given type."""
+
+from src.application.jobs.queries.job_batch import JobBatchQueryProtocol, JobBatchView
+from src.domain.common.value_objects.ids import UserId
+from src.domain.jobs.entities.job_batch import JobBatchType
+
+
+class GetActiveUserBatchUseCase:
+    def __init__(self, job_batch_query: JobBatchQueryProtocol) -> None:
+        self._job_batch_query = job_batch_query
+
+    async def execute(self, user_id: UserId, batch_type: JobBatchType) -> JobBatchView | None:
+        return await self._job_batch_query.get_active_for_user(
+            batch_type=batch_type,
+            user_id=user_id,
+        )

--- a/backend/src/application/jobs/queries/job_batch.py
+++ b/backend/src/application/jobs/queries/job_batch.py
@@ -35,3 +35,9 @@ class JobBatchQueryProtocol(Protocol):
     ) -> JobBatchView | None:
         """Return the newest batch for the reference that is still active."""
         ...
+
+    async def get_active_for_user(
+        self, batch_type: JobBatchType, user_id: UserId
+    ) -> JobBatchView | None:
+        """Return the user's active batch of this type, across all references."""
+        ...

--- a/backend/src/application/semantic/batching.py
+++ b/backend/src/application/semantic/batching.py
@@ -38,6 +38,7 @@ async def enqueue_embedding_batch(
     slices: list[tuple[ContentType, list[int]]],
     user_id: UserId,
     reference_id: str,
+    batch_type: JobBatchType,
     queue_service: JobQueueServiceProtocol,
     batch_repo: JobBatchRepositoryProtocol,
 ) -> JobBatch:
@@ -46,10 +47,14 @@ async def enqueue_embedding_batch(
     Stops at the first failed enqueue -- a queue that just rejected one job is
     unlikely to accept the next. Empty ``job_keys`` on the returned batch is the
     caller's signal that nothing landed.
+
+    ``batch_type`` separates the backfill from write-driven batches; see
+    ``JobBatchType``. Saving the batch can raise, which is how the backfill's
+    one-active-per-user constraint reaches its caller.
     """
     batch = JobBatch.create(
         user_id=user_id,
-        batch_type=JobBatchType.CONTENT_EMBEDDING,
+        batch_type=batch_type,
         reference_id=reference_id,
         total_jobs=len(slices),
     )

--- a/backend/src/application/semantic/commands/enqueue_content_embeddings_use_case.py
+++ b/backend/src/application/semantic/commands/enqueue_content_embeddings_use_case.py
@@ -11,7 +11,7 @@ from src.application.semantic.content_type import ContentType
 from src.application.semantic.protocols.content_source import ContentSourceProtocol, PendingUnit
 from src.domain.common.exceptions import DomainError
 from src.domain.common.value_objects.ids import BookId, UserId
-from src.domain.jobs.entities.job_batch import JobBatch
+from src.domain.jobs.entities.job_batch import JobBatch, JobBatchType
 
 logger = structlog.get_logger(__name__)
 
@@ -62,6 +62,7 @@ class EnqueueContentEmbeddingsUseCase:
             _slices(items_to_generate_embeddings),
             user_id=user_id,
             reference_id=reference_id,
+            batch_type=JobBatchType.CONTENT_EMBEDDING_BACKFILL,
             queue_service=self._queue_service,
             batch_repo=self._batch_repo,
         )

--- a/backend/src/application/semantic/services/embedding_enqueuer.py
+++ b/backend/src/application/semantic/services/embedding_enqueuer.py
@@ -21,6 +21,7 @@ from src.application.semantic.batching import (
 from src.application.semantic.content_type import ContentType
 from src.config import Settings
 from src.domain.common.value_objects.ids import UserId
+from src.domain.jobs.entities.job_batch import JobBatchType
 
 logger = structlog.get_logger(__name__)
 
@@ -76,6 +77,7 @@ class EmbeddingEnqueuer:
                 [(content_type, content_slice) for content_slice in slice_ids(content_ids)],
                 user_id=UserId(user_id),
                 reference_id=reference_id,
+                batch_type=JobBatchType.CONTENT_EMBEDDING,
                 queue_service=self._queue_service,
                 batch_repo=self._batch_repo,
             )

--- a/backend/src/containers/jobs.py
+++ b/backend/src/containers/jobs.py
@@ -9,6 +9,9 @@ from src.application.jobs.commands.enqueue_book_digests_use_case import (
 from src.application.jobs.queries.get_active_book_batch_use_case import (
     GetActiveBookBatchUseCase,
 )
+from src.application.jobs.queries.get_active_user_batch_use_case import (
+    GetActiveUserBatchUseCase,
+)
 from src.application.jobs.queries.get_job_batch_use_case import GetJobBatchUseCase
 
 
@@ -44,5 +47,10 @@ class JobsContainer(containers.DeclarativeContainer):
 
     get_active_book_batch_use_case = providers.Factory(
         GetActiveBookBatchUseCase,
+        job_batch_query=job_batch_query,
+    )
+
+    get_active_user_batch_use_case = providers.Factory(
+        GetActiveUserBatchUseCase,
         job_batch_query=job_batch_query,
     )

--- a/backend/src/domain/jobs/entities/job_batch.py
+++ b/backend/src/domain/jobs/entities/job_batch.py
@@ -10,10 +10,17 @@ from src.domain.common.value_objects.ids import JobBatchId, UserId
 
 
 class JobBatchType(StrEnum):
-    """Supported batch job types."""
+    """Supported batch job types.
+
+    Embedding work carries two: ``CONTENT_EMBEDDING`` for batches a write raises
+    (an upload), ``CONTENT_EMBEDDING_BACKFILL`` for the user-triggered
+    reconcile. Only the latter is limited to one active batch per user, so an
+    upload is never refused because a backfill is running.
+    """
 
     CHAPTER_DIGEST = "chapter_digest"
     CONTENT_EMBEDDING = "content_embedding"
+    CONTENT_EMBEDDING_BACKFILL = "content_embedding_backfill"
 
 
 class JobBatchStatus(StrEnum):

--- a/backend/src/domain/jobs/exceptions.py
+++ b/backend/src/domain/jobs/exceptions.py
@@ -1,6 +1,7 @@
 """Jobs domain exceptions."""
 
-from src.domain.common.exceptions import EntityNotFoundError
+from src.domain.common.exceptions import ConflictError, EntityNotFoundError
+from src.domain.jobs.entities.job_batch import JobBatchType
 
 
 class JobBatchNotFoundError(EntityNotFoundError):
@@ -8,3 +9,14 @@ class JobBatchNotFoundError(EntityNotFoundError):
 
     def __init__(self, batch_id: int) -> None:
         super().__init__("JobBatch", batch_id)
+
+
+class ActiveJobBatchExistsError(ConflictError):
+    """Raised when a batch type limited to one active run already has one."""
+
+    def __init__(self, batch_type: JobBatchType) -> None:
+        super().__init__(
+            f"An active {batch_type.value} batch already exists",
+            {"batch_type": batch_type.value},
+        )
+        self.batch_type = batch_type

--- a/backend/src/infrastructure/jobs/orm/job_batch_model.py
+++ b/backend/src/infrastructure/jobs/orm/job_batch_model.py
@@ -2,16 +2,46 @@
 
 from datetime import datetime as dt
 
-from sqlalchemy import DateTime, Integer, String, func
+from sqlalchemy import DateTime, Index, Integer, String, and_, column, func
 from sqlalchemy.dialects.postgresql import JSONB as PG_JSONB
 from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.sql.elements import ColumnElement
 from sqlalchemy.types import JSON
 
 from src.database import Base
+from src.domain.jobs.entities.job_batch import (
+    ACTIVE_JOB_BATCH_STATUSES,
+    JobBatchType,
+)
+
+ONE_ACTIVE_BACKFILL_INDEX = "uq_job_batches_active_backfill_per_user"
+
+
+def _active_backfill_predicate() -> ColumnElement[bool]:
+    """Rows the one-backfill-per-user index covers.
+
+    Built from the enums rather than string literals so a renamed status or type
+    breaks here instead of silently emptying the predicate. The migration
+    repeats the literals by design -- it is a frozen snapshot.
+    """
+    return and_(
+        column("batch_type") == JobBatchType.CONTENT_EMBEDDING_BACKFILL.value,
+        column("status").in_(sorted(s.value for s in ACTIVE_JOB_BATCH_STATUSES)),
+    )
 
 
 class JobBatchModel(Base):
     __tablename__ = "job_batches"
+
+    __table_args__ = (
+        Index(
+            ONE_ACTIVE_BACKFILL_INDEX,
+            "user_id",
+            unique=True,
+            postgresql_where=_active_backfill_predicate(),
+            sqlite_where=_active_backfill_predicate(),
+        ),
+    )
 
     id: Mapped[int] = mapped_column(primary_key=True, index=True)
     user_id: Mapped[int] = mapped_column(Integer, nullable=False, index=True)

--- a/backend/src/infrastructure/jobs/queries/job_batch_query.py
+++ b/backend/src/infrastructure/jobs/queries/job_batch_query.py
@@ -10,6 +10,7 @@ from datetime import datetime as dt
 
 from sqlalchemy import Select, select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.sql.elements import ColumnElement
 
 from src.application.jobs.queries.job_batch import JobBatchView
 from src.domain.common.value_objects.ids import JobBatchId, UserId
@@ -83,13 +84,34 @@ class JobBatchQuery:
         self, batch_type: JobBatchType, reference_id: str, user_id: UserId
     ) -> JobBatchView | None:
         """Return the newest batch for the reference that is still active."""
+        return await self._newest_active(
+            batch_type, user_id, JobBatchModel.reference_id == reference_id
+        )
+
+    async def get_active_for_user(
+        self, batch_type: JobBatchType, user_id: UserId
+    ) -> JobBatchView | None:
+        """Return the user's active batch of this type, across all references.
+
+        How a client finds the batch to cancel after a backfill was refused: the
+        409 says only that one is running, and for backfills the index
+        guarantees this returns at most one row.
+        """
+        return await self._newest_active(batch_type, user_id)
+
+    async def _newest_active(
+        self,
+        batch_type: JobBatchType,
+        user_id: UserId,
+        *conditions: ColumnElement[bool],
+    ) -> JobBatchView | None:
         result = await self.db.execute(
             _select_view()
             .where(
                 JobBatchModel.batch_type == batch_type.value,
-                JobBatchModel.reference_id == reference_id,
                 JobBatchModel.user_id == user_id.value,
                 JobBatchModel.status.in_(sorted(s.value for s in ACTIVE_JOB_BATCH_STATUSES)),
+                *conditions,
             )
             .order_by(JobBatchModel.created_at.desc())
             .limit(1)

--- a/backend/src/infrastructure/jobs/repositories/job_batch_repository.py
+++ b/backend/src/infrastructure/jobs/repositories/job_batch_repository.py
@@ -1,10 +1,12 @@
 """SQLAlchemy repository for job batches."""
 
 from sqlalchemy import case, select, update
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.domain.common.value_objects.ids import JobBatchId, UserId
-from src.domain.jobs.entities.job_batch import JobBatch, JobBatchStatus
+from src.domain.jobs.entities.job_batch import JobBatch, JobBatchStatus, JobBatchType
+from src.domain.jobs.exceptions import ActiveJobBatchExistsError
 from src.infrastructure.jobs.mappers.job_batch_mapper import JobBatchMapper
 from src.infrastructure.jobs.orm.job_batch_model import JobBatchModel
 
@@ -14,6 +16,17 @@ class JobBatchRepository:
         self._db = db
 
     async def save(self, batch: JobBatch) -> JobBatch:
+        """Persist a batch, translating the one-active-backfill index into a domain error.
+
+        The index is the only unique constraint on the table, and the only
+        batch type it covers is the backfill, so an integrity error inserting a
+        backfill row means a second one is already active. Postgres and SQLite
+        word that error differently, hence the type check rather than a match on
+        the constraint name. An update is excluded because no row can collide
+        with itself -- an integrity error there is some other fault, and
+        reporting it as "a backfill is already running" would send the caller
+        after a batch that does not exist.
+        """
         existing_model: JobBatchModel | None = None
         if batch.id.value > 0:
             existing_model = await self._db.get(JobBatchModel, batch.id.value)
@@ -22,7 +35,14 @@ class JobBatchRepository:
         if not existing_model:
             self._db.add(model)
 
-        await self._db.commit()
+        try:
+            await self._db.commit()
+        except IntegrityError:
+            await self._db.rollback()
+            if not existing_model and batch.batch_type is JobBatchType.CONTENT_EMBEDDING_BACKFILL:
+                raise ActiveJobBatchExistsError(batch.batch_type) from None
+            raise
+
         await self._db.refresh(model)
         return JobBatchMapper.to_domain(model)
 

--- a/backend/src/infrastructure/jobs/routers/job_batches.py
+++ b/backend/src/infrastructure/jobs/routers/job_batches.py
@@ -13,45 +13,20 @@ from src.application.jobs.queries.get_active_book_batch_use_case import (
     GetActiveBookBatchUseCase,
 )
 from src.application.jobs.queries.get_job_batch_use_case import GetJobBatchUseCase
-from src.application.jobs.queries.job_batch import JobBatchView
 from src.core import container
 from src.domain.common.value_objects.ids import BookId, JobBatchId, UserId
 from src.domain.identity import User
-from src.domain.jobs.entities.job_batch import JobBatch, JobBatchType
+from src.domain.jobs.entities.job_batch import JobBatchType
 from src.infrastructure.common.dependencies import require_ai_enabled
 from src.infrastructure.common.di import inject_use_case
 from src.infrastructure.identity import get_current_user
-from src.infrastructure.jobs.schemas.job_batch_schemas import JobBatchResponse
+from src.infrastructure.jobs.schemas.job_batch_schemas import (
+    JobBatchResponse,
+    batch_to_response,
+    view_to_response,
+)
 
 router = APIRouter(prefix="/jobs", tags=["jobs"])
-
-
-def _batch_to_response(batch: JobBatch) -> JobBatchResponse:
-    return JobBatchResponse(
-        id=batch.id.value,
-        batch_type=batch.batch_type.value,
-        reference_id=batch.reference_id,
-        total_jobs=batch.total_jobs,
-        completed_jobs=batch.completed_jobs,
-        failed_jobs=batch.failed_jobs,
-        status=batch.status.value,
-        created_at=batch.created_at,
-        updated_at=batch.updated_at,
-    )
-
-
-def _view_to_response(view: JobBatchView) -> JobBatchResponse:
-    return JobBatchResponse(
-        id=view.id,
-        batch_type=view.batch_type.value,
-        reference_id=view.reference_id,
-        total_jobs=view.total_jobs,
-        completed_jobs=view.completed_jobs,
-        failed_jobs=view.failed_jobs,
-        status=view.status.value,
-        created_at=view.created_at,
-        updated_at=view.updated_at,
-    )
 
 
 @router.post(
@@ -72,7 +47,7 @@ async def enqueue_book_digest(
         BookId(book_id),
         UserId(current_user.id.value),
     )
-    return _batch_to_response(batch)
+    return batch_to_response(batch)
 
 
 @router.get(
@@ -93,7 +68,7 @@ async def get_active_book_digest_batch(
         UserId(current_user.id.value),
         JobBatchType.CHAPTER_DIGEST,
     )
-    return _view_to_response(view) if view else None
+    return view_to_response(view) if view else None
 
 
 @router.get(
@@ -111,7 +86,7 @@ async def get_job_batch(
         JobBatchId(batch_id),
         UserId(current_user.id.value),
     )
-    return _view_to_response(view)
+    return view_to_response(view)
 
 
 @router.delete(
@@ -131,4 +106,4 @@ async def cancel_job_batch(
         JobBatchId(batch_id),
         UserId(current_user.id.value),
     )
-    return _batch_to_response(batch)
+    return batch_to_response(batch)

--- a/backend/src/infrastructure/jobs/schemas/job_batch_schemas.py
+++ b/backend/src/infrastructure/jobs/schemas/job_batch_schemas.py
@@ -1,8 +1,16 @@
-"""Pydantic schemas for job batch API responses."""
+"""Pydantic schemas for job batch API responses.
+
+The two converters live here rather than in a router because both the jobs and
+the semantic router answer with batches, from the write side and the read side
+respectively.
+"""
 
 from datetime import datetime
 
 from pydantic import BaseModel
+
+from src.application.jobs.queries.job_batch import JobBatchView
+from src.domain.jobs.entities.job_batch import JobBatch
 
 
 class JobBatchResponse(BaseModel):
@@ -15,3 +23,31 @@ class JobBatchResponse(BaseModel):
     status: str
     created_at: datetime
     updated_at: datetime
+
+
+def batch_to_response(batch: JobBatch) -> JobBatchResponse:
+    return JobBatchResponse(
+        id=batch.id.value,
+        batch_type=batch.batch_type.value,
+        reference_id=batch.reference_id,
+        total_jobs=batch.total_jobs,
+        completed_jobs=batch.completed_jobs,
+        failed_jobs=batch.failed_jobs,
+        status=batch.status.value,
+        created_at=batch.created_at,
+        updated_at=batch.updated_at,
+    )
+
+
+def view_to_response(view: JobBatchView) -> JobBatchResponse:
+    return JobBatchResponse(
+        id=view.id,
+        batch_type=view.batch_type.value,
+        reference_id=view.reference_id,
+        total_jobs=view.total_jobs,
+        completed_jobs=view.completed_jobs,
+        failed_jobs=view.failed_jobs,
+        status=view.status.value,
+        created_at=view.created_at,
+        updated_at=view.updated_at,
+    )

--- a/backend/src/infrastructure/semantic/routers/semantic.py
+++ b/backend/src/infrastructure/semantic/routers/semantic.py
@@ -5,6 +5,9 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, Query, Response
 from starlette import status
 
+from src.application.jobs.queries.get_active_user_batch_use_case import (
+    GetActiveUserBatchUseCase,
+)
 from src.application.semantic.commands.enqueue_content_embeddings_use_case import (
     EnqueueContentEmbeddingsUseCase,
 )
@@ -15,11 +18,15 @@ from src.application.semantic.queries.semantic_search import SemanticSearchView
 from src.core import container
 from src.domain.common.value_objects.ids import BookId, UserId
 from src.domain.identity import User
-from src.domain.jobs.entities.job_batch import JobBatch
+from src.domain.jobs.entities.job_batch import JobBatchType
 from src.infrastructure.common.dependencies import require_embeddings_enabled
 from src.infrastructure.common.di import inject_use_case
 from src.infrastructure.identity import get_current_user
-from src.infrastructure.jobs.schemas.job_batch_schemas import JobBatchResponse
+from src.infrastructure.jobs.schemas.job_batch_schemas import (
+    JobBatchResponse,
+    batch_to_response,
+    view_to_response,
+)
 from src.infrastructure.semantic.schemas.semantic_schemas import (
     BackfillResponse,
     SemanticSearchResult,
@@ -44,20 +51,6 @@ def _result(view: SemanticSearchView) -> SemanticSearchResult:
     )
 
 
-def _batch_to_response(batch: JobBatch) -> JobBatchResponse:
-    return JobBatchResponse(
-        id=batch.id.value,
-        batch_type=batch.batch_type.value,
-        reference_id=batch.reference_id,
-        total_jobs=batch.total_jobs,
-        completed_jobs=batch.completed_jobs,
-        failed_jobs=batch.failed_jobs,
-        status=batch.status.value,
-        created_at=batch.created_at,
-        updated_at=batch.updated_at,
-    )
-
-
 @router.post(
     "/backfill",
     response_model=BackfillResponse,
@@ -68,7 +61,10 @@ def _batch_to_response(batch: JobBatch) -> JobBatchResponse:
             # Same body as the 202, or the spec describes 200 as empty and a
             # generated client has nothing to read total_jobs from.
             "model": BackfillResponse,
-        }
+        },
+        status.HTTP_409_CONFLICT: {
+            "description": "A backfill is already running; cancel it or wait",
+        },
     },
 )
 @require_embeddings_enabled
@@ -86,6 +82,9 @@ async def backfill_embeddings(
     with ``total_jobs`` 0 when everything is already indexed. The second is a
     normal outcome of pressing backfill twice, which is why it is not a 4xx: a
     caller cannot tell a rejected request from a satisfied one.
+
+    409 when a backfill is already running -- ``GET /semantic/backfill/active``
+    names it, and cancelling it clears the way.
     """
     batch = await use_case.execute(
         UserId(current_user.id.value),
@@ -95,7 +94,27 @@ async def backfill_embeddings(
         # 200, not the route's default 202: nothing was accepted for processing.
         response.status_code = status.HTTP_200_OK
         return BackfillResponse(total_jobs=0, batch=None)
-    return BackfillResponse(total_jobs=batch.total_jobs, batch=_batch_to_response(batch))
+    return BackfillResponse(total_jobs=batch.total_jobs, batch=batch_to_response(batch))
+
+
+@router.get(
+    "/backfill/active",
+    response_model=JobBatchResponse | None,
+    status_code=status.HTTP_200_OK,
+)
+@require_embeddings_enabled
+async def get_active_backfill(
+    current_user: Annotated[User, Depends(get_current_user)],
+    use_case: GetActiveUserBatchUseCase = Depends(
+        inject_use_case(container.jobs.get_active_user_batch_use_case)
+    ),
+) -> JobBatchResponse | None:
+    """Get the user's running backfill, if any -- what a 409 from POST refers to."""
+    view = await use_case.execute(
+        UserId(current_user.id.value),
+        JobBatchType.CONTENT_EMBEDDING_BACKFILL,
+    )
+    return view_to_response(view) if view else None
 
 
 @router.get("/search", response_model=list[SemanticSearchResult])

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -263,15 +263,20 @@ async def client(db_session: AsyncSession, test_user: User) -> AsyncGenerator[As
     async def override_get_db() -> AsyncGenerator[AsyncSession, None]:
         yield db_session
 
+    # Read off the ORM user once, here, rather than per request. Every test
+    # shares one session, so a request that rolls back -- a rejected insert, say
+    # -- expires this instance, and the next request's attribute access would
+    # try to reload it from a dependency that cannot await.
+    current_user = DomainUser.create_with_id(
+        id=UserId(test_user.id),
+        email=test_user.email,
+        hashed_password=test_user.hashed_password,
+        created_at=test_user.created_at,
+        updated_at=test_user.updated_at,
+    )
+
     async def override_get_current_user() -> DomainUser:
-        # Convert ORM User to domain User entity for tests
-        return DomainUser.create_with_id(
-            id=UserId(test_user.id),
-            email=test_user.email,
-            hashed_password=test_user.hashed_password,
-            created_at=test_user.created_at,
-            updated_at=test_user.updated_at,
-        )
+        return current_user
 
     app.dependency_overrides[get_db] = override_get_db
     app.dependency_overrides[get_current_user] = override_get_current_user

--- a/backend/tests/semantic_helpers.py
+++ b/backend/tests/semantic_helpers.py
@@ -144,6 +144,24 @@ async def plant_indexed_highlight(
     return highlight
 
 
+async def upload_highlights(
+    client: AsyncClient, client_book_id: str, *texts: str
+) -> dict[str, PrimitiveData]:
+    """Upload highlights through the API -- the one write path that opens a batch."""
+    response = await client.post(
+        "/api/v1/highlights/upload",
+        json={
+            "client_book_id": client_book_id,
+            "highlights": [
+                {"text": text, "page": index, "datetime": f"2024-01-15 14:30:{index:02d}"}
+                for index, text in enumerate(texts)
+            ],
+        },
+    )
+    assert response.status_code == status.HTTP_200_OK, response.text
+    return response.json()
+
+
 async def get_search(client: AsyncClient, **params: PrimitiveData) -> Response:
     """GET /semantic/search with the feature flag forced on. Status not asserted."""
     with embeddings_enabled():

--- a/backend/tests/test_semantic_backfill.py
+++ b/backend/tests/test_semantic_backfill.py
@@ -1,19 +1,26 @@
 """Tests for the POST /semantic/backfill ingestion endpoint."""
 
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, patch
 
 from httpx import AsyncClient
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from starlette import status
 
-from src.models import Book, Highlight
-from tests.conftest import create_test_highlight
+from src.domain.jobs.entities.job_batch import JobBatchStatus, JobBatchType
+from src.infrastructure.jobs.orm.job_batch_model import JobBatchModel
+from src.models import Book, Highlight, User
+from tests.conftest import CreateBookFunc, create_test_highlight
 from tests.semantic_helpers import (
     backfill_enqueued_ids,
     embeddings_disabled,
     embeddings_enabled,
     plant_indexed_highlight,
+    upload_highlights,
 )
+
+OTHER_USER_ID = 2
 
 #: Patch target for the slice size, so a test can force several slices without
 #: planting 33 highlights to get past the real one.
@@ -43,7 +50,7 @@ class TestBackfillEndpoint:
         assert response.status_code == status.HTTP_202_ACCEPTED
         data = response.json()
         assert data["total_jobs"] >= 1
-        assert data["batch"]["batch_type"] == "content_embedding"
+        assert data["batch"]["batch_type"] == "content_embedding_backfill"
         assert data["batch"]["status"] == "pending"
         job_queue.enqueue.assert_awaited()
 
@@ -123,6 +130,177 @@ class TestBackfillEndpoint:
         assert data["total_jobs"] == 3
         assert data["batch"]["failed_jobs"] == 2
         assert data["batch"]["status"] == "running"
+
+
+class TestOneBackfillAtATime:
+    """The guard from issue #531: a double-tap must not double the bill."""
+
+    async def test_refuses_a_second_backfill_while_one_is_running(
+        self,
+        client: AsyncClient,
+        job_queue: AsyncMock,
+        test_book: Book,
+        test_highlight: Highlight,
+    ) -> None:
+        with embeddings_enabled():
+            first = await client.post("/api/v1/semantic/backfill")
+            second = await client.post("/api/v1/semantic/backfill")
+
+        assert first.status_code == status.HTTP_202_ACCEPTED
+        assert second.status_code == status.HTTP_409_CONFLICT
+        assert second.json()["error"] == "conflict"
+        # The point of the guard: the refused request enqueued nothing, so the
+        # units the first backfill picked up are not paid for twice.
+        assert job_queue.enqueue.await_count == 1
+
+    async def test_refuses_a_book_backfill_while_a_library_one_is_running(
+        self,
+        client: AsyncClient,
+        job_queue: AsyncMock,
+        test_book: Book,
+        test_highlight: Highlight,
+    ) -> None:
+        """The two carry different reference ids but overlapping content."""
+        with embeddings_enabled():
+            await client.post("/api/v1/semantic/backfill")
+            scoped = await client.post(f"/api/v1/semantic/backfill?book_id={test_book.id}")
+
+        assert scoped.status_code == status.HTTP_409_CONFLICT
+        assert job_queue.enqueue.await_count == 1
+
+    async def test_cancelling_the_running_backfill_clears_the_way(
+        self,
+        client: AsyncClient,
+        job_queue: AsyncMock,
+        test_book: Book,
+        test_highlight: Highlight,
+    ) -> None:
+        """Why the guard is not a lockout: a stranded batch is one request away.
+
+        Without this the ADR's original objection stands -- a backfill that
+        never reaches a terminal status would block every later one.
+        """
+        with embeddings_enabled():
+            first = await client.post("/api/v1/semantic/backfill")
+            batch_id = first.json()["batch"]["id"]
+            refused = await client.post("/api/v1/semantic/backfill")
+
+            cancelled = await client.delete(f"/api/v1/jobs/batches/{batch_id}")
+            second = await client.post("/api/v1/semantic/backfill")
+
+        assert refused.status_code == status.HTTP_409_CONFLICT
+        assert cancelled.status_code == status.HTTP_200_OK
+        assert cancelled.json()["status"] == "cancelled"
+        assert second.status_code == status.HTTP_202_ACCEPTED
+        assert second.json()["batch"]["id"] != batch_id
+
+    async def test_an_upload_still_enqueues_while_a_backfill_is_running(
+        self,
+        client: AsyncClient,
+        job_queue: AsyncMock,
+        db_session: AsyncSession,
+        test_book: Book,
+        test_highlight: Highlight,
+        create_book_via_api: CreateBookFunc,
+    ) -> None:
+        """Uploads keep their own batch type, so the guard cannot refuse content.
+
+        A single ``CONTENT_EMBEDDING`` type for both paths would make a running
+        backfill reject the batch an upload opens, and the uploaded highlights
+        would go unembedded until the next reconcile.
+        """
+        await create_book_via_api({"client_book_id": "book-1", "title": "Crime and Punishment"})
+
+        with embeddings_enabled():
+            backfill = await client.post("/api/v1/semantic/backfill")
+            await upload_highlights(client, "book-1", "fresh one", "fresh two")
+
+        assert backfill.status_code == status.HTTP_202_ACCEPTED
+        uploaded = {
+            content_id
+            for call in job_queue.enqueue.await_args_list[1:]
+            for content_id in call.kwargs["content_ids"]
+        }
+        assert len(uploaded) == 2
+
+        batch_types = (await db_session.execute(select(JobBatchModel.batch_type))).scalars().all()
+        assert sorted(batch_types) == ["content_embedding", "content_embedding_backfill"]
+
+
+class TestActiveBackfillEndpoint:
+    """GET /semantic/backfill/active -- how a client finds what a 409 refers to."""
+
+    async def test_blocked_when_embeddings_disabled(self, client: AsyncClient) -> None:
+        """Gated like every other route here: no provider, nothing to say about a backfill."""
+        with embeddings_disabled():
+            response = await client.get("/api/v1/semantic/backfill/active")
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    async def test_returns_null_when_nothing_is_running(self, client: AsyncClient) -> None:
+        with embeddings_enabled():
+            response = await client.get("/api/v1/semantic/backfill/active")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json() is None
+
+    async def test_returns_the_running_backfill(
+        self,
+        client: AsyncClient,
+        job_queue: AsyncMock,
+        test_book: Book,
+        test_highlight: Highlight,
+    ) -> None:
+        with embeddings_enabled():
+            started = await client.post("/api/v1/semantic/backfill")
+            response = await client.get("/api/v1/semantic/backfill/active")
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["id"] == started.json()["batch"]["id"]
+        assert data["batch_type"] == "content_embedding_backfill"
+        assert data["status"] == "pending"
+
+    async def test_ignores_a_batch_an_upload_opened(
+        self,
+        client: AsyncClient,
+        job_queue: AsyncMock,
+        create_book_via_api: CreateBookFunc,
+    ) -> None:
+        await create_book_via_api({"client_book_id": "book-1", "title": "Crime and Punishment"})
+
+        with embeddings_enabled():
+            await upload_highlights(client, "book-1", "just uploaded")
+            response = await client.get("/api/v1/semantic/backfill/active")
+
+        assert response.json() is None
+
+    async def test_ignores_another_users_backfill(
+        self, client: AsyncClient, db_session: AsyncSession
+    ) -> None:
+        now = datetime.now(UTC)
+        db_session.add(User(id=OTHER_USER_ID, email="other@test.com"))
+        await db_session.flush()
+        db_session.add(
+            JobBatchModel(
+                user_id=OTHER_USER_ID,
+                batch_type=JobBatchType.CONTENT_EMBEDDING_BACKFILL.value,
+                reference_id=f"user:{OTHER_USER_ID}",
+                total_jobs=2,
+                completed_jobs=0,
+                failed_jobs=0,
+                status=JobBatchStatus.RUNNING.value,
+                job_keys=["saq:1"],
+                created_at=now,
+                updated_at=now,
+            )
+        )
+        await db_session.commit()
+
+        with embeddings_enabled():
+            response = await client.get("/api/v1/semantic/backfill/active")
+
+        assert response.json() is None
 
 
 class TestBackfillReconciliation:

--- a/backend/tests/test_semantic_live_enqueue.py
+++ b/backend/tests/test_semantic_live_enqueue.py
@@ -23,7 +23,11 @@ from src.application.reading.protocols.ai_digest_service import DigestResult
 from src.domain.reading.entities.chapter_digest import DigestQuestion
 from src.models import Book, Chapter, Note
 from tests.conftest import CreateBookFunc, create_test_chapter
-from tests.semantic_helpers import embeddings_disabled, embeddings_enabled
+from tests.semantic_helpers import (
+    embeddings_disabled,
+    embeddings_enabled,
+    upload_highlights,
+)
 
 #: Patch target for the slice size, so an upload can be cut into several jobs
 #: without posting 33 highlights.
@@ -46,23 +50,6 @@ async def create_note(client: AsyncClient, book: Book) -> dict[str, Any]:
     )
     assert response.status_code == status.HTTP_201_CREATED, response.text
     return response.json()["note"]
-
-
-async def upload_highlights(
-    client: AsyncClient, client_book_id: str, *texts: str
-) -> dict[str, Any]:
-    response = await client.post(
-        "/api/v1/highlights/upload",
-        json={
-            "client_book_id": client_book_id,
-            "highlights": [
-                {"text": text, "page": index, "datetime": f"2024-01-15 14:30:{index:02d}"}
-                for index, text in enumerate(texts)
-            ],
-        },
-    )
-    assert response.status_code == status.HTTP_200_OK, response.text
-    return response.json()
 
 
 class TestNoteWrites:

--- a/backend/tests/unit/application/semantic/commands/test_enqueue_content_embeddings_use_case.py
+++ b/backend/tests/unit/application/semantic/commands/test_enqueue_content_embeddings_use_case.py
@@ -74,7 +74,7 @@ class TestEnqueueContentEmbeddings:
         assert batch is not None
 
         assert batch.total_jobs == 3
-        assert batch.batch_type == JobBatchType.CONTENT_EMBEDDING
+        assert batch.batch_type == JobBatchType.CONTENT_EMBEDDING_BACKFILL
         assert batch.reference_id == "user:1"
         assert len(batch.job_keys) == 3
         assert queue_service.enqueue.call_count == 3

--- a/docs/adr/0002-semantic-search-embeddings.md
+++ b/docs/adr/0002-semantic-search-embeddings.md
@@ -286,14 +286,33 @@ are recorded as failures** rather than trimmed out of `total_jobs`. Trimming
 made a backfill of 500 units that broke at item 3 terminate as "completed,
 total_jobs=3", with nothing to say the other 497 were dropped.
 
-Two backfills can **overlap**, and nothing dedups the jobs they enqueue.
-Refusing a new batch while one is active was considered and rejected: the
-enqueue loop runs inside the HTTP request, so a request that dies partway leaves
-a batch that never reaches a terminal status, and gating on "a batch is active"
-would then lock the user out of backfill permanently. Wasted work is the better
-failure of the two — most duplicates lose the hash race and cost nothing. The
-fix belongs at the queue instead, as deterministic job keys, so that
-re-enqueueing a unit collapses into the pending job rather than being gated.
+Two backfills can **overlap**, and nothing dedups the jobs they enqueue. The
+fix is to **refuse a second active backfill per user**, enforced by a partial
+unique index on `user_id` over the active statuses rather than by a
+read-then-insert check, which a double-tap races straight through.
+
+Two things the guard must *not* be keyed on. Not `reference_id`: a book
+backfill and a whole-library one carry different references but overlapping
+content, so a per-reference guard would miss the case it exists for. And not
+`CONTENT_EMBEDDING` as a whole, which a highlight upload also raises a batch
+under — an upload is content arriving, not a button, and must never be refused
+because a backfill happens to be running. Backfill therefore gets its own
+`JobBatchType`, and the index constrains only that type.
+
+This was first rejected on the grounds that a request dying mid-loop leaves a
+batch that never terminates, locking the user out of backfill for good. That
+holds only without a way back: `DELETE /jobs/batches/{id}` already cancels any
+batch type, so the lockout is a button press, not a hand-edited row. The
+cancel does not necessarily stop the *work* — `job_keys` is persisted after the
+enqueue loop, so a batch stranded mid-loop has no keys to abort and its jobs
+run on — but it clears the guard, which is what the lockout argument turns on.
+
+Deterministic job keys were the earlier plan and are not pursued: they leave
+open what `total_jobs` should count when an enqueue collapses into an existing
+job, which is the never-terminating batch again from the other side. Duplicates
+on the **live** enqueue path (a rapid edit-save-edit-save queuing several jobs
+for one note) are accepted as-is. A generation is cheap; what justifies the
+guard is the multiplier of doubling an entire library, not redundancy per se.
 Tracked in issue #531.
 
 ### Read side
@@ -392,7 +411,8 @@ Sequenced deliberately, so each lands as its own reviewable change. Live
 enqueue-on-write and explicit soft-delete cleanup have since landed; what
 remains:
 
-- **Deterministic job keys** so overlapping backfills collapse (issue #531).
+- **One active backfill per user**, guarded by a unique index and recoverable
+  through the existing batch cancel (issue #531).
 - **Frontend.** Surfacing search and related content in the UI.
 - **Production wiring.** OpenRouter `baai/bge-m3`, confirming pgvector on
   Railway — **0.8 or newer**, since the read path sets `hnsw.iterative_scan` —

--- a/frontend/src/api/generated/semantic/semantic.ts
+++ b/frontend/src/api/generated/semantic/semantic.ts
@@ -24,6 +24,7 @@ import type {
   BackfillEmbeddingsParams,
   BackfillResponse,
   HTTPValidationError,
+  JobBatchResponse,
   RelatedContentParams,
   SearchContentParams,
   SemanticSearchResult,
@@ -53,6 +54,9 @@ const withQueryKey = <T extends object, K>(query: T, queryKey: K): T & { queryKe
  * with ``total_jobs`` 0 when everything is already indexed. The second is a
  * normal outcome of pressing backfill twice, which is why it is not a 4xx: a
  * caller cannot tell a rejected request from a satisfied one.
+ *
+ * 409 when a backfill is already running -- ``GET /semantic/backfill/active``
+ * names it, and cancelling it clears the way.
  * @summary Backfill Embeddings
  */
 export const backfillEmbeddings = (params?: BackfillEmbeddingsParams, signal?: AbortSignal) => {
@@ -65,7 +69,7 @@ export const backfillEmbeddings = (params?: BackfillEmbeddingsParams, signal?: A
 };
 
 export const getBackfillEmbeddingsMutationOptions = <
-  TError = HTTPValidationError,
+  TError = void | HTTPValidationError,
   TContext = unknown,
 >(options?: {
   mutation?: UseMutationOptions<
@@ -103,12 +107,12 @@ export type BackfillEmbeddingsMutationResult = NonNullable<
   Awaited<ReturnType<typeof backfillEmbeddings>>
 >;
 
-export type BackfillEmbeddingsMutationError = HTTPValidationError;
+export type BackfillEmbeddingsMutationError = void | HTTPValidationError;
 
 /**
  * @summary Backfill Embeddings
  */
-export const useBackfillEmbeddings = <TError = HTTPValidationError, TContext = unknown>(
+export const useBackfillEmbeddings = <TError = void | HTTPValidationError, TContext = unknown>(
   options?: {
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof backfillEmbeddings>>,
@@ -126,6 +130,112 @@ export const useBackfillEmbeddings = <TError = HTTPValidationError, TContext = u
 > => {
   return useMutation(getBackfillEmbeddingsMutationOptions(options), queryClient);
 };
+/**
+ * Get the user's running backfill, if any -- what a 409 from POST refers to.
+ * @summary Get Active Backfill
+ */
+export const getActiveBackfill = (signal?: AbortSignal) => {
+  return axiosInstance<JobBatchResponse | null>({
+    url: `/api/v1/semantic/backfill/active`,
+    method: 'GET',
+    signal,
+  });
+};
+
+export const getGetActiveBackfillQueryKey = () => {
+  return [`/api/v1/semantic/backfill/active`] as const;
+};
+
+export const getGetActiveBackfillQueryOptions = <
+  TData = Awaited<ReturnType<typeof getActiveBackfill>>,
+  TError = unknown,
+>(options?: {
+  query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof getActiveBackfill>>, TError, TData>>;
+}) => {
+  const { query: queryOptions } = options ?? {};
+
+  const queryKey = queryOptions?.queryKey ?? getGetActiveBackfillQueryKey();
+
+  const queryFn: QueryFunction<Awaited<ReturnType<typeof getActiveBackfill>>> = ({ signal }) =>
+    getActiveBackfill(signal);
+
+  return { queryKey, queryFn, ...queryOptions } as UseQueryOptions<
+    Awaited<ReturnType<typeof getActiveBackfill>>,
+    TError,
+    TData
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+};
+
+export type GetActiveBackfillQueryResult = NonNullable<
+  Awaited<ReturnType<typeof getActiveBackfill>>
+>;
+export type GetActiveBackfillQueryError = unknown;
+
+export function useGetActiveBackfill<
+  TData = Awaited<ReturnType<typeof getActiveBackfill>>,
+  TError = unknown,
+>(
+  options: {
+    query: Partial<UseQueryOptions<Awaited<ReturnType<typeof getActiveBackfill>>, TError, TData>> &
+      Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof getActiveBackfill>>,
+          TError,
+          Awaited<ReturnType<typeof getActiveBackfill>>
+        >,
+        'initialData'
+      >;
+  },
+  queryClient?: QueryClient
+): DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+export function useGetActiveBackfill<
+  TData = Awaited<ReturnType<typeof getActiveBackfill>>,
+  TError = unknown,
+>(
+  options?: {
+    query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof getActiveBackfill>>, TError, TData>> &
+      Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof getActiveBackfill>>,
+          TError,
+          Awaited<ReturnType<typeof getActiveBackfill>>
+        >,
+        'initialData'
+      >;
+  },
+  queryClient?: QueryClient
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+export function useGetActiveBackfill<
+  TData = Awaited<ReturnType<typeof getActiveBackfill>>,
+  TError = unknown,
+>(
+  options?: {
+    query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof getActiveBackfill>>, TError, TData>>;
+  },
+  queryClient?: QueryClient
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+/**
+ * @summary Get Active Backfill
+ */
+
+export function useGetActiveBackfill<
+  TData = Awaited<ReturnType<typeof getActiveBackfill>>,
+  TError = unknown,
+>(
+  options?: {
+    query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof getActiveBackfill>>, TError, TData>>;
+  },
+  queryClient?: QueryClient
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+  const queryOptions = getGetActiveBackfillQueryOptions(options);
+
+  const query = useQuery(queryOptions, queryClient) as UseQueryResult<TData, TError> & {
+    queryKey: DataTag<QueryKey, TData, TError>;
+  };
+
+  return withQueryKey(query, queryOptions.queryKey);
+}
+
 /**
  * Rank the user's embedded content by semantic similarity to a free-text query.
  * @summary Search Content


### PR DESCRIPTION
Closes #531 (bar the rate-limiting item folded in at the bottom of that issue, which is untouched).

## What this does

`POST /semantic/backfill` refuses a second backfill while one is running, answering **409**. `GET /semantic/backfill/active` names the running batch, and the existing `DELETE /jobs/batches/{id}` cancels it — so a refusal is always recoverable.

## Why not deterministic job keys

The issue originally planned to dedup at the queue instead, because gating on "a batch is active" would lock a user out for good when a request dies mid-loop. That premise no longer holds: `DELETE /jobs/batches/{id}` already cancels any batch type, so the lockout it feared costs a button press rather than a hand-edited row.

Job keys also left an unresolved question the issue lists itself — what `total_jobs` should count when an enqueue collapses into an existing job. Count it and the batch never terminates, which is the same trap from the other side.

ADR-0002's decision section is updated to record the reversal.

## Design points worth review

- **The guard is a partial unique index, not a read-then-insert check.** `find active → none → create` is check-then-act with no lock, so two simultaneous requests both see nothing and both proceed — exactly the double-tap this is about. The repository translates the violation into `ActiveJobBatchExistsError`, which the existing domain-error handler already answers 409 for.
- **The backfill gets its own `JobBatchType`.** `EmbeddingEnqueuer.enqueue_many` opens a batch under `CONTENT_EMBEDDING` for highlight uploads; constraining that type would make an upload fail while a backfill runs. Content arriving must never be refused.
- **Not keyed on `reference_id` either.** A book backfill (`"5"`) and a library one (`"user:7"`) differ in reference but overlap in content, so a per-reference guard would miss the case it exists for.

## Accepted limits

- **Cancel does not reliably stop the work.** `job_keys` is persisted after the enqueue loop, so a batch stranded mid-loop has no keys to abort and its jobs run on. It still clears the guard, which is what the lockout argument turned on. Chapter digests have the same shape today.
- **Live-edit duplicates stay.** A rapid edit-save-edit-save can still queue several jobs for one note. A single generation is cheap; the multiplier of doubling a whole library is what justifies the guard.

## Incidental

- Both `JobBatchResponse` converters moved into the schema module — the jobs and semantic routers had a copy each. Duplication ratchet drops 2.6 → 2.55.
- The `client` test fixture now reads the ORM user once instead of per request. Tests share one session, so a request that rolls back expires the fixture user, and the identity override would then reload it from a context that cannot await. This made the cancel test fail with `MissingGreenlet` before it was fixed, and would have hit any future test that triggers a rollback.

## Verification

769 backend tests pass, pyright clean, 5/5 import-linter contracts kept, jscpd under threshold, frontend type-check and knip clean. The new tests were each confirmed to fail against the unguarded code.

No frontend work: there is no backfill UI yet, and ADR-0002 keeps it deferred. The generated client is regenerated for the new endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
