### PR TITLE
Run the embedding backfill from settings

### DIFF
--- a/frontend/.jscpd.json
+++ b/frontend/.jscpd.json
@@ -11,5 +11,5 @@
   "minLines": 5,
   "minTokens": 50,
   "reporters": ["ai", "threshold"],
-  "threshold": 1.8
+  "threshold": 1.7
 }

--- a/frontend/src/components/features/EmbeddingFeature.tsx
+++ b/frontend/src/components/features/EmbeddingFeature.tsx
@@ -1,0 +1,14 @@
+import type { ReactNode } from 'react';
+import { FeatureGate } from './FeatureGate.tsx';
+
+interface EmbeddingFeatureProps {
+  children: ReactNode;
+}
+
+export function EmbeddingFeature({ children }: EmbeddingFeatureProps) {
+  return (
+    <FeatureGate flag="embeddings" value={true}>
+      {children}
+    </FeatureGate>
+  );
+}

--- a/frontend/src/hooks/useJobBatchProgress.ts
+++ b/frontend/src/hooks/useJobBatchProgress.ts
@@ -1,0 +1,102 @@
+import { useCancelJobBatch, useGetJobBatch } from '@/api/generated/jobs/jobs';
+import type { JobBatchResponse } from '@/api/generated/model';
+import { useSnackbar } from '@/context/SnackbarContext';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+const TERMINAL_STATUSES = ['completed', 'completed_with_errors', 'failed', 'cancelled'];
+const POLL_INTERVAL = 3000;
+
+function isTerminal(status: string | undefined): boolean {
+  return !!status && TERMINAL_STATUSES.includes(status);
+}
+
+interface UseJobBatchProgressOptions {
+  /**
+   * The batch already running when the page loaded, from the feature's own
+   * "active batch" query. Tracking resumes from it, so a refresh mid-run does
+   * not lose the progress display.
+   */
+  activeBatch: JobBatchResponse | null | undefined;
+  /** The batch reached a terminal status. Fires once per batch. */
+  onFinished: (batch: JobBatchResponse) => void;
+  onCancelled: () => void;
+}
+
+interface JobBatchProgress {
+  batch: JobBatchResponse | undefined;
+  isActive: boolean;
+  /** Follow a batch that was just enqueued. */
+  track: (batchId: number) => void;
+  cancel: () => void;
+}
+
+/**
+ * Follows one job batch from enqueued to terminal: polls it, reports the
+ * outcome once, and cancels it on request.
+ *
+ * Starting a batch is deliberately not part of this — each feature enqueues
+ * through its own endpoint, with its own arguments and response shape — so a
+ * caller passes the new batch's id to `track` from its own mutation.
+ */
+export const useJobBatchProgress = ({
+  activeBatch,
+  onFinished,
+  onCancelled,
+}: UseJobBatchProgressOptions): JobBatchProgress => {
+  const { showSnackbar } = useSnackbar();
+  const [batchId, setBatchId] = useState<number | null>(null);
+  // Batches whose outcome has already been reported. Without this, a stale
+  // "active batch" response would restart tracking on a batch that just ended,
+  // and it is also what makes the effects below safe to re-run: a caller may
+  // pass fresh callbacks on every render without its outcome firing twice.
+  const settledIdRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (!activeBatch || isTerminal(activeBatch.status) || activeBatch.id === settledIdRef.current) {
+      return;
+    }
+    setBatchId((current) => current ?? activeBatch.id);
+  }, [activeBatch]);
+
+  const { data: batch } = useGetJobBatch(batchId ?? 0, {
+    query: {
+      enabled: batchId !== null,
+      refetchInterval: (query) => (isTerminal(query.state.data?.status) ? false : POLL_INTERVAL),
+    },
+  });
+
+  useEffect(() => {
+    if (!batch || !isTerminal(batch.status) || settledIdRef.current === batch.id) {
+      return;
+    }
+    settledIdRef.current = batch.id;
+    setBatchId(null);
+    onFinished(batch);
+  }, [batch, onFinished]);
+
+  const { mutate: cancelBatch } = useCancelJobBatch({
+    mutation: {
+      onSuccess: (cancelled) => {
+        settledIdRef.current = cancelled.id;
+        setBatchId(null);
+        onCancelled();
+      },
+      onError: () => {
+        showSnackbar('Failed to cancel batch.', 'error');
+      },
+    },
+  });
+
+  const cancel = useCallback(() => {
+    if (batchId !== null) {
+      cancelBatch({ batchId });
+    }
+  }, [cancelBatch, batchId]);
+
+  return {
+    batch,
+    isActive: batchId !== null && !isTerminal(batch?.status),
+    track: setBatchId,
+    cancel,
+  };
+};

--- a/frontend/src/lib/cacheEvents.ts
+++ b/frontend/src/lib/cacheEvents.ts
@@ -7,6 +7,7 @@ import { getGetBookDigestQueryKey } from '@/api/generated/digest/digest.ts';
 import { getGetBookHighlightLabelsQueryKey } from '@/api/generated/highlight-labels/highlight-labels.ts';
 import { getGetActiveBookDigestBatchQueryKey } from '@/api/generated/jobs/jobs.ts';
 import { getGetNoteQueryKey, getGetNotesForBookQueryKey } from '@/api/generated/notes/notes.ts';
+import { getGetActiveBackfillQueryKey } from '@/api/generated/semantic/semantic.ts';
 import { getGetTagsQueryKey } from '@/api/generated/tags/tags.ts';
 import { useQueryClient, type QueryKey } from '@tanstack/react-query';
 import { useMemo } from 'react';
@@ -93,6 +94,15 @@ export const useCacheEvents = () => {
       /** A batch digest job was cancelled; no new digest content exists. */
       digestBatchCancelled: (bookId: number) =>
         invalidate(getGetActiveBookDigestBatchQueryKey(bookId)),
+
+      /**
+       * The embedding backfill started, ended or was cancelled.
+       *
+       * One event rather than the digest batch's pair: nothing caches embedded
+       * content — search is fetched on demand — so only the "is one running"
+       * query is ever affected.
+       */
+      embeddingBackfillChanged: () => invalidate(getGetActiveBackfillQueryKey()),
 
       /** A highlight label was renamed or recoloured. Book details embeds labels. */
       highlightLabelsChanged: (bookId: number) =>

--- a/frontend/src/pages/BookPage/Structure/BatchDigestToolbar.tsx
+++ b/frontend/src/pages/BookPage/Structure/BatchDigestToolbar.tsx
@@ -1,27 +1,16 @@
-import {
-  useCancelJobBatch,
-  useEnqueueBookDigest,
-  useGetActiveBookDigestBatch,
-  useGetJobBatch,
-} from '@/api/generated/jobs/jobs';
+import { useEnqueueBookDigest, useGetActiveBookDigestBatch } from '@/api/generated/jobs/jobs';
 import type { JobBatchResponse } from '@/api/generated/model';
 import { IconButtonWithTooltip } from '@/components/buttons/IconButtonWithTooltip';
 import { AIFeature } from '@/components/features/AIFeature';
 import { useSnackbar } from '@/context/SnackbarContext';
+import { useJobBatchProgress } from '@/hooks/useJobBatchProgress';
 import { useCacheEvents } from '@/lib/cacheEvents.ts';
 import { AIIcon, CloseIcon } from '@/theme/Icons';
 import { Box, CircularProgress, Typography } from '@mui/material';
-import { useCallback, useRef, useState } from 'react';
+import { useCallback } from 'react';
 
 interface BatchDigestToolbarProps {
   bookId: number;
-}
-
-const TERMINAL_STATUSES = ['completed', 'completed_with_errors', 'failed', 'cancelled'];
-const POLL_INTERVAL = 3000;
-
-function isTerminal(status: string | undefined): boolean {
-  return !!status && TERMINAL_STATUSES.includes(status);
 }
 
 function showCompletionMessage(
@@ -43,28 +32,26 @@ function showCompletionMessage(
 export const BatchDigestToolbar = ({ bookId }: BatchDigestToolbarProps) => {
   const cache = useCacheEvents();
   const { showSnackbar } = useSnackbar();
-  const [batchId, setBatchId] = useState<number | null>(null);
-  const handledTerminalRef = useRef<number | null>(null);
 
-  // Check for an already-active batch on mount (survives page refresh)
-  useGetActiveBookDigestBatch(bookId, {
-    query: {
-      select: (response: JobBatchResponse | null) => {
-        if (response && !isTerminal(response.status) && batchId === null) {
-          queueMicrotask(() => {
-            setBatchId(response.id);
-          });
-        }
-        return response;
-      },
+  // An already-active batch, so the progress display survives a page refresh.
+  const { data: activeBatch } = useGetActiveBookDigestBatch(bookId);
+
+  const { batch, isActive, track, cancel } = useJobBatchProgress({
+    activeBatch,
+    onFinished: (finished) => {
+      cache.digestBatchFinished(bookId);
+      showCompletionMessage(finished, showSnackbar);
+    },
+    onCancelled: () => {
+      cache.digestBatchCancelled(bookId);
+      showSnackbar('Batch generation cancelled.', 'info');
     },
   });
 
   const { mutate: enqueue, isPending: isEnqueuing } = useEnqueueBookDigest({
     mutation: {
       onSuccess: (response) => {
-        handledTerminalRef.current = null;
-        setBatchId(response.id);
+        track(response.id);
       },
       onError: () => {
         showSnackbar('Failed to start batch generation.', 'error');
@@ -72,55 +59,9 @@ export const BatchDigestToolbar = ({ bookId }: BatchDigestToolbarProps) => {
     },
   });
 
-  const { data: batch } = useGetJobBatch(batchId ?? 0, {
-    query: {
-      enabled: batchId !== null,
-      refetchInterval: (query) => {
-        const status = query.state.data?.status;
-        if (isTerminal(status)) return false;
-        return POLL_INTERVAL;
-      },
-      select: (response: JobBatchResponse) => {
-        if (isTerminal(response.status) && handledTerminalRef.current !== response.id) {
-          handledTerminalRef.current = response.id;
-
-          cache.digestBatchFinished(bookId);
-
-          showCompletionMessage(response, showSnackbar);
-
-          queueMicrotask(() => {
-            setBatchId(null);
-          });
-        }
-        return response;
-      },
-    },
-  });
-
-  const { mutate: cancelBatch } = useCancelJobBatch({
-    mutation: {
-      onSuccess: () => {
-        showSnackbar('Batch generation cancelled.', 'info');
-        cache.digestBatchCancelled(bookId);
-        setBatchId(null);
-      },
-      onError: () => {
-        showSnackbar('Failed to cancel batch.', 'error');
-      },
-    },
-  });
-
-  const isActive = batchId !== null && (!batch || !isTerminal(batch.status));
-
   const handleEnqueue = useCallback(() => {
     enqueue({ bookId });
   }, [enqueue, bookId]);
-
-  const handleCancel = useCallback(() => {
-    if (batchId) {
-      cancelBatch({ batchId });
-    }
-  }, [cancelBatch, batchId]);
 
   if (isEnqueuing || isActive) {
     const completed = batch ? batch.completed_jobs + batch.failed_jobs : 0;
@@ -140,7 +81,7 @@ export const BatchDigestToolbar = ({ bookId }: BatchDigestToolbarProps) => {
           </Typography>
           <IconButtonWithTooltip
             title="Cancel generation"
-            onClick={handleCancel}
+            onClick={cancel}
             ariaLabel="Cancel batch generation"
             icon={<CloseIcon />}
           />

--- a/frontend/src/pages/SettingsPage/EmbeddingBackfillSection.tsx
+++ b/frontend/src/pages/SettingsPage/EmbeddingBackfillSection.tsx
@@ -1,0 +1,116 @@
+import type { JobBatchResponse } from '@/api/generated/model';
+import { useBackfillEmbeddings, useGetActiveBackfill } from '@/api/generated/semantic/semantic';
+import { IconButtonWithTooltip } from '@/components/buttons/IconButtonWithTooltip';
+import { useSnackbar } from '@/context/SnackbarContext';
+import { useJobBatchProgress } from '@/hooks/useJobBatchProgress';
+import { useCacheEvents } from '@/lib/cacheEvents.ts';
+import { CloseIcon } from '@/theme/Icons';
+import { Box, Button, CircularProgress, Divider, Typography } from '@mui/material';
+import type { AxiosError } from 'axios';
+
+type ShowSnackbar = ReturnType<typeof useSnackbar>['showSnackbar'];
+
+function reportOutcome(batch: JobBatchResponse, showSnackbar: ShowSnackbar) {
+  if (batch.status === 'completed') {
+    showSnackbar('Text embedding complete.', 'success');
+  } else if (batch.status === 'completed_with_errors') {
+    showSnackbar(
+      `Embedded ${batch.completed_jobs}/${batch.total_jobs} items. Some failed.`,
+      'warning'
+    );
+  } else if (batch.status === 'failed') {
+    showSnackbar('Text embedding failed.', 'error');
+  }
+}
+
+/**
+ * Starts and follows the library-wide embedding backfill.
+ *
+ * The run outlives the page, so the active-batch query is what the display is
+ * built from: arriving mid-run shows the progress of a batch this page never
+ * started.
+ */
+export const EmbeddingBackfillSection = () => {
+  const cache = useCacheEvents();
+  const { showSnackbar } = useSnackbar();
+  const { data: activeBatch } = useGetActiveBackfill();
+
+  const { batch, isActive, track, cancel } = useJobBatchProgress({
+    activeBatch,
+    onFinished: (finished) => {
+      cache.embeddingBackfillChanged();
+      reportOutcome(finished, showSnackbar);
+    },
+    onCancelled: () => {
+      cache.embeddingBackfillChanged();
+      showSnackbar('Text embedding cancelled.', 'info');
+    },
+  });
+
+  const { mutate: startBackfill, isPending: isStarting } = useBackfillEmbeddings({
+    mutation: {
+      onSuccess: (response) => {
+        if (response.batch) {
+          track(response.batch.id);
+        } else {
+          showSnackbar('Everything in your library is already indexed.', 'info');
+        }
+      },
+      onError: (error) => {
+        if ((error as AxiosError).response?.status === 409) {
+          // Someone else's tab, or another device, got there first — refetch so
+          // this page picks up the run it is being told about.
+          cache.embeddingBackfillChanged();
+          showSnackbar('A text embedding run is already in progress.', 'warning');
+        } else {
+          showSnackbar('Failed to start text embedding.', 'error');
+        }
+      },
+    },
+  });
+
+  const isBusy = isStarting || isActive;
+  const done = batch ? batch.completed_jobs + batch.failed_jobs : 0;
+
+  return (
+    <Box sx={{ mt: 6 }}>
+      <Typography variant="h3" sx={{ mb: 1, color: 'text.primary' }}>
+        Background processes
+      </Typography>
+      <Typography variant="body2" sx={{ mb: 3, color: 'text.secondary' }}>
+        Index your library for semantic search. Only content that has not been embedded yet is
+        processed, so running this again is cheap.
+      </Typography>
+
+      <Divider sx={{ mb: 3 }} />
+
+      <Box sx={{ display: 'flex', alignItems: 'center', flexWrap: 'wrap', gap: 2 }}>
+        <Button
+          variant="contained"
+          disabled={isBusy}
+          onClick={() => {
+            // No `book_id`: the whole library.
+            startBackfill({});
+          }}
+        >
+          Run text embedding for the library
+        </Button>
+
+        {isBusy && (
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            <CircularProgress size={20} />
+            <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+              {batch ? `Embedding content (${done}/${batch.total_jobs})` : 'Starting...'}
+            </Typography>
+            <IconButtonWithTooltip
+              title="Cancel text embedding"
+              onClick={cancel}
+              ariaLabel="Cancel text embedding"
+              icon={<CloseIcon />}
+            />
+          </Box>
+        )}
+      </Box>
+    </Box>
+  );
+};

--- a/frontend/src/pages/SettingsPage/SettingsPage.test.tsx
+++ b/frontend/src/pages/SettingsPage/SettingsPage.test.tsx
@@ -1,0 +1,109 @@
+import { appSettings } from '@tests/fixtures/auth';
+import { aJobBatch } from '@tests/fixtures/jobs';
+import { renderApp } from '@tests/harness/renderApp';
+import { semanticApi } from '@tests/msw/semanticApi';
+import { worker } from '@tests/msw/worker';
+import { http, HttpResponse, type RequestHandler } from 'msw';
+import { expect, test } from 'vitest';
+import { userEvent } from 'vitest/browser';
+
+type Screen = Awaited<ReturnType<typeof renderApp>>;
+
+const RUN_BUTTON = 'Run text embedding for the library';
+// One poll interval plus room for the request itself.
+const POLL_TIMEOUT = 8000;
+
+const embeddingsFlag = (enabled: boolean) =>
+  http.get('/api/v1/settings', () =>
+    HttpResponse.json(
+      appSettings({ feature_flags: { ai: false, embeddings: enabled, user_registrations: false } })
+    )
+  );
+
+/** Settings with embeddings on, over `handlers` — the first match there wins. */
+const renderSettings = (handlers: RequestHandler[] = []) => {
+  worker.use(embeddingsFlag(true), ...handlers);
+  return renderApp({ path: '/settings' });
+};
+
+const clickRun = (screen: Screen) =>
+  userEvent.click(screen.getByRole('button', { name: RUN_BUTTON }));
+
+const expectRunReady = (screen: Screen) =>
+  expect.element(screen.getByRole('button', { name: RUN_BUTTON })).toBeEnabled();
+
+test('starting a backfill shows its progress and reports completion', async () => {
+  const { handlers, advance } = semanticApi({ pendingJobs: 4 });
+
+  const screen = await renderSettings(handlers);
+  await expect.element(screen.getByRole('heading', { name: 'Background processes' })).toBeVisible();
+
+  await clickRun(screen);
+
+  await expect.element(screen.getByText('Embedding content (0/4)')).toBeVisible();
+  await expect.element(screen.getByRole('button', { name: RUN_BUTTON })).toBeDisabled();
+
+  advance({ completed_jobs: 4, status: 'completed' });
+
+  await expect
+    .element(screen.getByRole('alert').filter({ hasText: 'Text embedding complete' }), {
+      timeout: POLL_TIMEOUT,
+    })
+    .toBeVisible();
+  await expectRunReady(screen);
+}, 20000);
+
+test('a backfill already running when the page loads is shown and can be cancelled', async () => {
+  const { handlers, state } = semanticApi({
+    batch: aJobBatch({ total_jobs: 10, completed_jobs: 3, status: 'processing' }),
+  });
+
+  const screen = await renderSettings(handlers);
+
+  await expect.element(screen.getByText('Embedding content (3/10)')).toBeVisible();
+  await expect.element(screen.getByRole('button', { name: RUN_BUTTON })).toBeDisabled();
+
+  await userEvent.click(screen.getByRole('button', { name: 'Cancel text embedding' }));
+
+  await expectRunReady(screen);
+  expect(screen.getByText('Embedding content (3/10)').elements()).toHaveLength(0);
+  expect(state.batch?.status).toBe('cancelled');
+});
+
+test('an already indexed library reports that there was nothing to embed', async () => {
+  const { handlers } = semanticApi({ pendingJobs: 0 });
+
+  const screen = await renderSettings(handlers);
+  await clickRun(screen);
+
+  await expect
+    .element(screen.getByRole('alert').filter({ hasText: 'already indexed' }))
+    .toBeVisible();
+  await expectRunReady(screen);
+});
+
+test('a failed start reports the error and leaves the button ready', async () => {
+  const { handlers } = semanticApi();
+  // Listed ahead of the happy path, so this POST is the one that matches.
+  const failingStart = http.post(
+    '/api/v1/semantic/backfill',
+    () => new HttpResponse(null, { status: 500 })
+  );
+
+  const screen = await renderSettings([failingStart, ...handlers]);
+  await clickRun(screen);
+
+  await expect
+    .element(screen.getByRole('alert').filter({ hasText: 'Failed to start text embedding' }))
+    .toBeVisible();
+  await expectRunReady(screen);
+});
+
+test('the section is hidden when embeddings are disabled', async () => {
+  worker.use(embeddingsFlag(false));
+
+  const screen = await renderApp({ path: '/settings' });
+  await expect.element(screen.getByRole('heading', { name: 'Settings' })).toBeVisible();
+
+  expect(screen.getByRole('heading', { name: 'Background processes' }).elements()).toHaveLength(0);
+});

--- a/frontend/src/pages/SettingsPage/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage/SettingsPage.tsx
@@ -1,10 +1,12 @@
 import { useUpdateMe } from '@/api/generated/users/users';
+import { EmbeddingFeature } from '@/components/features/EmbeddingFeature.tsx';
 import { RHFTextField } from '@/components/inputs/RHFTextField.tsx';
 import { PageContainer } from '@/components/layout/Layouts.tsx';
 import { useAuth } from '@/context/AuthContext';
 import { Alert, Box, Button, Divider, Typography } from '@mui/material';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
+import { EmbeddingBackfillSection } from './EmbeddingBackfillSection.tsx';
 
 interface EmailFormValues {
   email: string;
@@ -218,6 +220,10 @@ export const SettingsPage = () => {
 
       <EmailForm />
       <PasswordForm />
+
+      <EmbeddingFeature>
+        <EmbeddingBackfillSection />
+      </EmbeddingFeature>
     </PageContainer>
   );
 };

--- a/frontend/tests/fixtures/jobs.ts
+++ b/frontend/tests/fixtures/jobs.ts
@@ -1,0 +1,14 @@
+import type { JobBatchResponse } from '@/api/generated/model';
+
+export const aJobBatch = (overrides: Partial<JobBatchResponse> = {}): JobBatchResponse => ({
+  id: 7,
+  batch_type: 'content_embedding_backfill',
+  reference_id: '1',
+  total_jobs: 4,
+  completed_jobs: 0,
+  failed_jobs: 0,
+  status: 'processing',
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+  ...overrides,
+});

--- a/frontend/tests/msw/semanticApi.ts
+++ b/frontend/tests/msw/semanticApi.ts
@@ -1,0 +1,64 @@
+import type { JobBatchResponse } from '@/api/generated/model';
+import { http, HttpResponse } from 'msw';
+import { aJobBatch } from '../fixtures/jobs';
+
+const TERMINAL_STATUSES = ['completed', 'completed_with_errors', 'failed', 'cancelled'];
+
+interface SemanticApiState {
+  /** Jobs the next backfill request enqueues. 0 means everything is indexed. */
+  pendingJobs: number;
+  batch: JobBatchResponse | null;
+}
+
+/**
+ * The semantic backfill endpoints plus the job-batch endpoints they hand off
+ * to, backed by mutable state so a POST is visible to the polling GET that
+ * follows it.
+ *
+ * `advance` stands in for the worker: a test calls it to move the running batch
+ * on, and the next poll sees the new counts the way the real page would.
+ */
+export function semanticApi(initial: Partial<SemanticApiState> = {}) {
+  const state: SemanticApiState = {
+    pendingJobs: initial.pendingJobs ?? 4,
+    batch: initial.batch ?? null,
+  };
+
+  const running = () =>
+    state.batch && !TERMINAL_STATUSES.includes(state.batch.status) ? state.batch : null;
+
+  const advance = (patch: Partial<JobBatchResponse>) => {
+    if (state.batch) {
+      state.batch = { ...state.batch, ...patch };
+    }
+  };
+
+  const handlers = [
+    http.get('/api/v1/semantic/backfill/active', () => HttpResponse.json(running())),
+
+    http.post('/api/v1/semantic/backfill', () => {
+      if (running()) {
+        return new HttpResponse(null, { status: 409 });
+      }
+      if (state.pendingJobs === 0) {
+        return HttpResponse.json({ total_jobs: 0, batch: null });
+      }
+      state.batch = aJobBatch({ total_jobs: state.pendingJobs });
+      return HttpResponse.json(
+        { total_jobs: state.pendingJobs, batch: state.batch },
+        { status: 202 }
+      );
+    }),
+
+    http.get('/api/v1/jobs/batches/:batchId', () =>
+      state.batch ? HttpResponse.json(state.batch) : new HttpResponse(null, { status: 404 })
+    ),
+
+    http.delete('/api/v1/jobs/batches/:batchId', () => {
+      advance({ status: 'cancelled' });
+      return HttpResponse.json(state.batch);
+    }),
+  ];
+
+  return { handlers, state, advance };
+}


### PR DESCRIPTION
Adds a **Background processes** section at the bottom of the settings page that runs the library-wide embedding backfill against the endpoints added in #550.

## Behaviour

- Idle: a `Run text embedding for the library` button.
- Running: the button disables, and a spinner, `Embedding content (3/10)`, and a cancel button appear beside it.
- Arriving mid-run picks the batch up from `GET /semantic/backfill/active`, since the run outlives the page.

All three answers from `POST /semantic/backfill` are acted on, not just the 202: a 200 with `total_jobs` 0 reports that the library is already indexed, and a 409 reports that another tab or device got there first — and refetches, so this page adopts the run it is being told about.

## Shared polling

The start-poll-cancel lifecycle already existed in `BatchDigestToolbar`. The first commit lifts the half both features share into `useJobBatchProgress` and moves the toolbar onto it, with no change in behaviour. Enqueueing stays with each feature: the two endpoints differ in arguments and response shape, so a caller hands the hook a batch id through `track`.

Adoption of an already-running batch became a plain effect rather than a `queueMicrotask` inside the query's `select`, guarded by the id of the batch whose outcome was last reported.

`EmbeddingFeature` gates the section on the `embeddings` flag, the way `AIFeature` does for AI — a component rather than an inline `FeatureGate` because more embedding-only UI is coming.

## Testing

`SettingsPage.test.tsx` covers start → progress → completion, resuming and cancelling a run that was already going, the already-indexed path, a failed start, and the flag-off case. It is backed by a stateful `tests/msw/semanticApi.ts` whose `advance()` stands in for the worker.

**One gap worth naming:** the `BatchDigestToolbar` refactor has no test of its own — nothing covered `StructurePage` before this either. It rides on type-checking plus the hook's five tests through settings.

Frontend duplication falls to 1.6%, so the jscpd threshold ratchets down to 1.7 in the same change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)