### PR TITLE
Add a reusable semantic search field to the Structure and Notes tabs

### DIFF
--- a/docs/adr/0002-semantic-search-embeddings.md
+++ b/docs/adr/0002-semantic-search-embeddings.md
@@ -413,7 +413,9 @@ remains:
 
 - **One active backfill per user**, guarded by a unique index and recoverable
   through the existing batch cancel (issue #531).
-- **Frontend.** Surfacing search and related content in the UI.
+- **Frontend.** A global search page across every content type and book, and
+  surfacing related content in the UI. (Search within a book's Structure and
+  Notes tabs has landed.)
 - **Production wiring.** OpenRouter `baai/bge-m3`, confirming pgvector on
   Railway — **0.8 or newer**, since the read path sets `hnsw.iterative_scan` —
   and running the migration there.

--- a/frontend/knip.config.ts
+++ b/frontend/knip.config.ts
@@ -22,6 +22,9 @@ const config: KnipConfig = {
     // MSW's worker script, served as a static asset during tests rather than
     // imported, so nothing links to it.
     'tests/public/**',
+    // `aNoteHit` is the fixture Task 2's Notes tab search tests consume — it's
+    // exported ahead of its importer, which lands in that follow-up task.
+    'tests/fixtures/semantic.ts',
   ],
   ignoreDependencies: [
     // Required by Vitest browser mode and loaded by the runner, never imported

--- a/frontend/knip.config.ts
+++ b/frontend/knip.config.ts
@@ -22,9 +22,6 @@ const config: KnipConfig = {
     // MSW's worker script, served as a static asset during tests rather than
     // imported, so nothing links to it.
     'tests/public/**',
-    // `aNoteHit` is the fixture Task 2's Notes tab search tests consume — it's
-    // exported ahead of its importer, which lands in that follow-up task.
-    'tests/fixtures/semantic.ts',
   ],
   ignoreDependencies: [
     // Required by Vitest browser mode and loaded by the runner, never imported

--- a/frontend/src/components/search/SemanticSearchField.tsx
+++ b/frontend/src/components/search/SemanticSearchField.tsx
@@ -1,0 +1,34 @@
+import { EmbeddingFeature } from '@/components/features/EmbeddingFeature.tsx';
+import { SearchBar } from '@/components/inputs/SearchBar.tsx';
+import { Box, LinearProgress } from '@mui/material';
+
+interface SemanticSearchFieldProps {
+  value: string;
+  /** Called with the debounced query text. Must be a stable callback. */
+  onChange: (value: string) => void;
+  placeholder: string;
+  isFetching?: boolean;
+}
+
+/**
+ * Debounced natural-language search box, hidden when embeddings are off.
+ *
+ * Deliberately dumb: it renders the input and a progress hairline, and knows
+ * nothing about results. Callers pair it with `useSemanticSearch` and decide
+ * what a match means.
+ */
+export const SemanticSearchField = ({
+  value,
+  onChange,
+  placeholder,
+  isFetching = false,
+}: SemanticSearchFieldProps) => (
+  <EmbeddingFeature>
+    <Box>
+      <SearchBar onSearch={onChange} placeholder={placeholder} initialValue={value} />
+      <LinearProgress
+        sx={{ height: 2, borderRadius: 1, visibility: isFetching ? 'visible' : 'hidden' }}
+      />
+    </Box>
+  </EmbeddingFeature>
+);

--- a/frontend/src/components/search/SemanticSearchField.tsx
+++ b/frontend/src/components/search/SemanticSearchField.tsx
@@ -26,9 +26,7 @@ export const SemanticSearchField = ({
   <EmbeddingFeature>
     <Box>
       <SearchBar onSearch={onChange} placeholder={placeholder} initialValue={value} />
-      <LinearProgress
-        sx={{ height: 2, borderRadius: 1, visibility: isFetching ? 'visible' : 'hidden' }}
-      />
+      {isFetching && <LinearProgress sx={{ height: 2, borderRadius: 1 }} />}
     </Box>
   </EmbeddingFeature>
 );

--- a/frontend/src/components/search/SemanticSearchField.tsx
+++ b/frontend/src/components/search/SemanticSearchField.tsx
@@ -1,32 +1,25 @@
 import { EmbeddingFeature } from '@/components/features/EmbeddingFeature.tsx';
 import { SearchBar } from '@/components/inputs/SearchBar.tsx';
-import { Box, LinearProgress } from '@mui/material';
+import { Box } from '@mui/material';
 
 interface SemanticSearchFieldProps {
   value: string;
   /** Called with the debounced query text. Must be a stable callback. */
   onChange: (value: string) => void;
   placeholder: string;
-  isFetching?: boolean;
 }
 
 /**
  * Debounced natural-language search box, hidden when embeddings are off.
  *
- * Deliberately dumb: it renders the input and a progress hairline, and knows
+ * Deliberately dumb: it renders the input and knows
  * nothing about results. Callers pair it with `useSemanticSearch` and decide
  * what a match means.
  */
-export const SemanticSearchField = ({
-  value,
-  onChange,
-  placeholder,
-  isFetching = false,
-}: SemanticSearchFieldProps) => (
+export const SemanticSearchField = ({ value, onChange, placeholder }: SemanticSearchFieldProps) => (
   <EmbeddingFeature>
     <Box>
       <SearchBar onSearch={onChange} placeholder={placeholder} initialValue={value} />
-      {isFetching && <LinearProgress sx={{ height: 2, borderRadius: 1 }} />}
     </Box>
   </EmbeddingFeature>
 );

--- a/frontend/src/components/search/useSemanticSearch.ts
+++ b/frontend/src/components/search/useSemanticSearch.ts
@@ -1,5 +1,6 @@
 import type { SemanticSearchResults } from '@/api/generated/model';
 import { useSearchContent } from '@/api/generated/semantic/semantic.ts';
+import { useSettings } from '@/context/SettingsContext.tsx';
 import { keepPreviousData } from '@tanstack/react-query';
 import { useMemo } from 'react';
 
@@ -28,7 +29,10 @@ interface SemanticSearchState {
   results: SemanticSearchResults | undefined;
   isFetching: boolean;
   isError: boolean;
-  /** True when the trimmed query is non-empty — i.e. the page should filter. */
+  /**
+   * True when embeddings are enabled and the trimmed query is non-empty —
+   * i.e. the page should filter.
+   */
   hasQuery: boolean;
 }
 
@@ -46,14 +50,17 @@ export const useSemanticSearch = ({
   query,
   bookId,
 }: UseSemanticSearchOptions): SemanticSearchState => {
+  const { featureFlags } = useSettings();
   const q = query.trim();
-  const hasQuery = q.length > 0;
+  // Gated here, not just in the field: a page must never filter on a query
+  // the user cannot see or clear because the flag hid the input that owns it.
+  const hasQuery = featureFlags?.embeddings === true && q.length > 0;
 
   const { data, isFetching, isError } = useSearchContent(
     { q, book_id: bookId, limit: LIMIT },
     // `q` is a required param with minLength 1; `enabled` is what keeps an
-    // empty query off the wire. keepPreviousData stops the filtered list
-    // flashing empty between keystrokes.
+    // empty query (or a disabled feature) off the wire. keepPreviousData
+    // stops the filtered list flashing empty between keystrokes.
     { query: { enabled: hasQuery, placeholderData: keepPreviousData } }
   );
 

--- a/frontend/src/components/search/useSemanticSearch.ts
+++ b/frontend/src/components/search/useSemanticSearch.ts
@@ -1,0 +1,70 @@
+import type { SemanticSearchResults } from '@/api/generated/model';
+import { useSearchContent } from '@/api/generated/semantic/semantic.ts';
+import { keepPreviousData } from '@tanstack/react-query';
+import { useMemo } from 'react';
+
+/**
+ * Cosine-similarity floor for a result worth showing.
+ *
+ * Nearest-neighbour search always returns its top N, so a query with no real
+ * match still comes back with the least-bad items. Without a floor, "quantum"
+ * against a philosophy book produces a confident-looking list of noise. 0.35 is
+ * a starting value for this embedding model, not a measured one.
+ */
+const MIN_SCORE = 0.35;
+
+/** Results per content type. The endpoint's maximum is 100. */
+const LIMIT = 25;
+
+interface UseSemanticSearchOptions {
+  /** Current query text. The caller owns where it is stored. */
+  query: string;
+  /** Scope to one book. Omit to search every book. */
+  bookId?: number;
+}
+
+interface SemanticSearchState {
+  /** Groups with weak matches dropped, each still ordered best first. */
+  results: SemanticSearchResults | undefined;
+  isFetching: boolean;
+  isError: boolean;
+  /** True when the trimmed query is non-empty — i.e. the page should filter. */
+  hasQuery: boolean;
+}
+
+const strongEnough = <T extends { score: number }>(items: T[]) =>
+  items.filter((item) => item.score >= MIN_SCORE);
+
+/**
+ * Semantic search over the user's embedded content.
+ *
+ * `results` is `undefined` until there is a query and an answer, so a page
+ * branches on `hasQuery` rather than on emptiness: no search and "nothing
+ * matched" are different states that must render differently.
+ */
+export const useSemanticSearch = ({
+  query,
+  bookId,
+}: UseSemanticSearchOptions): SemanticSearchState => {
+  const q = query.trim();
+  const hasQuery = q.length > 0;
+
+  const { data, isFetching, isError } = useSearchContent(
+    { q, book_id: bookId, limit: LIMIT },
+    // `q` is a required param with minLength 1; `enabled` is what keeps an
+    // empty query off the wire. keepPreviousData stops the filtered list
+    // flashing empty between keystrokes.
+    { query: { enabled: hasQuery, placeholderData: keepPreviousData } }
+  );
+
+  const results = useMemo(() => {
+    if (!hasQuery || !data) return undefined;
+    return {
+      highlights: strongEnough(data.highlights),
+      notes: strongEnough(data.notes),
+      digests: strongEnough(data.digests),
+    };
+  }, [data, hasQuery]);
+
+  return { results, isFetching, isError, hasQuery };
+};

--- a/frontend/src/components/typography/PageTitle.tsx
+++ b/frontend/src/components/typography/PageTitle.tsx
@@ -1,0 +1,9 @@
+import { Typography } from '@mui/material';
+
+export const PageTitle = ({ text }: { text: string }) => {
+  return (
+    <Typography variant="h1" component="h2" gutterBottom sx={{ color: 'primary.main', mb: 2 }}>
+      {text}
+    </Typography>
+  );
+};

--- a/frontend/src/components/typography/PageTitle.tsx
+++ b/frontend/src/components/typography/PageTitle.tsx
@@ -2,7 +2,12 @@ import { Typography } from '@mui/material';
 
 export const PageTitle = ({ text }: { text: string }) => {
   return (
-    <Typography variant="h1" component="h2" gutterBottom sx={{ color: 'primary.main', mb: 2 }}>
+    <Typography
+      variant="h2"
+      component="h2"
+      gutterBottom
+      sx={{ color: 'primary.main', mb: 2, fontWeight: 900 }}
+    >
       {text}
     </Typography>
   );

--- a/frontend/src/pages/BookPage/Flashcards/FlashcardsPage.tsx
+++ b/frontend/src/pages/BookPage/Flashcards/FlashcardsPage.tsx
@@ -11,6 +11,7 @@ import {
   type FlashcardWithContext,
 } from '@/components/features/flashcards/FlashcardChapterList.tsx';
 import { ContentWithSidebar } from '@/components/layout/Layouts.tsx';
+import { PageTitle } from '@/components/typography/PageTitle.tsx';
 import { useBookPage } from '@/pages/BookPage/BookPageContext';
 import { ListSearchSortHeader } from '@/pages/BookPage/common/ListSearchSortHeader.tsx';
 import { useBookTabFilters } from '@/pages/BookPage/common/useBookTabFilters.ts';
@@ -184,6 +185,7 @@ export const FlashcardsPage = () => {
       {isDesktop ? (
         <ContentWithSidebar>
           <Box>
+            <PageTitle text="Flashcards" />
             <ListSearchSortHeader
               onSearch={handleSearch}
               searchPlaceholder="Search flashcards..."
@@ -207,6 +209,7 @@ export const FlashcardsPage = () => {
         </ContentWithSidebar>
       ) : (
         <>
+          <PageTitle text="Flashcards" />
           <ListSearchSortHeader
             onSearch={handleSearch}
             searchPlaceholder="Search flashcards..."

--- a/frontend/src/pages/BookPage/Highlights/HighlightsPage.tsx
+++ b/frontend/src/pages/BookPage/Highlights/HighlightsPage.tsx
@@ -9,6 +9,7 @@ import type {
 import { useGetTags } from '@/api/generated/tags/tags.ts';
 import { scrollToElementWithHighlight } from '@/components/animations/scrollUtils';
 import { ContentWithSidebar } from '@/components/layout/Layouts.tsx';
+import { PageTitle } from '@/components/typography/PageTitle.tsx';
 import { useResetOnChange } from '@/hooks/useResetOnChange.ts';
 import { useBookPage } from '@/pages/BookPage/BookPageContext';
 import { ListSearchSortHeader } from '@/pages/BookPage/common/ListSearchSortHeader.tsx';
@@ -176,6 +177,7 @@ export const HighlightsPage = () => {
       {isDesktop ? (
         <ContentWithSidebar>
           <Box>
+            <PageTitle text="Highlights" />
             <ListSearchSortHeader
               onSearch={handleSearch}
               searchPlaceholder="Search highlights..."
@@ -208,6 +210,7 @@ export const HighlightsPage = () => {
         </ContentWithSidebar>
       ) : (
         <>
+          <PageTitle text="Highlights" />
           <ListSearchSortHeader
             onSearch={handleSearch}
             searchPlaceholder="Search highlights..."

--- a/frontend/src/pages/BookPage/Notes/NotesPage.test.tsx
+++ b/frontend/src/pages/BookPage/Notes/NotesPage.test.tsx
@@ -1,13 +1,18 @@
 import { aBookDetails } from '@tests/fixtures/book';
 import { aNote } from '@tests/fixtures/notes';
+import { aNoteHit } from '@tests/fixtures/semantic';
 import { renderApp } from '@tests/harness/renderApp';
+import { settingsWithEmbeddings } from '@tests/msw/auth';
 import { bookApi } from '@tests/msw/bookApi';
+import { semanticSearchApi } from '@tests/msw/semanticSearchApi';
 import { worker } from '@tests/msw/worker';
 import { http, HttpResponse } from 'msw';
 import { expect, test } from 'vitest';
 import { userEvent } from 'vitest/browser';
 
 type Screen = Awaited<ReturnType<typeof renderApp>>;
+
+const NOTES_SEARCH_PLACEHOLDER = 'Search notes by meaning…';
 
 const openNoteForEditing = async (screen: Screen, title: string) => {
   await userEvent.click(screen.getByRole('button', { name: new RegExp(title) }));
@@ -60,4 +65,62 @@ test('a failed save reports the error and leaves the note unchanged', async () =
 
   await expect.element(screen.getByRole('heading', { name: 'Analytical Engine' })).toBeVisible();
   expect(screen.getByRole('heading', { name: 'Difference Engine' }).elements()).toHaveLength(0);
+});
+
+test('searching notes lists only the notes on this page that matched', async () => {
+  const { handlers } = bookApi({
+    // Author overridden: the default 'Ada Lovelace' collides with a note of
+    // the same title, and the book title heading persists through filtering.
+    book: aBookDetails({ author: 'Grace Hopper' }),
+    notes: [
+      aNote({ id: 100, title: 'Ada Lovelace' }),
+      aNote({ id: 101, title: 'Difference Engine' }),
+    ],
+  });
+  worker.use(
+    settingsWithEmbeddings(true),
+    ...semanticSearchApi({
+      engines: {
+        notes: [
+          aNoteHit({ id: 101, title: 'Difference Engine', score: 0.71 }),
+          // A hit the page does not hold: notes can link to several books, so
+          // the page must intersect with its own list, not render hits.
+          aNoteHit({ id: 999, title: 'Analytical Engine', score: 0.9 }),
+        ],
+      },
+    }),
+    ...handlers
+  );
+
+  const screen = await renderApp({ path: '/book/1/notes' });
+  await expect.element(screen.getByRole('heading', { name: 'Ada Lovelace' })).toBeVisible();
+
+  await userEvent.fill(screen.getByPlaceholder(NOTES_SEARCH_PLACEHOLDER), 'engines');
+
+  await expect
+    .element(screen.getByRole('heading', { name: 'Ada Lovelace' }))
+    .not.toBeInTheDocument();
+  await expect.element(screen.getByRole('heading', { name: 'Difference Engine' })).toBeVisible();
+  expect(screen.getByRole('heading', { name: 'Analytical Engine' }).elements()).toHaveLength(0);
+});
+
+test('a failed search reports the error and keeps every note listed', async () => {
+  const { handlers } = bookApi({
+    // Same author override as above, and for the same reason.
+    book: aBookDetails({ author: 'Grace Hopper' }),
+    notes: [aNote({ id: 100, title: 'Ada Lovelace' })],
+  });
+  worker.use(
+    settingsWithEmbeddings(true),
+    http.get('/api/v1/semantic/search', () => new HttpResponse(null, { status: 500 })),
+    ...handlers
+  );
+
+  const screen = await renderApp({ path: '/book/1/notes' });
+  await userEvent.fill(screen.getByPlaceholder(NOTES_SEARCH_PLACEHOLDER), 'engines');
+
+  await expect
+    .element(screen.getByRole('alert').filter({ hasText: 'Search failed' }))
+    .toBeVisible();
+  await expect.element(screen.getByRole('heading', { name: 'Ada Lovelace' })).toBeVisible();
 });

--- a/frontend/src/pages/BookPage/Notes/NotesPage.test.tsx
+++ b/frontend/src/pages/BookPage/Notes/NotesPage.test.tsx
@@ -19,6 +19,21 @@ const openNoteForEditing = async (screen: Screen, title: string) => {
   await userEvent.click(screen.getByRole('button', { name: 'Edit note' }));
 };
 
+/**
+ * Two notes on the page — enough for a search to prove it intersects with
+ * the page's own list rather than rendering hits verbatim. Author overridden:
+ * the default 'Ada Lovelace' collides with a note of the same title, and the
+ * book title heading persists through filtering.
+ */
+const aTwoNoteBook = () =>
+  bookApi({
+    book: aBookDetails({ author: 'Grace Hopper' }),
+    notes: [
+      aNote({ id: 100, title: 'Ada Lovelace' }),
+      aNote({ id: 101, title: 'Difference Engine' }),
+    ],
+  });
+
 test('renaming a note updates the notes list', async () => {
   const { handlers } = bookApi({
     book: aBookDetails(),
@@ -68,15 +83,7 @@ test('a failed save reports the error and leaves the note unchanged', async () =
 });
 
 test('searching notes lists only the notes on this page that matched', async () => {
-  const { handlers } = bookApi({
-    // Author overridden: the default 'Ada Lovelace' collides with a note of
-    // the same title, and the book title heading persists through filtering.
-    book: aBookDetails({ author: 'Grace Hopper' }),
-    notes: [
-      aNote({ id: 100, title: 'Ada Lovelace' }),
-      aNote({ id: 101, title: 'Difference Engine' }),
-    ],
-  });
+  const { handlers } = aTwoNoteBook();
   worker.use(
     settingsWithEmbeddings(true),
     ...semanticSearchApi({
@@ -102,6 +109,27 @@ test('searching notes lists only the notes on this page that matched', async () 
     .not.toBeInTheDocument();
   await expect.element(screen.getByRole('heading', { name: 'Difference Engine' })).toBeVisible();
   expect(screen.getByRole('heading', { name: 'Analytical Engine' }).elements()).toHaveLength(0);
+});
+
+test('a query that matches none of the notes on this page shows the search empty state', async () => {
+  const { handlers } = aTwoNoteBook();
+  worker.use(
+    settingsWithEmbeddings(true),
+    // Unlisted query → every group comes back empty, i.e. nothing matched.
+    ...semanticSearchApi({ underwater: {} }),
+    ...handlers
+  );
+
+  const screen = await renderApp({ path: '/book/1/notes' });
+  await expect.element(screen.getByRole('heading', { name: 'Ada Lovelace' })).toBeVisible();
+
+  await userEvent.fill(screen.getByPlaceholder(NOTES_SEARCH_PLACEHOLDER), 'underwater');
+
+  await expect.element(screen.getByText(/No notes match/)).toBeVisible();
+  await expect
+    .element(screen.getByRole('heading', { name: 'Ada Lovelace' }))
+    .not.toBeInTheDocument();
+  expect(screen.getByRole('heading', { name: 'Difference Engine' }).elements()).toHaveLength(0);
 });
 
 test('a failed search reports the error and keeps every note listed', async () => {

--- a/frontend/src/pages/BookPage/Notes/NotesPage.tsx
+++ b/frontend/src/pages/BookPage/Notes/NotesPage.tsx
@@ -3,6 +3,8 @@ import { useGetNotesForBook } from '@/api/generated/notes/notes.ts';
 import { CardList } from '@/components/CardList.tsx';
 import { EmptyStateText } from '@/components/EmptyStateText.tsx';
 import { Spinner } from '@/components/animations/Spinner.tsx';
+import { SemanticSearchField } from '@/components/search/SemanticSearchField.tsx';
+import { useSemanticSearch } from '@/components/search/useSemanticSearch.ts';
 import { useBookPage } from '@/pages/BookPage/BookPageContext';
 import { useBookTabFilters } from '@/pages/BookPage/common/useBookTabFilters.ts';
 import { AddIcon } from '@/theme/Icons.tsx';
@@ -31,7 +33,8 @@ export const NotesPage = () => {
   const navigate = useNavigate({ from: '/book/$bookId/notes' });
   const { kinds, chapterId } = useSearch({ from: '/book/$bookId/notes' });
 
-  const { selectedTagId, handleTagClick } = useBookTabFilters('/book/$bookId/notes');
+  const { searchText, handleSearch, selectedTagId, handleTagClick } =
+    useBookTabFilters('/book/$bookId/notes');
   const [filterDrawerOpen, setFilterDrawerOpen] = useState(false);
 
   const selectedKinds = kinds ?? DEFAULT_NOTE_KINDS;
@@ -46,7 +49,19 @@ export const NotesPage = () => {
   // so the generated GET hook's `data` is the payload itself, not an AxiosResponse.
   const notes = data?.items ?? [];
   const visibleNotes = notes.filter((note) => selectedKinds.includes(noteKindOf(note.kind)));
-  const noteDialogs = useNoteDialogs({ allNotes: visibleNotes });
+
+  const search = useSemanticSearch({ query: searchText, bookId: book.id });
+  const scoreByNoteId = new Map(search.results?.notes.map((hit) => [hit.id, hit.score]) ?? []);
+
+  // The search intersects with the kind and tag filters rather than replacing
+  // them: a note must pass all of them. Matches are ordered best first.
+  const notesToShow = search.results
+    ? visibleNotes
+        .filter((note) => scoreByNoteId.has(note.id))
+        .sort((a, b) => (scoreByNoteId.get(b.id) ?? 0) - (scoreByNoteId.get(a.id) ?? 0))
+    : visibleNotes;
+
+  const noteDialogs = useNoteDialogs({ allNotes: notesToShow });
 
   const handleKindsChange = (next: NoteKindValue[]) => {
     void navigate({
@@ -103,24 +118,40 @@ export const NotesPage = () => {
           leftSidebarEl
         )}
 
-      <Box sx={{ display: 'flex', justifyContent: 'flex-end', mb: 2 }}>
+      <Box sx={{ display: 'flex', gap: 1, alignItems: 'flex-start', mb: 2 }}>
+        <Box sx={{ flexGrow: 1 }}>
+          <SemanticSearchField
+            value={searchText}
+            onChange={handleSearch}
+            placeholder="Search notes by meaning…"
+            isFetching={search.isFetching}
+          />
+        </Box>
         <Button variant="contained" startIcon={<AddIcon />} onClick={noteDialogs.openCreate}>
           New note
         </Button>
       </Box>
 
+      {search.isError && (
+        <Alert severity="warning" sx={{ mb: 2 }}>
+          Search failed. Showing all notes.
+        </Alert>
+      )}
+
       {isLoading && <Spinner />}
       {isError && <Alert severity="error">Failed to load notes.</Alert>}
-      {!isLoading && !isError && visibleNotes.length === 0 && (
+      {!isLoading && !isError && notesToShow.length === 0 && (
         <EmptyStateText>
-          {notes.length > 0
-            ? 'No notes match the selected filters.'
-            : 'No notes yet. Create notes about characters, terms, and concepts as you read.'}
+          {search.hasQuery && visibleNotes.length > 0
+            ? `No notes match “${searchText}”.`
+            : notes.length > 0
+              ? 'No notes match the selected filters.'
+              : 'No notes yet. Create notes about characters, terms, and concepts as you read.'}
         </EmptyStateText>
       )}
 
       <CardList>
-        {visibleNotes.map((note) => (
+        {notesToShow.map((note) => (
           <li key={note.id}>
             <NoteCard note={note} onClick={() => noteDialogs.openView(note)} />
           </li>

--- a/frontend/src/pages/BookPage/Notes/NotesPage.tsx
+++ b/frontend/src/pages/BookPage/Notes/NotesPage.tsx
@@ -124,7 +124,6 @@ export const NotesPage = () => {
             value={searchText}
             onChange={handleSearch}
             placeholder="Search notes by meaning…"
-            isFetching={search.isFetching}
           />
         </Box>
         <Button variant="contained" startIcon={<AddIcon />} onClick={noteDialogs.openCreate}>

--- a/frontend/src/pages/BookPage/Notes/NotesPage.tsx
+++ b/frontend/src/pages/BookPage/Notes/NotesPage.tsx
@@ -125,7 +125,6 @@ export const NotesPage = () => {
           gap: 1,
           alignItems: 'flex-start',
           justifyContent: 'space-between',
-          mb: 2,
         }}
       >
         <PageTitle text="Notes" />

--- a/frontend/src/pages/BookPage/Notes/NotesPage.tsx
+++ b/frontend/src/pages/BookPage/Notes/NotesPage.tsx
@@ -8,12 +8,13 @@ import { useSemanticSearch } from '@/components/search/useSemanticSearch.ts';
 import { useBookPage } from '@/pages/BookPage/BookPageContext';
 import { useBookTabFilters } from '@/pages/BookPage/common/useBookTabFilters.ts';
 import { AddIcon } from '@/theme/Icons.tsx';
-import { Alert, Box, Button, Divider } from '@mui/material';
+import { Alert, Box, Divider, IconButton } from '@mui/material';
 import { useNavigate, useSearch } from '@tanstack/react-router';
 import { useState } from 'react';
 import { createPortal } from 'react-dom';
 
 import { MiddleContentColumn } from '@/components/layout/Layouts.tsx';
+import { PageTitle } from '@/components/typography/PageTitle.tsx';
 import { FilterFab } from '../common/FilterFab.tsx';
 import { FilterDrawer, type FilterTab } from '../navigation/FilterDrawer.tsx';
 import { TagsList } from '../navigation/TagsList/TagsList.tsx';
@@ -118,6 +119,21 @@ export const NotesPage = () => {
           leftSidebarEl
         )}
 
+      <Box
+        sx={{
+          display: 'flex',
+          gap: 1,
+          alignItems: 'flex-start',
+          justifyContent: 'space-between',
+          mb: 2,
+        }}
+      >
+        <PageTitle text="Notes" />
+        <IconButton aria-label="Add note" color="primary" onClick={noteDialogs.openCreate}>
+          <AddIcon />
+        </IconButton>
+      </Box>
+
       <Box sx={{ display: 'flex', gap: 1, alignItems: 'flex-start', mb: 2 }}>
         <Box sx={{ flexGrow: 1 }}>
           <SemanticSearchField
@@ -126,9 +142,6 @@ export const NotesPage = () => {
             placeholder="Search notes by meaning…"
           />
         </Box>
-        <Button variant="contained" startIcon={<AddIcon />} onClick={noteDialogs.openCreate}>
-          New note
-        </Button>
       </Box>
 
       {search.isError && (

--- a/frontend/src/pages/BookPage/ReadingSessions/ReadingSessionList.tsx
+++ b/frontend/src/pages/BookPage/ReadingSessions/ReadingSessionList.tsx
@@ -1,5 +1,6 @@
 import type { Bookmark, ReadingSession } from '@/api/generated/model';
 import { FadeInOut } from '@/components/animations/FadeInOut';
+import { useSettings } from '@/context/SettingsContext';
 import { Box, Typography } from '@mui/material';
 import { ReadingSessionCard } from './ReadingSessionCard';
 
@@ -18,6 +19,7 @@ export const ReadingSessionList = ({
   bookmarksByHighlightId,
   onOpenHighlight,
 }: ReadingSessionListProps) => {
+  const aiEnabled = !!useSettings().featureFlags?.ai;
   return (
     <FadeInOut ekey={animationKey}>
       {sessions.length === 0 ? (
@@ -34,7 +36,12 @@ export const ReadingSessionList = ({
       ) : (
         <Box
           component="ul"
-          sx={{ display: 'flex', flexDirection: 'column', listStyle: 'none', p: 0, m: 0 }}
+          sx={{
+            display: 'flex',
+            flexDirection: 'column',
+            listStyle: 'none',
+            m: aiEnabled ? -3.5 : -1,
+          }}
           aria-label="Reading sessions"
         >
           {sessions.map((session) => (

--- a/frontend/src/pages/BookPage/ReadingSessions/ReadingSessionsPage.tsx
+++ b/frontend/src/pages/BookPage/ReadingSessions/ReadingSessionsPage.tsx
@@ -2,6 +2,7 @@ import type { ReadingSession } from '@/api/generated/model';
 import { useGetBookReadingSessions } from '@/api/generated/reading-sessions/reading-sessions';
 import { useGetTags } from '@/api/generated/tags/tags';
 import { Spinner } from '@/components/animations/Spinner.tsx';
+import { PageTitle } from '@/components/typography/PageTitle.tsx';
 import { useBookPage } from '@/pages/BookPage/BookPageContext';
 import { HighlightViewDialog } from '@/pages/BookPage/Highlights/HighlightViewDialog/HighlightViewDialog';
 import {
@@ -80,6 +81,7 @@ export const ReadingSessionsPage = () => {
   return (
     <>
       <Box>
+        <PageTitle text="Reading sessions" />
         {isLoading && <Spinner />}
 
         {isError && (

--- a/frontend/src/pages/BookPage/Reflection/ReflectionPage.tsx
+++ b/frontend/src/pages/BookPage/Reflection/ReflectionPage.tsx
@@ -13,6 +13,7 @@ import {
 import { Spinner } from '@/components/animations/Spinner.tsx';
 import { IconButtonWithTooltip } from '@/components/buttons/IconButtonWithTooltip.tsx';
 import { MiddleContentColumn } from '@/components/layout/Layouts.tsx';
+import { PageTitle } from '@/components/typography/PageTitle.tsx';
 import { SectionTitle } from '@/components/typography/SectionTitle.tsx';
 import { useMutationErrorHandler } from '@/hooks/useMutationErrorHandler.ts';
 import { useBookPage } from '@/pages/BookPage/BookPageContext';
@@ -120,6 +121,7 @@ export const ReflectionPage = () => {
 
   return (
     <MiddleContentColumn>
+      <PageTitle text="Reflection" />
       {stageHint && (
         <Typography
           variant="body2"

--- a/frontend/src/pages/BookPage/Structure/ChapterAccordion.tsx
+++ b/frontend/src/pages/BookPage/Structure/ChapterAccordion.tsx
@@ -21,9 +21,15 @@ interface ChapterAccordionProps {
   gistByChapterId: Map<number, string>;
   bookId: number;
   depth?: number;
-  isRead?: boolean;
-  isCurrent?: boolean;
   readingPosition?: PositionResponse | null;
+  /**
+   * Ids of chapters on the current reading-position path, derived once from
+   * unfiltered document order (see `StructurePage`). Membership, not sibling
+   * position, is what decides "current" — a search filters and re-sorts
+   * `childrenByParentId`, so peeking at the next rendered sibling would not
+   * mean the next chapter in the book.
+   */
+  currentChapterIds: Set<number>;
   preExpanded?: boolean;
   onChapterClick?: (chapterId: number) => void;
 }
@@ -85,7 +91,7 @@ const ExpandableChapter = ({
       }}
     >
       <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1 }}>
-        {readStatus && <ChapterReadIndicator status={readStatus} />}
+        {readStatus && <ChapterReadIndicator status={readStatus} chapterName={name} />}
         <Box>
           <Typography variant="body1" sx={{ fontWeight: 600 }}>
             {name}
@@ -142,7 +148,7 @@ const LeafChapterRow = ({
       })}
     >
       <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1 }}>
-        {readStatus && <ChapterReadIndicator status={readStatus} />}
+        {readStatus && <ChapterReadIndicator status={readStatus} chapterName={chapter.name} />}
         <Box>
           <Typography variant="body1" sx={{ fontWeight: 600 }}>
             {chapter.name}
@@ -174,12 +180,16 @@ export const ChapterAccordion = ({
   gistByChapterId,
   bookId,
   depth = 0,
-  isRead,
-  isCurrent,
   readingPosition,
+  currentChapterIds,
   preExpanded = false,
   onChapterClick,
 }: ChapterAccordionProps) => {
+  const isRead =
+    readingPosition != null &&
+    chapter.start_position != null &&
+    readingPosition.index >= chapter.start_position.index;
+  const isCurrent = currentChapterIds.has(chapter.id);
   const readStatus: ReadStatus | undefined =
     readingPosition == null ? undefined : isCurrent ? 'current' : isRead ? 'read' : 'unread';
   const [expanded, setExpanded] = useState(isCurrent || readingPosition == null || preExpanded);
@@ -200,35 +210,20 @@ export const ChapterAccordion = ({
         readStatus={readStatus}
       >
         <Box>
-          {childChapters.map((child, index) => {
-            const childIsRead =
-              readingPosition != null && child.start_position != null
-                ? readingPosition.index >= child.start_position.index
-                : undefined;
-            // Current = this child is read but the next sibling is not
-            const isLastChild = index === childChapters.length - 1;
-            const nextIsRead = isLastChild
-              ? false
-              : readingPosition != null && childChapters[index + 1].start_position != null
-                ? readingPosition.index >= childChapters[index + 1].start_position!.index
-                : false;
-            const childIsCurrent = isCurrent === true && childIsRead === true && !nextIsRead;
-
-            return (
-              <ChapterAccordion
-                key={child.id}
-                chapter={child}
-                childrenByParentId={childrenByParentId}
-                gistByChapterId={gistByChapterId}
-                bookId={bookId}
-                depth={depth + 1}
-                isRead={childIsRead}
-                isCurrent={childIsCurrent}
-                readingPosition={readingPosition}
-                onChapterClick={onChapterClick}
-              />
-            );
-          })}
+          {childChapters.map((child) => (
+            <ChapterAccordion
+              key={child.id}
+              chapter={child}
+              childrenByParentId={childrenByParentId}
+              gistByChapterId={gistByChapterId}
+              bookId={bookId}
+              depth={depth + 1}
+              readingPosition={readingPosition}
+              currentChapterIds={currentChapterIds}
+              preExpanded={preExpanded}
+              onChapterClick={onChapterClick}
+            />
+          ))}
         </Box>
       </ExpandableChapter>
     );

--- a/frontend/src/pages/BookPage/Structure/ChapterReadIndicator.tsx
+++ b/frontend/src/pages/BookPage/Structure/ChapterReadIndicator.tsx
@@ -4,17 +4,28 @@ type ReadStatus = 'read' | 'current' | 'unread';
 
 interface ChapterReadIndicatorProps {
   status: ReadStatus;
+  /** Chapter this indicator belongs to, folded into the accessible name so a
+   * test (or a screen reader) can tell which chapter is "current". */
+  chapterName: string;
 }
 
 const SIZE = 20;
 
-export const ChapterReadIndicator = ({ status }: ChapterReadIndicatorProps) => {
+const STATUS_LABEL: Record<ReadStatus, string> = {
+  read: 'Read chapter',
+  current: 'Current chapter',
+  unread: 'Unread chapter',
+};
+
+export const ChapterReadIndicator = ({ status, chapterName }: ChapterReadIndicatorProps) => {
   const theme = useTheme();
   const brown = theme.palette.secondary.dark;
   const gray = theme.palette.text.disabled;
 
   return (
     <svg
+      role="img"
+      aria-label={`${chapterName}: ${STATUS_LABEL[status]}`}
       width={SIZE}
       height={SIZE}
       viewBox={`0 0 ${SIZE} ${SIZE}`}

--- a/frontend/src/pages/BookPage/Structure/StructurePage.test.tsx
+++ b/frontend/src/pages/BookPage/Structure/StructurePage.test.tsx
@@ -51,6 +51,97 @@ test('searching narrows the chapter tree to matches and their parents', async ()
   await expect.element(screen.getByText('Part Two')).toBeVisible();
 });
 
+/**
+ * Three levels deep, with a reading position that makes "Part Two" the true
+ * current chapter (read, and its next top-level sibling "Part Three" is not).
+ * "Deep Topic" sits two levels under "Part One" (10 > 11 > 12), so a search
+ * that matches only it must still expand both ancestors to reveal it.
+ */
+const aBookWithReadingPosition = () =>
+  aBookDetails({
+    reading_position: { index: 5, char_index: 0 },
+    chapters: [
+      aChapter({
+        id: 10,
+        name: 'Part One',
+        chapter_number: 1,
+        start_position: { index: 0, char_index: 0 },
+      }),
+      aChapter({
+        id: 11,
+        name: 'Overview',
+        chapter_number: 2,
+        parent_id: 10,
+        start_position: { index: 1, char_index: 0 },
+      }),
+      aChapter({
+        id: 12,
+        name: 'Deep Topic',
+        chapter_number: 3,
+        parent_id: 11,
+        start_position: { index: 2, char_index: 0 },
+      }),
+      aChapter({
+        id: 20,
+        name: 'Part Two',
+        chapter_number: 4,
+        start_position: { index: 5, char_index: 0 },
+      }),
+      aChapter({
+        id: 21,
+        name: 'Section X',
+        chapter_number: 5,
+        parent_id: 20,
+        start_position: { index: 6, char_index: 0 },
+      }),
+      aChapter({
+        id: 30,
+        name: 'Part Three',
+        chapter_number: 6,
+        start_position: { index: 10, char_index: 0 },
+      }),
+    ],
+  });
+
+test('a search reveals a deeply-nested match and leaves the current-chapter indicator on the true current chapter', async () => {
+  worker.use(
+    settingsWithEmbeddings(true),
+    ...semanticSearchApi({
+      deep: {
+        digests: [
+          aDigestHit({ chapter_id: 12, chapter_name: 'Deep Topic', score: 0.5 }),
+          // Scored above "Deep Topic" so the top level re-sorts to [Part Two,
+          // Part One] — the opposite of document order, which is what would
+          // fool an index-based "next sibling" current-chapter check.
+          aDigestHit({ chapter_id: 20, chapter_name: 'Part Two', score: 0.9 }),
+        ],
+      },
+    }),
+    ...bookApi({ book: aBookWithReadingPosition() }).handlers
+  );
+
+  const screen = await renderApp({ path: '/book/1/structure' });
+  await expect.element(screen.getByText('Part Three')).toBeVisible();
+
+  await userEvent.fill(screen.getByPlaceholder(SEARCH_PLACEHOLDER), 'deep');
+
+  // The non-matching top-level chapter disappearing is what proves the
+  // search landed before the assertions below are trusted.
+  await expect.element(screen.getByText('Part Three')).not.toBeInTheDocument();
+
+  // Finding 2: a match two levels down (10 > 11 > 12) stays reachable —
+  // both ancestor accordions must have expanded, not just the top one.
+  await expect.element(screen.getByText('Deep Topic')).toBeVisible();
+
+  // Finding 1: "Part Two" is current in document order regardless of how
+  // the search re-sorts the top level; "Part One" is merely read.
+  await expect
+    .element(screen.getByRole('img', { name: 'Part Two: Current chapter' }))
+    .toBeVisible();
+  await expect.element(screen.getByRole('img', { name: 'Part One: Read chapter' })).toBeVisible();
+  expect(screen.getByRole('img', { name: 'Part One: Current chapter' }).elements()).toHaveLength(0);
+});
+
 test('a match below the score cutoff counts as no match', async () => {
   worker.use(
     settingsWithEmbeddings(true),

--- a/frontend/src/pages/BookPage/Structure/StructurePage.test.tsx
+++ b/frontend/src/pages/BookPage/Structure/StructurePage.test.tsx
@@ -1,0 +1,72 @@
+import { aBookDetails, aChapter } from '@tests/fixtures/book';
+import { aDigestHit } from '@tests/fixtures/semantic';
+import { renderApp } from '@tests/harness/renderApp';
+import { settingsWithEmbeddings } from '@tests/msw/auth';
+import { bookApi } from '@tests/msw/bookApi';
+import { semanticSearchApi } from '@tests/msw/semanticSearchApi';
+import { worker } from '@tests/msw/worker';
+import { expect, test } from 'vitest';
+import { userEvent } from 'vitest/browser';
+
+const SEARCH_PLACEHOLDER = 'Search chapters by meaning…';
+
+/** Two parts, one leaf chapter each — enough to prove ancestors survive. */
+const aStructuredBook = () =>
+  aBookDetails({
+    chapters: [
+      aChapter({ id: 10, name: 'Part One', chapter_number: 1 }),
+      aChapter({ id: 11, name: 'Attention and memory', chapter_number: 2, parent_id: 10 }),
+      aChapter({ id: 20, name: 'Part Two', chapter_number: 3 }),
+      aChapter({ id: 21, name: 'Roman roads', chapter_number: 4, parent_id: 20 }),
+    ],
+  });
+
+test('searching narrows the chapter tree to matches and their parents', async () => {
+  worker.use(
+    settingsWithEmbeddings(true),
+    ...semanticSearchApi({
+      attention: {
+        digests: [
+          aDigestHit({ chapter_id: 11, chapter_name: 'Attention and memory', score: 0.72 }),
+        ],
+      },
+    }),
+    ...bookApi({ book: aStructuredBook() }).handlers
+  );
+
+  const screen = await renderApp({ path: '/book/1/structure' });
+  await expect.element(screen.getByText('Roman roads')).toBeVisible();
+
+  await userEvent.fill(screen.getByPlaceholder(SEARCH_PLACEHOLDER), 'attention');
+
+  // The non-matching branch disappearing is what proves the search landed.
+  await expect.element(screen.getByText('Roman roads')).not.toBeInTheDocument();
+  await expect.element(screen.getByText('Attention and memory')).toBeVisible();
+  await expect.element(screen.getByText('Part One')).toBeVisible();
+  expect(screen.getByText('Part Two').elements()).toHaveLength(0);
+
+  // Clearing restores the whole tree.
+  await userEvent.fill(screen.getByPlaceholder(SEARCH_PLACEHOLDER), '');
+  await expect.element(screen.getByText('Roman roads')).toBeVisible();
+  await expect.element(screen.getByText('Part Two')).toBeVisible();
+});
+
+test('a match below the score cutoff counts as no match', async () => {
+  worker.use(
+    settingsWithEmbeddings(true),
+    ...semanticSearchApi({
+      quantum: {
+        digests: [
+          aDigestHit({ chapter_id: 11, chapter_name: 'Attention and memory', score: 0.12 }),
+        ],
+      },
+    }),
+    ...bookApi({ book: aStructuredBook() }).handlers
+  );
+
+  const screen = await renderApp({ path: '/book/1/structure' });
+  await userEvent.fill(screen.getByPlaceholder(SEARCH_PLACEHOLDER), 'quantum');
+
+  await expect.element(screen.getByText(/No chapters match/)).toBeVisible();
+  expect(screen.getByText('Attention and memory').elements()).toHaveLength(0);
+});

--- a/frontend/src/pages/BookPage/Structure/StructurePage.tsx
+++ b/frontend/src/pages/BookPage/Structure/StructurePage.tsx
@@ -1,5 +1,9 @@
 import { useGetBookDigest } from '@/api/generated/digest/digest';
-import type { ChapterDigestResponse, ChapterWithHighlights } from '@/api/generated/model';
+import type {
+  ChapterDigestResponse,
+  ChapterWithHighlights,
+  PositionResponse,
+} from '@/api/generated/model';
 import { useGetNotesForBook } from '@/api/generated/notes/notes.ts';
 import { EmptyStateText } from '@/components/EmptyStateText.tsx';
 import { useUrlEntityDialog } from '@/components/dialogs/useUrlEntityDialog.ts';
@@ -14,6 +18,38 @@ import { BatchDigestToolbar } from './BatchDigestToolbar';
 import { ChapterAccordion } from './ChapterAccordion';
 import { ChapterDetailDialog } from './ChapterDetailDialog/ChapterDetailDialog.tsx';
 import { chapterMatchesFromDigests } from './chapterMatches.ts';
+
+/**
+ * Chapter ids along the reading-position path, walked once over *unfiltered*
+ * document order. A search filters and re-sorts `childrenByParentId` by
+ * score, so deriving "current" from that map (e.g. by peeking at the next
+ * rendered sibling) would put the indicator on whichever chapter happens to
+ * render next rather than the next chapter in the book. At each level the
+ * current chapter is the one that is read while its next document-order
+ * sibling is not; its children are then walked the same way.
+ */
+const currentChapterIdsAlongReadingPath = (
+  childrenByParentId: Map<number | null, ChapterWithHighlights[]>,
+  readingPosition: PositionResponse | null | undefined
+): Set<number> => {
+  const ids = new Set<number>();
+  if (!readingPosition) return ids;
+
+  const isRead = (chapter: ChapterWithHighlights) =>
+    chapter.start_position != null && readingPosition.index >= chapter.start_position.index;
+
+  let parentId: number | null = null;
+  for (;;) {
+    const siblings: ChapterWithHighlights[] = childrenByParentId.get(parentId) ?? [];
+    const current: ChapterWithHighlights | undefined = siblings.find(
+      (chapter, index) => isRead(chapter) && !(siblings[index + 1] && isRead(siblings[index + 1]))
+    );
+    if (!current) break;
+    ids.add(current.id);
+    parentId = current.id;
+  }
+  return ids;
+};
 
 export const StructurePage = () => {
   const { book } = useBookPage();
@@ -111,6 +147,15 @@ export const StructurePage = () => {
     return map;
   }, [childrenByParentId, matches]);
 
+  const readingPosition = book.reading_position;
+
+  // Derived from the unfiltered tree so a search can never move the
+  // current-chapter indicator (see the function's own doc comment).
+  const currentChapterIds = useMemo(
+    () => currentChapterIdsAlongReadingPath(childrenByParentId, readingPosition),
+    [childrenByParentId, readingPosition]
+  );
+
   if (book.chapters.length === 0) {
     return (
       <Box sx={{ p: 3, textAlign: 'center' }}>
@@ -127,13 +172,6 @@ export const StructurePage = () => {
   }
 
   const topLevelChapters = visibleChildrenByParentId.get(null) ?? [];
-
-  const readingPosition = book.reading_position;
-
-  const isChapterRead = (startPosition: { index: number } | null | undefined): boolean => {
-    if (!readingPosition || !startPosition) return false;
-    return readingPosition.index >= startPosition.index;
-  };
 
   return (
     <>
@@ -160,31 +198,21 @@ export const StructurePage = () => {
           <EmptyStateText>No chapters match “{searchText}”.</EmptyStateText>
         </Box>
       ) : (
-        topLevelChapters.map((chapter, index) => {
-          const chapterIsRead = isChapterRead(chapter.start_position);
-          const isLastChapter = index === topLevelChapters.length - 1;
-          const nextIsRead = isLastChapter
-            ? false
-            : isChapterRead(topLevelChapters[index + 1].start_position);
-          const chapterIsCurrent = chapterIsRead && !nextIsRead;
-
-          return (
-            <ChapterAccordion
-              // Keyed by the query so a new search remounts the branch and its
-              // `expanded` state re-initialises from `preExpanded`.
-              key={`${chapter.id}:${searchText}`}
-              chapter={chapter}
-              childrenByParentId={visibleChildrenByParentId}
-              gistByChapterId={gistByChapterId}
-              bookId={book.id}
-              isRead={chapterIsRead}
-              isCurrent={chapterIsCurrent}
-              readingPosition={readingPosition}
-              preExpanded={search.hasQuery}
-              onChapterClick={chapterDialog.open}
-            />
-          );
-        })
+        topLevelChapters.map((chapter) => (
+          <ChapterAccordion
+            // Keyed by the query so a new search remounts the branch and its
+            // `expanded` state re-initialises from `preExpanded`.
+            key={`${chapter.id}:${searchText}`}
+            chapter={chapter}
+            childrenByParentId={visibleChildrenByParentId}
+            gistByChapterId={gistByChapterId}
+            bookId={book.id}
+            readingPosition={readingPosition}
+            currentChapterIds={currentChapterIds}
+            preExpanded={search.hasQuery}
+            onChapterClick={chapterDialog.open}
+          />
+        ))
       )}
 
       {chapterDialog.activeItem && (

--- a/frontend/src/pages/BookPage/Structure/StructurePage.tsx
+++ b/frontend/src/pages/BookPage/Structure/StructurePage.tsx
@@ -182,13 +182,12 @@ export const StructurePage = () => {
           gap: 1,
           alignItems: 'flex-start',
           justifyContent: 'space-between',
-          mb: 2,
         }}
       >
         <PageTitle text="Structure of the book" />
         <BatchDigestToolbar bookId={book.id} />
       </Box>
-      <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1, pt: 1 }}>
+      <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1 }}>
         <Box sx={{ flexGrow: 1 }}>
           <SemanticSearchField
             value={searchText}

--- a/frontend/src/pages/BookPage/Structure/StructurePage.tsx
+++ b/frontend/src/pages/BookPage/Structure/StructurePage.tsx
@@ -9,6 +9,7 @@ import { EmptyStateText } from '@/components/EmptyStateText.tsx';
 import { useUrlEntityDialog } from '@/components/dialogs/useUrlEntityDialog.ts';
 import { SemanticSearchField } from '@/components/search/SemanticSearchField.tsx';
 import { useSemanticSearch } from '@/components/search/useSemanticSearch.ts';
+import { PageTitle } from '@/components/typography/PageTitle.tsx';
 import { useBookPage } from '@/pages/BookPage/BookPageContext';
 import { useBookTabFilters } from '@/pages/BookPage/common/useBookTabFilters.ts';
 import { Alert, Box, Typography } from '@mui/material';
@@ -175,7 +176,19 @@ export const StructurePage = () => {
 
   return (
     <>
-      <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1, px: 1, pt: 1 }}>
+      <Box
+        sx={{
+          display: 'flex',
+          gap: 1,
+          alignItems: 'flex-start',
+          justifyContent: 'space-between',
+          mb: 2,
+        }}
+      >
+        <PageTitle text="Structure of the book" />
+        <BatchDigestToolbar bookId={book.id} />
+      </Box>
+      <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1, pt: 1 }}>
         <Box sx={{ flexGrow: 1 }}>
           <SemanticSearchField
             value={searchText}
@@ -183,7 +196,6 @@ export const StructurePage = () => {
             placeholder="Search chapters by meaning…"
           />
         </Box>
-        <BatchDigestToolbar bookId={book.id} />
       </Box>
 
       {search.isError && (

--- a/frontend/src/pages/BookPage/Structure/StructurePage.tsx
+++ b/frontend/src/pages/BookPage/Structure/StructurePage.tsx
@@ -181,7 +181,6 @@ export const StructurePage = () => {
             value={searchText}
             onChange={handleSearch}
             placeholder="Search chapters by meaning…"
-            isFetching={search.isFetching}
           />
         </Box>
         <BatchDigestToolbar bookId={book.id} />

--- a/frontend/src/pages/BookPage/Structure/StructurePage.tsx
+++ b/frontend/src/pages/BookPage/Structure/StructurePage.tsx
@@ -1,14 +1,19 @@
 import { useGetBookDigest } from '@/api/generated/digest/digest';
 import type { ChapterDigestResponse, ChapterWithHighlights } from '@/api/generated/model';
 import { useGetNotesForBook } from '@/api/generated/notes/notes.ts';
+import { EmptyStateText } from '@/components/EmptyStateText.tsx';
 import { useUrlEntityDialog } from '@/components/dialogs/useUrlEntityDialog.ts';
+import { SemanticSearchField } from '@/components/search/SemanticSearchField.tsx';
+import { useSemanticSearch } from '@/components/search/useSemanticSearch.ts';
 import { useBookPage } from '@/pages/BookPage/BookPageContext';
-import { Box, Typography } from '@mui/material';
+import { useBookTabFilters } from '@/pages/BookPage/common/useBookTabFilters.ts';
+import { Alert, Box, Typography } from '@mui/material';
 import { keyBy } from 'lodash';
 import { useMemo } from 'react';
 import { BatchDigestToolbar } from './BatchDigestToolbar';
 import { ChapterAccordion } from './ChapterAccordion';
 import { ChapterDetailDialog } from './ChapterDetailDialog/ChapterDetailDialog.tsx';
+import { chapterMatchesFromDigests } from './chapterMatches.ts';
 
 export const StructurePage = () => {
   const { book } = useBookPage();
@@ -81,6 +86,31 @@ export const StructurePage = () => {
     [book.bookmarks]
   );
 
+  const { searchText, handleSearch } = useBookTabFilters('/book/$bookId/structure');
+  const search = useSemanticSearch({ query: searchText, bookId: book.id });
+
+  const matches = useMemo(
+    () =>
+      search.results ? chapterMatchesFromDigests(search.results.digests, book.chapters) : null,
+    [search.results, book.chapters]
+  );
+
+  // While a search is active, each parent keeps only its matching children,
+  // ordered by their best descendant score. No search → the map is untouched.
+  const visibleChildrenByParentId = useMemo(() => {
+    if (!matches) return childrenByParentId;
+    const map = new Map<number | null, ChapterWithHighlights[]>();
+    for (const [parentId, children] of childrenByParentId) {
+      const kept = children
+        .filter((chapter) => matches.visibleIds.has(chapter.id))
+        .sort(
+          (a, b) => (matches.bestScoreById.get(b.id) ?? 0) - (matches.bestScoreById.get(a.id) ?? 0)
+        );
+      if (kept.length > 0) map.set(parentId, kept);
+    }
+    return map;
+  }, [childrenByParentId, matches]);
+
   if (book.chapters.length === 0) {
     return (
       <Box sx={{ p: 3, textAlign: 'center' }}>
@@ -96,7 +126,7 @@ export const StructurePage = () => {
     );
   }
 
-  const topLevelChapters = childrenByParentId.get(null) ?? [];
+  const topLevelChapters = visibleChildrenByParentId.get(null) ?? [];
 
   const readingPosition = book.reading_position;
 
@@ -107,31 +137,55 @@ export const StructurePage = () => {
 
   return (
     <>
-      <Box sx={{ display: 'flex', justifyContent: 'flex-end', px: 1, pt: 1 }}>
+      <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1, px: 1, pt: 1 }}>
+        <Box sx={{ flexGrow: 1 }}>
+          <SemanticSearchField
+            value={searchText}
+            onChange={handleSearch}
+            placeholder="Search chapters by meaning…"
+            isFetching={search.isFetching}
+          />
+        </Box>
         <BatchDigestToolbar bookId={book.id} />
       </Box>
-      {topLevelChapters.map((chapter, index) => {
-        const chapterIsRead = isChapterRead(chapter.start_position);
-        const isLastChapter = index === topLevelChapters.length - 1;
-        const nextIsRead = isLastChapter
-          ? false
-          : isChapterRead(topLevelChapters[index + 1].start_position);
-        const chapterIsCurrent = chapterIsRead && !nextIsRead;
 
-        return (
-          <ChapterAccordion
-            key={chapter.id}
-            chapter={chapter}
-            childrenByParentId={childrenByParentId}
-            gistByChapterId={gistByChapterId}
-            bookId={book.id}
-            isRead={chapterIsRead}
-            isCurrent={chapterIsCurrent}
-            readingPosition={readingPosition}
-            onChapterClick={chapterDialog.open}
-          />
-        );
-      })}
+      {search.isError && (
+        <Alert severity="warning" sx={{ mx: 1, mb: 1 }}>
+          Search failed. Showing all chapters.
+        </Alert>
+      )}
+
+      {search.hasQuery && topLevelChapters.length === 0 ? (
+        <Box sx={{ p: 3, textAlign: 'center' }}>
+          <EmptyStateText>No chapters match “{searchText}”.</EmptyStateText>
+        </Box>
+      ) : (
+        topLevelChapters.map((chapter, index) => {
+          const chapterIsRead = isChapterRead(chapter.start_position);
+          const isLastChapter = index === topLevelChapters.length - 1;
+          const nextIsRead = isLastChapter
+            ? false
+            : isChapterRead(topLevelChapters[index + 1].start_position);
+          const chapterIsCurrent = chapterIsRead && !nextIsRead;
+
+          return (
+            <ChapterAccordion
+              // Keyed by the query so a new search remounts the branch and its
+              // `expanded` state re-initialises from `preExpanded`.
+              key={`${chapter.id}:${searchText}`}
+              chapter={chapter}
+              childrenByParentId={visibleChildrenByParentId}
+              gistByChapterId={gistByChapterId}
+              bookId={book.id}
+              isRead={chapterIsRead}
+              isCurrent={chapterIsCurrent}
+              readingPosition={readingPosition}
+              preExpanded={search.hasQuery}
+              onChapterClick={chapterDialog.open}
+            />
+          );
+        })
+      )}
 
       {chapterDialog.activeItem && (
         <ChapterDetailDialog

--- a/frontend/src/pages/BookPage/Structure/chapterMatches.ts
+++ b/frontend/src/pages/BookPage/Structure/chapterMatches.ts
@@ -1,0 +1,40 @@
+import type { ChapterWithHighlights, DigestSearchItem } from '@/api/generated/model';
+
+export interface ChapterMatches {
+  /** Chapters to render: every match plus its ancestors, so the tree keeps its spine. */
+  visibleIds: Set<number>;
+  /** Best score on the chapter itself or any descendant — what the tree is ordered by. */
+  bestScoreById: Map<number, number>;
+}
+
+/**
+ * Turn matched digests into the chapters the structure tree should show.
+ *
+ * A digest matches one chapter, and showing that chapter alone would orphan it,
+ * so each match walks up `parent_id` marking its ancestors visible and carrying
+ * its score up with it.
+ */
+export const chapterMatchesFromDigests = (
+  digests: DigestSearchItem[],
+  chapters: ChapterWithHighlights[]
+): ChapterMatches => {
+  const parentById = new Map(chapters.map((chapter) => [chapter.id, chapter.parent_id ?? null]));
+  const visibleIds = new Set<number>();
+  const bestScoreById = new Map<number, number>();
+
+  for (const digest of digests) {
+    const seen = new Set<number>();
+    let id: number | null = digest.chapter_id;
+    while (id !== null && parentById.has(id) && !seen.has(id)) {
+      seen.add(id);
+      visibleIds.add(id);
+      const best = bestScoreById.get(id);
+      if (best === undefined || digest.score > best) {
+        bestScoreById.set(id, digest.score);
+      }
+      id = parentById.get(id) ?? null;
+    }
+  }
+
+  return { visibleIds, bestScoreById };
+};

--- a/frontend/src/pages/BookPage/Structure/chapterMatches.ts
+++ b/frontend/src/pages/BookPage/Structure/chapterMatches.ts
@@ -1,6 +1,6 @@
 import type { ChapterWithHighlights, DigestSearchItem } from '@/api/generated/model';
 
-export interface ChapterMatches {
+interface ChapterMatches {
   /** Chapters to render: every match plus its ancestors, so the tree keeps its spine. */
   visibleIds: Set<number>;
   /** Best score on the chapter itself or any descendant — what the tree is ordered by. */

--- a/frontend/src/pages/BookPage/common/useBookTabFilters.ts
+++ b/frontend/src/pages/BookPage/common/useBookTabFilters.ts
@@ -7,7 +7,8 @@ import { useCallback, useState } from 'react';
 type BookTabFilterRoute =
   | '/book/$bookId/highlights'
   | '/book/$bookId/flashcards'
-  | '/book/$bookId/notes';
+  | '/book/$bookId/notes'
+  | '/book/$bookId/structure';
 
 /** The URL filters read/written by these tabs. `search` is absent on the notes tab. */
 interface BookTabSearch {
@@ -21,8 +22,8 @@ interface BookTabSearch {
  * Owns the `selectedTagId` mirror of the `tagId` search param (kept in local
  * state so the sidebar highlights immediately) plus the navigate callbacks that
  * were re-implemented near-identically across the highlights, flashcards and
- * notes tabs. `handleSearch`/`handleChapterClick` apply to the two tabs with a
- * search field; the notes tab only uses the tag pieces.
+ * notes tabs. `handleChapterClick` applies only to the tabs that scroll to a
+ * chapter; every tab may use the search and tag pieces.
  */
 export const useBookTabFilters = (from: BookTabFilterRoute) => {
   const search = useSearch({ from }) as BookTabSearch;

--- a/frontend/src/pages/BookPage/common/useBookTabFilters.ts
+++ b/frontend/src/pages/BookPage/common/useBookTabFilters.ts
@@ -10,7 +10,7 @@ type BookTabFilterRoute =
   | '/book/$bookId/notes'
   | '/book/$bookId/structure';
 
-/** The URL filters read/written by these tabs. `search` is absent on the notes tab. */
+/** The URL filters read/written by these tabs. */
 interface BookTabSearch {
   search?: string;
   tagId?: number;
@@ -27,9 +27,9 @@ interface BookTabSearch {
  */
 export const useBookTabFilters = (from: BookTabFilterRoute) => {
   const search = useSearch({ from }) as BookTabSearch;
-  // The navigate signature differs per route (the notes route has no `search`
-  // param); this hook drives all three, so widen the search updater to a plain
-  // record. Call sites remain fully typed via the literal `from` argument.
+  // The navigate signature differs per route; this hook drives all four, so
+  // widen the search updater to a plain record. Call sites remain fully
+  // typed via the literal `from` argument.
   const navigate = useNavigate({ from }) as unknown as (opts: {
     search: (prev: Record<string, unknown>) => Record<string, unknown>;
     replace?: boolean;

--- a/frontend/src/pages/SettingsPage/SettingsPage.test.tsx
+++ b/frontend/src/pages/SettingsPage/SettingsPage.test.tsx
@@ -1,6 +1,6 @@
-import { appSettings } from '@tests/fixtures/auth';
 import { aJobBatch } from '@tests/fixtures/jobs';
 import { renderApp } from '@tests/harness/renderApp';
+import { settingsWithEmbeddings } from '@tests/msw/auth';
 import { semanticApi } from '@tests/msw/semanticApi';
 import { worker } from '@tests/msw/worker';
 import { http, HttpResponse, type RequestHandler } from 'msw';
@@ -13,16 +13,9 @@ const RUN_BUTTON = 'Run text embedding for the library';
 // One poll interval plus room for the request itself.
 const POLL_TIMEOUT = 8000;
 
-const embeddingsFlag = (enabled: boolean) =>
-  http.get('/api/v1/settings', () =>
-    HttpResponse.json(
-      appSettings({ feature_flags: { ai: false, embeddings: enabled, user_registrations: false } })
-    )
-  );
-
 /** Settings with embeddings on, over `handlers` — the first match there wins. */
 const renderSettings = (handlers: RequestHandler[] = []) => {
-  worker.use(embeddingsFlag(true), ...handlers);
+  worker.use(settingsWithEmbeddings(true), ...handlers);
   return renderApp({ path: '/settings' });
 };
 
@@ -100,7 +93,7 @@ test('a failed start reports the error and leaves the button ready', async () =>
 });
 
 test('the section is hidden when embeddings are disabled', async () => {
-  worker.use(embeddingsFlag(false));
+  worker.use(settingsWithEmbeddings(false));
 
   const screen = await renderApp({ path: '/settings' });
   await expect.element(screen.getByRole('heading', { name: 'Settings' })).toBeVisible();

--- a/frontend/src/routes/book.$bookId/notes.tsx
+++ b/frontend/src/routes/book.$bookId/notes.tsx
@@ -7,6 +7,7 @@ type NotesSearch = {
   chapterId?: number;
   tagId?: number;
   noteId?: number;
+  search?: string;
 };
 
 export const Route = createFileRoute('/book/$bookId/notes')({
@@ -16,5 +17,6 @@ export const Route = createFileRoute('/book/$bookId/notes')({
     chapterId: (search.chapterId as number | undefined) || undefined,
     tagId: (search.tagId as number | undefined) || undefined,
     noteId: (search.noteId as number | undefined) || undefined,
+    search: (search.search as string | undefined) || undefined,
   }),
 });

--- a/frontend/src/routes/book.$bookId/structure.tsx
+++ b/frontend/src/routes/book.$bookId/structure.tsx
@@ -3,11 +3,13 @@ import { createFileRoute } from '@tanstack/react-router';
 
 type StructureSearch = {
   chapterId?: number;
+  search?: string;
 };
 
 export const Route = createFileRoute('/book/$bookId/structure')({
   component: StructurePage,
   validateSearch: (search: Record<string, unknown>): StructureSearch => ({
     chapterId: (search.chapterId as number | undefined) || undefined,
+    search: (search.search as string | undefined) || undefined,
   }),
 });

--- a/frontend/tests/fixtures/semantic.ts
+++ b/frontend/tests/fixtures/semantic.ts
@@ -13,10 +13,6 @@ export const aDigestHit = (overrides: Partial<DigestSearchItem> = {}): DigestSea
   ...overrides,
 });
 
-/**
- * @public Unused within this task — the Notes tab's search tests are the next
- * consumer.
- */
 export const aNoteHit = (overrides: Partial<NoteSearchItem> = {}): NoteSearchItem => ({
   score: 0.7,
   id: 100,

--- a/frontend/tests/fixtures/semantic.ts
+++ b/frontend/tests/fixtures/semantic.ts
@@ -1,0 +1,28 @@
+import type { DigestSearchItem, NoteSearchItem } from '@/api/generated/model';
+
+export const aDigestHit = (overrides: Partial<DigestSearchItem> = {}): DigestSearchItem => ({
+  score: 0.7,
+  id: 500,
+  book_id: 1,
+  book_title: 'The Pragmatic Reader',
+  chapter_id: 10,
+  chapter_name: 'Chapter One',
+  chapter_number: 1,
+  summary: 'A summary of the chapter.',
+  keypoints: [],
+  ...overrides,
+});
+
+/**
+ * @public Unused within this task — the Notes tab's search tests are the next
+ * consumer.
+ */
+export const aNoteHit = (overrides: Partial<NoteSearchItem> = {}): NoteSearchItem => ({
+  score: 0.7,
+  id: 100,
+  books: [{ id: 1, title: 'The Pragmatic Reader' }],
+  title: 'Ada Lovelace',
+  body: 'The first programmer.',
+  kind: 'character',
+  ...overrides,
+});

--- a/frontend/tests/msw/auth.ts
+++ b/frontend/tests/msw/auth.ts
@@ -7,3 +7,11 @@ export const authHandlers = [
   http.get('/api/v1/users/me', () => HttpResponse.json(aUser())),
   http.get('/api/v1/settings', () => HttpResponse.json(appSettings())),
 ];
+
+/** Settings with the embeddings feature flag forced on or off. */
+export const settingsWithEmbeddings = (enabled: boolean) =>
+  http.get('/api/v1/settings', () =>
+    HttpResponse.json(
+      appSettings({ feature_flags: { ai: false, embeddings: enabled, user_registrations: false } })
+    )
+  );

--- a/frontend/tests/msw/semanticSearchApi.ts
+++ b/frontend/tests/msw/semanticSearchApi.ts
@@ -1,0 +1,16 @@
+import type { SemanticSearchResults } from '@/api/generated/model';
+import { http, HttpResponse } from 'msw';
+
+const EMPTY: SemanticSearchResults = { highlights: [], notes: [], digests: [] };
+
+/**
+ * `GET /semantic/search` answering from a query-text lookup table, so a test
+ * says what "attention" matches and nothing else. An unlisted query answers
+ * with all three groups empty, which is what "nothing matched" looks like.
+ */
+export const semanticSearchApi = (byQuery: Record<string, Partial<SemanticSearchResults>>) => [
+  http.get('/api/v1/semantic/search', ({ request }) => {
+    const q = new URL(request.url).searchParams.get('q') ?? '';
+    return HttpResponse.json({ ...EMPTY, ...(byQuery[q] ?? {}) });
+  }),
+];


### PR DESCRIPTION
## Why

#552 gave `GET /api/v1/semantic/search` a display-ready, grouped response, and nothing consumed it. Two book tabs want it now, and a third consumer is coming:

- **Structure** — find the chapter you half-remember, by meaning, without scrolling the tree.
- **Notes** — the notes list had no search at all.
- **Global search** (not in this PR) — every content type, every book, rendering its own result list.

That third consumer is why this is not simply a search box on a page. A component that owned both the input and the rendering of results would have to be rewritten for the global case.

## What changed

Two pieces in `frontend/src/components/search/`, neither of which knows about pages:

| Piece | Responsibility |
| --- | --- |
| `useSemanticSearch({ query, bookId? })` | Owns the request, the score cutoff and the feature flag. Returns `{ results, isFetching, isError, hasQuery }`. |
| `SemanticSearchField` | Controlled, debounced input. Renders nothing about results. |

Omitting `bookId` is the global search — `book_id` is already optional on the endpoint, so there is no second code path to build later.

Each page decides what a match *means*:

- **Structure** maps `results.digests` to chapter ids, keeps each match's ancestors so the tree keeps its spine, orders branches by their best descendant score, and expands the matching ones.
- **Notes** maps `results.notes` to note ids and **intersects** with the kind and tag filters already on the page — a note must pass all of them.

Both keep the query in the `search` URL param, like the Highlights and Flashcards tabs already do, so a search survives reload, back/forward and a shared link. `useBookTabFilters` grew the structure route rather than either page re-implementing the wiring.

### The score cutoff

`score` is raw cosine similarity, and nearest-neighbour search always returns its top N — so "quantum" against a philosophy book comes back with the ten least-bad chapters. `MIN_SCORE = 0.35` in `useSemanticSearch.ts` turns those into an empty state instead of confident-looking noise. It is a starting value for this embedding model, not a measured one; expect to tune it once real queries exist.

## Bugs fixed along the way

Both were found by the whole-branch review, and both live in the Structure tree:

- **The current-chapter indicator followed `topLevelChapters[index + 1]`**, which only means "the next chapter" while the list is in document order. Under a search the list is filtered *and* re-sorted by score, so the dot landed on the wrong chapter, on several, or on none. It is now derived by id from the unfiltered tree.
- **`ChapterAccordion` never passed `preExpanded` down its recursion**, so in any book with a reading position and a three-level table of contents, a matching leaf rendered inside a collapsed accordion — the user saw an open part, a closed section, and no sign of where the match was.

The Structure test could not have failed on either: the book fixture sets `reading_position: null`, and every accordion starts expanded when there is no reading position. The test now uses a three-level book with a reading position.

## Not in scope

- **The global search page.** The hook supports it; nothing renders it yet. The page-level wiring is deliberately left duplicated across the two tabs — two call sites do not justify an abstraction, and the third will show what the shared shape actually is.
- **`limit` / `minScore` as options.** Module constants until a caller varies them.

## How to verify

```bash
cd frontend && npm run type-check && npm run knip && npm run duplication-check && npm run test
```

- [x] `type-check` clean
- [x] `knip` clean
- [x] `duplication-check` 1.6% against the 1.7 threshold — unchanged
- [x] `npm run test` — 34/34 across 9 files, including the two new Structure tests and three new Notes tests

## Notes for review

- **With the `embeddings` flag off, both tabs render exactly as before.** The flag is enforced inside `useSemanticSearch`, not only by hiding the field, so a shared `?search=…` link cannot filter a list whose search box is invisible.
- **A failed search never masquerades as "nothing matched"** — both pages fall back to the unfiltered list under a warning alert, and both have a test for it.
- ADR-0002's deferred list narrows: in-book semantic search has landed; the global page and the related-content UI remain.
- Pre-existing and untouched: `tests/setup.ts` calls `worker.resetHandlers()` before recording unhandled requests, so a late refetch is charged to the *next* test. It is the source of the console noise in the suite and deserves its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
