### PR TITLE
Search semantic queries on Enter or blur, not per keystroke

### DIFF
--- a/frontend/src/components/inputs/SearchBar.tsx
+++ b/frontend/src/components/inputs/SearchBar.tsx
@@ -7,12 +7,19 @@ interface SearchBarProps {
   onSearch: (searchText: string) => void;
   placeholder?: string;
   initialValue?: string;
+  /**
+   * `change` searches while typing, debounced — right for filtering data the
+   * page already has. `submit` waits for Enter or blur, so an expensive search
+   * runs once per finished query rather than once per keystroke.
+   */
+  commitOn?: 'change' | 'submit';
 }
 
 export const SearchBar = ({
   onSearch,
   placeholder = 'Search...',
   initialValue = '',
+  commitOn = 'change',
 }: SearchBarProps) => {
   const [searchInput, setSearchInput] = useState(initialValue);
 
@@ -37,7 +44,15 @@ export const SearchBar = ({
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const value = event.target.value;
     setSearchInput(value);
-    debouncedSearch(value);
+    if (commitOn === 'change') {
+      debouncedSearch(value);
+    }
+  };
+
+  const handleCommit = () => {
+    if (commitOn === 'submit') {
+      onSearch(searchInput);
+    }
   };
 
   const handleClear = () => {
@@ -53,9 +68,13 @@ export const SearchBar = ({
         placeholder={placeholder}
         value={searchInput}
         onChange={handleChange}
+        onBlur={handleCommit}
         onKeyDown={(e) => {
           if (e.key === 'Escape') {
             handleClear();
+          }
+          if (e.key === 'Enter') {
+            handleCommit();
           }
         }}
         slotProps={{
@@ -63,6 +82,9 @@ export const SearchBar = ({
             endAdornment: searchInput && (
               <Box
                 component="span"
+                // Keep the focus in the field: a blur here would commit the
+                // text the click is about to throw away.
+                onMouseDown={(e: React.MouseEvent) => e.preventDefault()}
                 onClick={handleClear}
                 sx={{
                   cursor: 'pointer',

--- a/frontend/src/components/search/SemanticSearchField.tsx
+++ b/frontend/src/components/search/SemanticSearchField.tsx
@@ -4,13 +4,15 @@ import { Box } from '@mui/material';
 
 interface SemanticSearchFieldProps {
   value: string;
-  /** Called with the debounced query text. Must be a stable callback. */
+  /** Called with the submitted query text. Must be a stable callback. */
   onChange: (value: string) => void;
   placeholder: string;
 }
 
 /**
- * Debounced natural-language search box, hidden when embeddings are off.
+ * Natural-language search box, hidden when embeddings are off. The query is
+ * submitted on Enter or blur, never per keystroke: each search is an embedding
+ * call, so half-typed queries are not worth running.
  *
  * Deliberately dumb: it renders the input and knows
  * nothing about results. Callers pair it with `useSemanticSearch` and decide
@@ -19,7 +21,12 @@ interface SemanticSearchFieldProps {
 export const SemanticSearchField = ({ value, onChange, placeholder }: SemanticSearchFieldProps) => (
   <EmbeddingFeature>
     <Box>
-      <SearchBar onSearch={onChange} placeholder={placeholder} initialValue={value} />
+      <SearchBar
+        onSearch={onChange}
+        placeholder={placeholder}
+        initialValue={value}
+        commitOn="submit"
+      />
     </Box>
   </EmbeddingFeature>
 );

--- a/frontend/src/pages/BookPage/Notes/NotesPage.test.tsx
+++ b/frontend/src/pages/BookPage/Notes/NotesPage.test.tsx
@@ -103,6 +103,7 @@ test('searching notes lists only the notes on this page that matched', async () 
   await expect.element(screen.getByRole('heading', { name: 'Ada Lovelace' })).toBeVisible();
 
   await userEvent.fill(screen.getByPlaceholder(NOTES_SEARCH_PLACEHOLDER), 'engines');
+  await userEvent.keyboard('{Enter}');
 
   await expect
     .element(screen.getByRole('heading', { name: 'Ada Lovelace' }))
@@ -124,6 +125,7 @@ test('a query that matches none of the notes on this page shows the search empty
   await expect.element(screen.getByRole('heading', { name: 'Ada Lovelace' })).toBeVisible();
 
   await userEvent.fill(screen.getByPlaceholder(NOTES_SEARCH_PLACEHOLDER), 'underwater');
+  await userEvent.keyboard('{Enter}');
 
   await expect.element(screen.getByText(/No notes match/)).toBeVisible();
   await expect
@@ -146,6 +148,7 @@ test('a failed search reports the error and keeps every note listed', async () =
 
   const screen = await renderApp({ path: '/book/1/notes' });
   await userEvent.fill(screen.getByPlaceholder(NOTES_SEARCH_PLACEHOLDER), 'engines');
+  await userEvent.keyboard('{Enter}');
 
   await expect
     .element(screen.getByRole('alert').filter({ hasText: 'Search failed' }))

--- a/frontend/src/pages/BookPage/Structure/StructurePage.test.tsx
+++ b/frontend/src/pages/BookPage/Structure/StructurePage.test.tsx
@@ -21,7 +21,11 @@ const aStructuredBook = () =>
     ],
   });
 
-test('searching narrows the chapter tree to matches and their parents', async () => {
+/**
+ * The structure tab of a book where "attention" matches chapter 11 only,
+ * rendered and settled — "Roman roads" on screen is the unfiltered tree.
+ */
+const renderStructureWithAttentionMatch = async () => {
   worker.use(
     settingsWithEmbeddings(true),
     ...semanticSearchApi({
@@ -36,8 +40,15 @@ test('searching narrows the chapter tree to matches and their parents', async ()
 
   const screen = await renderApp({ path: '/book/1/structure' });
   await expect.element(screen.getByText('Roman roads')).toBeVisible();
+  return screen;
+};
 
+test('searching narrows the chapter tree to matches and their parents', async () => {
+  const screen = await renderStructureWithAttentionMatch();
+
+  // The field searches on Enter, not per keystroke.
   await userEvent.fill(screen.getByPlaceholder(SEARCH_PLACEHOLDER), 'attention');
+  await userEvent.keyboard('{Enter}');
 
   // The non-matching branch disappearing is what proves the search landed.
   await expect.element(screen.getByText('Roman roads')).not.toBeInTheDocument();
@@ -47,8 +58,19 @@ test('searching narrows the chapter tree to matches and their parents', async ()
 
   // Clearing restores the whole tree.
   await userEvent.fill(screen.getByPlaceholder(SEARCH_PLACEHOLDER), '');
+  await userEvent.keyboard('{Enter}');
   await expect.element(screen.getByText('Roman roads')).toBeVisible();
   await expect.element(screen.getByText('Part Two')).toBeVisible();
+});
+
+test('leaving the search field runs the search without pressing Enter', async () => {
+  const screen = await renderStructureWithAttentionMatch();
+
+  await userEvent.fill(screen.getByPlaceholder(SEARCH_PLACEHOLDER), 'attention');
+  await userEvent.tab();
+
+  await expect.element(screen.getByText('Roman roads')).not.toBeInTheDocument();
+  await expect.element(screen.getByText('Attention and memory')).toBeVisible();
 });
 
 /**
@@ -124,6 +146,7 @@ test('a search reveals a deeply-nested match and leaves the current-chapter indi
   await expect.element(screen.getByText('Part Three')).toBeVisible();
 
   await userEvent.fill(screen.getByPlaceholder(SEARCH_PLACEHOLDER), 'deep');
+  await userEvent.keyboard('{Enter}');
 
   // The non-matching top-level chapter disappearing is what proves the
   // search landed before the assertions below are trusted.
@@ -157,6 +180,7 @@ test('a match below the score cutoff counts as no match', async () => {
 
   const screen = await renderApp({ path: '/book/1/structure' });
   await userEvent.fill(screen.getByPlaceholder(SEARCH_PLACEHOLDER), 'quantum');
+  await userEvent.keyboard('{Enter}');
 
   await expect.element(screen.getByText(/No chapters match/)).toBeVisible();
   expect(screen.getByText('Attention and memory').elements()).toHaveLength(0);


### PR DESCRIPTION
## Why

Every semantic search is an embedding call. The debounced field spent one on each pause in typing, so half-typed queries — \"att\", \"atten\" — each cost a request whose results nobody wanted.

## What changed

`SearchBar` gains a `commitOn` prop:

| Mode | Behaviour | Used by |
| --- | --- | --- |
| `change` (default) | Debounced 300 ms while typing | `ListSearchSortHeader`, `LandingPage` — both filter data the page already holds |
| `submit` | Runs on Enter or blur | `SemanticSearchField` |

The clear button now suppresses the blur it would otherwise cause, so clicking ✕ cannot commit the text it is about to discard.

Blurring a field whose text has not changed re-invokes `onSearch` with the same string. That is a no-op for TanStack Query (same key) and for the `replace` navigation, so there is no bookkeeping to guard it.

## Tests

- The existing Structure and Notes search tests now press Enter after filling the field. Dropping those presses fails three of them, which is what proves typing alone no longer searches.
- New test: leaving the field with `tab()` runs the search without Enter.

`npm run test` (35 passed), `lint`, `format`, `type-check`, `knip` and `duplication-check` (1.6%, unchanged) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)