### PR TITLE
Global semantic search in the app bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Syncs data from e-readers using Koreader.
 - Create flash cards from your highlights and sync them to Anki or get AI suggestions from highlights.
 - Create AI summaries from epub book chapters for review and skimming. Ollama, OpenAI, Anthropic and Gemini supported.
 - Create notes and link them to the highlights, chapters etc.
+- Semantic search over highlights, notes and chapter summaries - find them by meaning instead of exact words, across books and languages. Optional, requires an embedding provider (Ollama or OpenRouter).
 - Supporting features to reflect on the books you have read
 - Self-hosted - your data stays on your server
 - Multi-user support

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -5009,6 +5009,28 @@
             },
             "type": "array",
             "title": "Keypoints"
+          },
+          "cover_file": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cover File"
+          },
+          "cover_blurhash": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cover Blurhash"
           }
         },
         "type": "object",
@@ -5021,7 +5043,9 @@
           "chapter_name",
           "chapter_number",
           "summary",
-          "keypoints"
+          "keypoints",
+          "cover_file",
+          "cover_blurhash"
         ],
         "title": "DigestSearchItem",
         "description": "A matched chapter digest.\n\n``id`` is the digest -- the unit that was embedded, and what ``score``\nbelongs to. ``chapter_id`` is what ``/book/{book_id}/structure?chapterId=``\nopens."
@@ -6168,6 +6192,28 @@
           "datetime": {
             "type": "string",
             "title": "Datetime"
+          },
+          "cover_file": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cover File"
+          },
+          "cover_blurhash": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cover Blurhash"
           }
         },
         "type": "object",
@@ -6181,7 +6227,9 @@
           "chapter_number",
           "text",
           "page",
-          "datetime"
+          "datetime",
+          "cover_file",
+          "cover_blurhash"
         ],
         "title": "HighlightSearchItem",
         "description": "A matched highlight, shaped for a highlight list row.\n\n``id`` opens the highlight view at\n``/book/{book_id}/highlights?highlightId={id}``."
@@ -7223,12 +7271,36 @@
           "title": {
             "type": "string",
             "title": "Title"
+          },
+          "cover_file": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cover File"
+          },
+          "cover_blurhash": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cover Blurhash"
           }
         },
         "type": "object",
         "required": [
           "id",
-          "title"
+          "title",
+          "cover_file",
+          "cover_blurhash"
         ],
         "title": "SearchBookRef",
         "description": "A book a search result belongs to."

--- a/backend/src/application/semantic/queries/content_search.py
+++ b/backend/src/application/semantic/queries/content_search.py
@@ -31,6 +31,8 @@ class BookRef:
 
     id: int
     title: str
+    cover_file: str | None
+    cover_blurhash: str | None
 
 
 @dataclass(frozen=True)
@@ -47,6 +49,8 @@ class HighlightSearchView:
     text: str
     page: int | None
     datetime: str
+    cover_file: str | None
+    cover_blurhash: str | None
 
 
 @dataclass(frozen=True)
@@ -78,6 +82,8 @@ class DigestSearchView:
     chapter_number: int | None
     summary: str
     keypoints: tuple[str, ...]
+    cover_file: str | None
+    cover_blurhash: str | None
 
 
 @dataclass(frozen=True)

--- a/backend/src/infrastructure/semantic/queries/search_hydration_query.py
+++ b/backend/src/infrastructure/semantic/queries/search_hydration_query.py
@@ -77,6 +77,8 @@ class SearchHydrationQuery:
                     HighlightORM.text,
                     HighlightORM.page,
                     HighlightORM.datetime,
+                    BookORM.cover_file,
+                    BookORM.cover_blurhash,
                 )
                 .join(BookORM, HighlightORM.book_id == BookORM.id)
                 .outerjoin(ChapterORM, HighlightORM.chapter_id == ChapterORM.id)
@@ -99,6 +101,8 @@ class SearchHydrationQuery:
                 text=row.text,
                 page=row.page,
                 datetime=row.datetime,
+                cover_file=row.cover_file,
+                cover_blurhash=row.cover_blurhash,
             )
             for score, row in matched
         )
@@ -146,6 +150,8 @@ class SearchHydrationQuery:
                     ChapterORM.chapter_number,
                     BookORM.id.label("book_id"),
                     BookORM.title.label("book_title"),
+                    BookORM.cover_file,
+                    BookORM.cover_blurhash,
                 )
                 .join(ChapterORM, ChapterDigestORM.chapter_id == ChapterORM.id)
                 .join(BookORM, ChapterORM.book_id == BookORM.id)
@@ -163,6 +169,8 @@ class SearchHydrationQuery:
                 chapter_number=row.chapter_number,
                 summary=row.summary,
                 keypoints=tuple(row.keypoints),
+                cover_file=row.cover_file,
+                cover_blurhash=row.cover_blurhash,
             )
             for score, row in matched
         )
@@ -179,12 +187,27 @@ class SearchHydrationQuery:
         if not note_ids:
             return {}
         stmt = (
-            select(note_books.c.note_id, BookORM.id, BookORM.title)
+            select(
+                note_books.c.note_id,
+                BookORM.id,
+                BookORM.title,
+                BookORM.cover_file,
+                BookORM.cover_blurhash,
+            )
             .join(BookORM, note_books.c.book_id == BookORM.id)
             .where(note_books.c.note_id.in_(note_ids), BookORM.user_id == user_id)
             .order_by(BookORM.id)
         )
         grouped: dict[int, list[BookRef]] = {}
-        for note_id, book_id, title in (await self.db.execute(stmt)).all():
-            grouped.setdefault(note_id, []).append(BookRef(id=book_id, title=title))
+        for note_id, book_id, title, cover_file, cover_blurhash in (
+            await self.db.execute(stmt)
+        ).all():
+            grouped.setdefault(note_id, []).append(
+                BookRef(
+                    id=book_id,
+                    title=title,
+                    cover_file=cover_file,
+                    cover_blurhash=cover_blurhash,
+                )
+            )
         return {note_id: tuple(refs) for note_id, refs in grouped.items()}

--- a/backend/src/infrastructure/semantic/schemas/semantic_schemas.py
+++ b/backend/src/infrastructure/semantic/schemas/semantic_schemas.py
@@ -41,6 +41,8 @@ class SearchBookRef(BaseModel):
 
     id: int
     title: str
+    cover_file: str | None
+    cover_blurhash: str | None
 
 
 class HighlightSearchItem(BaseModel):
@@ -62,6 +64,8 @@ class HighlightSearchItem(BaseModel):
     text: str
     page: int | None
     datetime: str
+    cover_file: str | None
+    cover_blurhash: str | None
 
 
 class NoteSearchItem(BaseModel):
@@ -96,6 +100,8 @@ class DigestSearchItem(BaseModel):
     chapter_number: int | None
     summary: str
     keypoints: list[str]
+    cover_file: str | None
+    cover_blurhash: str | None
 
 
 class SemanticSearchResults(BaseModel):

--- a/backend/tests/test_semantic_search_api.py
+++ b/backend/tests/test_semantic_search_api.py
@@ -278,6 +278,65 @@ class TestRenderableFields:
         assert item["summary"] == "What happened"
         assert item["keypoints"] == ["first", "second"]
 
+    async def test_highlight_item_carries_its_books_cover(
+        self,
+        client: AsyncClient,
+        override_embedding_client: AsyncMock,
+        db_session: AsyncSession,
+        test_book: Book,
+    ) -> None:
+        """A result row shows a cover, and the row's own payload has to carry it."""
+        test_book.cover_file = "cover-one.jpg"
+        test_book.cover_blurhash = "L6PZfSi_.AyE_3t7t7R**0o#DgR4"
+        await plant_indexed_highlight(db_session, test_book, "the text", vector=[1.0, 0.0])
+        await db_session.commit()
+
+        item = (await search_groups(client))["highlights"][0]
+
+        assert item["cover_file"] == "cover-one.jpg"
+        assert item["cover_blurhash"] == "L6PZfSi_.AyE_3t7t7R**0o#DgR4"
+
+    async def test_digest_item_and_note_books_carry_covers_and_tolerate_none(
+        self,
+        client: AsyncClient,
+        override_embedding_client: AsyncMock,
+        db_session: AsyncSession,
+        test_book: Book,
+    ) -> None:
+        """A book with no cover is normal, so both fields must be nullable end to end."""
+        second = Book(user_id=test_book.user_id, title="Second Book", cover_file="cover-two.jpg")
+        db_session.add(second)
+        await db_session.commit()
+        await db_session.refresh(second)
+        await plant_indexed_digest(
+            db_session,
+            test_book,
+            "Chapter Seven",
+            chapter_number=7,
+            summary="What happened",
+            keypoints=["first"],
+            vector=[1.0, 0.0],
+        )
+        await plant_indexed_note(
+            db_session,
+            test_book.user_id,
+            "A Title",
+            body="A body",
+            kind="concept",
+            books=(test_book, second),
+            vector=[1.0, 0.0],
+        )
+
+        groups = await search_groups(client)
+
+        # test_book has no cover: null, not a missing key.
+        digest = groups["digests"][0]
+        assert digest["cover_file"] is None
+        assert digest["cover_blurhash"] is None
+
+        covers = {book["title"]: book["cover_file"] for book in groups["notes"][0]["books"]}
+        assert covers == {"Test Book": None, "Second Book": "cover-two.jpg"}
+
 
 class TestBookScoping:
     async def test_finds_a_note_linked_to_two_books(

--- a/frontend/src/api/generated/model/digestSearchItem.ts
+++ b/frontend/src/api/generated/model/digestSearchItem.ts
@@ -22,4 +22,6 @@ export interface DigestSearchItem {
   chapter_number: number | null;
   summary: string;
   keypoints: string[];
+  cover_file: string | null;
+  cover_blurhash: string | null;
 }

--- a/frontend/src/api/generated/model/highlightSearchItem.ts
+++ b/frontend/src/api/generated/model/highlightSearchItem.ts
@@ -22,4 +22,6 @@ export interface HighlightSearchItem {
   text: string;
   page: number | null;
   datetime: string;
+  cover_file: string | null;
+  cover_blurhash: string | null;
 }

--- a/frontend/src/api/generated/model/searchBookRef.ts
+++ b/frontend/src/api/generated/model/searchBookRef.ts
@@ -11,4 +11,6 @@
 export interface SearchBookRef {
   id: number;
   title: string;
+  cover_file: string | null;
+  cover_blurhash: string | null;
 }

--- a/frontend/src/components/inputs/SearchBar.tsx
+++ b/frontend/src/components/inputs/SearchBar.tsx
@@ -17,6 +17,9 @@ interface SearchBarProps {
   sx?: SxProps<Theme>;
   /** Off by default: only a caller that owns the field's only focus target (e.g. a just-opened dialog) should set this. */
   autoFocus?: boolean;
+  /** Extra attributes merged onto the native `<input>`, e.g. ARIA combobox
+   *  wiring for a caller that owns a listbox of its own. Off by default. */
+  slotProps?: { htmlInput?: React.InputHTMLAttributes<HTMLInputElement> };
 }
 
 export const SearchBar = ({
@@ -26,6 +29,7 @@ export const SearchBar = ({
   commitOn = 'change',
   sx,
   autoFocus = false,
+  slotProps,
 }: SearchBarProps) => {
   const [searchInput, setSearchInput] = useState(initialValue);
 
@@ -104,6 +108,7 @@ export const SearchBar = ({
               </Box>
             ),
           },
+          htmlInput: slotProps?.htmlInput,
         }}
       />
     </Box>

--- a/frontend/src/components/inputs/SearchBar.tsx
+++ b/frontend/src/components/inputs/SearchBar.tsx
@@ -1,5 +1,5 @@
 import { useResetOnChange } from '@/hooks/useResetOnChange.ts';
-import { Box, TextField } from '@mui/material';
+import { Box, TextField, type SxProps, type Theme } from '@mui/material';
 import { debounce } from 'lodash';
 import { useEffect, useMemo, useState } from 'react';
 
@@ -13,6 +13,8 @@ interface SearchBarProps {
    * runs once per finished query rather than once per keystroke.
    */
   commitOn?: 'change' | 'submit';
+  /** Applied to the TextField, for callers on a non-default background. */
+  sx?: SxProps<Theme>;
 }
 
 export const SearchBar = ({
@@ -20,6 +22,7 @@ export const SearchBar = ({
   placeholder = 'Search...',
   initialValue = '',
   commitOn = 'change',
+  sx,
 }: SearchBarProps) => {
   const [searchInput, setSearchInput] = useState(initialValue);
 
@@ -68,6 +71,7 @@ export const SearchBar = ({
         placeholder={placeholder}
         value={searchInput}
         onChange={handleChange}
+        sx={sx}
         onBlur={handleCommit}
         onKeyDown={(e) => {
           if (e.key === 'Escape') {

--- a/frontend/src/components/inputs/SearchBar.tsx
+++ b/frontend/src/components/inputs/SearchBar.tsx
@@ -15,6 +15,8 @@ interface SearchBarProps {
   commitOn?: 'change' | 'submit';
   /** Applied to the TextField, for callers on a non-default background. */
   sx?: SxProps<Theme>;
+  /** Off by default: only a caller that owns the field's only focus target (e.g. a just-opened dialog) should set this. */
+  autoFocus?: boolean;
 }
 
 export const SearchBar = ({
@@ -23,6 +25,7 @@ export const SearchBar = ({
   initialValue = '',
   commitOn = 'change',
   sx,
+  autoFocus = false,
 }: SearchBarProps) => {
   const [searchInput, setSearchInput] = useState(initialValue);
 
@@ -68,6 +71,7 @@ export const SearchBar = ({
     <Box>
       <TextField
         fullWidth
+        autoFocus={autoFocus}
         placeholder={placeholder}
         value={searchInput}
         onChange={handleChange}

--- a/frontend/src/components/layout/AppBar.tsx
+++ b/frontend/src/components/layout/AppBar.tsx
@@ -85,8 +85,8 @@ export function AppBar() {
 
           <GlobalSearch />
 
-          {/* Spacer */}
-          <Box sx={{ flexGrow: 1 }} />
+          {/* Spacer: collapses below `md` so the compact search icon sits against the hamburger, matching the desktop field's centring above it. */}
+          <Box sx={{ flexGrow: { xs: 0, md: 1 } }} />
 
           {/* Hamburger menu */}
           <IconButton

--- a/frontend/src/components/layout/AppBar.tsx
+++ b/frontend/src/components/layout/AppBar.tsx
@@ -42,7 +42,7 @@ export function AppBar() {
       }}
     >
       <Container maxWidth="xl" disableGutters>
-        <Toolbar sx={{ gap: 2 }}>
+        <Toolbar>
           {/* Crossbill Icon and Title - Clickable */}
           <Box
             component={Link}

--- a/frontend/src/components/layout/AppBar.tsx
+++ b/frontend/src/components/layout/AppBar.tsx
@@ -85,7 +85,6 @@ export function AppBar() {
 
           <GlobalSearch />
 
-          {/* Spacer: collapses below `md` so the compact search icon sits against the hamburger, matching the desktop field's centring above it. */}
           <Box sx={{ flexGrow: { xs: 0, md: 1 } }} />
 
           {/* Hamburger menu */}

--- a/frontend/src/components/layout/AppBar.tsx
+++ b/frontend/src/components/layout/AppBar.tsx
@@ -1,3 +1,4 @@
+import { GlobalSearch } from '@/components/search/GlobalSearch.tsx';
 import { LogoutIcon, MenuIcon, SettingsIcon } from '@/theme/Icons.tsx';
 import {
   Box,
@@ -78,6 +79,11 @@ export function AppBar() {
               Crossbill
             </Typography>
           </Box>
+
+          {/* Spacer */}
+          <Box sx={{ flexGrow: 1 }} />
+
+          <GlobalSearch />
 
           {/* Spacer */}
           <Box sx={{ flexGrow: 1 }} />

--- a/frontend/src/components/search/GlobalSearch.test.tsx
+++ b/frontend/src/components/search/GlobalSearch.test.tsx
@@ -1,10 +1,12 @@
 import { aBookDetails } from '@tests/fixtures/book';
+import { aDigestHit, aHighlightHit, aNoteHit } from '@tests/fixtures/semantic';
 import { renderApp } from '@tests/harness/renderApp';
 import { settingsWithEmbeddings } from '@tests/msw/auth';
 import { bookApi } from '@tests/msw/bookApi';
 import { semanticSearchApi } from '@tests/msw/semanticSearchApi';
 import { worker } from '@tests/msw/worker';
 import { expect, test } from 'vitest';
+import { userEvent } from 'vitest/browser';
 
 const PLACEHOLDER = 'Search everything…';
 
@@ -25,4 +27,79 @@ test('the app bar has no search field when embeddings are off', async () => {
 
   await expect.element(screen.getByRole('heading', { name: 'The Pragmatic Reader' })).toBeVisible();
   await expect.element(screen.getByPlaceholder(PLACEHOLDER)).not.toBeInTheDocument();
+});
+
+/** Renders the app at a book page with the app bar's search wired to `results`. */
+const renderWithResults = async (results: Parameters<typeof semanticSearchApi>[0]) => {
+  const { handlers } = bookApi({ book: aBookDetails() });
+  worker.use(settingsWithEmbeddings(true), ...handlers, ...semanticSearchApi(results));
+  return renderApp({ path: '/book/1' });
+};
+
+const search = async (screen: Awaited<ReturnType<typeof renderApp>>, query: string) => {
+  await userEvent.fill(screen.getByPlaceholder(PLACEHOLDER), query);
+  await userEvent.keyboard('{Enter}');
+};
+
+test('results from every type are ranked together, not grouped by type', async () => {
+  const screen = await renderWithResults({
+    attention: {
+      highlights: [aHighlightHit({ id: 300, score: 0.5, text: 'A middling highlight' })],
+      notes: [aNoteHit({ id: 100, score: 0.9, title: 'The best note' })],
+      digests: [aDigestHit({ id: 500, score: 0.7, summary: 'A decent chapter' })],
+    },
+  });
+
+  await search(screen, 'attention');
+
+  const rows = screen.getByRole('option');
+  await expect.element(rows.nth(0)).toHaveTextContent('The best note');
+  await expect.element(rows.nth(1)).toHaveTextContent('A decent chapter');
+  await expect.element(rows.nth(2)).toHaveTextContent('A middling highlight');
+});
+
+test('the list is capped at ten rows after merging, not per type', async () => {
+  // Six of each type: under the cap individually, twelve combined. A
+  // per-type cap applied before merging would let all twelve through.
+  // Interleaved scores also mean the true global top ten mixes both types,
+  // rather than favouring whichever type happens to be capped last.
+  const screen = await renderWithResults({
+    attention: {
+      highlights: Array.from({ length: 6 }, (_, index) =>
+        aHighlightHit({ id: 300 + index, score: 0.95 - index * 0.1, text: `Highlight ${index}` })
+      ),
+      notes: Array.from({ length: 6 }, (_, index) =>
+        aNoteHit({ id: 100 + index, score: 0.9 - index * 0.1, title: `Note ${index}` })
+      ),
+    },
+  });
+
+  await search(screen, 'attention');
+
+  const rows = screen.getByRole('option');
+  await expect.element(rows.nth(9)).toBeVisible();
+  expect(rows.elements()).toHaveLength(10);
+
+  // Ranks 1-10 by score: Highlight 0/1/2/3/4 and Note 0/1/2/3/4.
+  await expect.element(screen.getByText('Highlight 4')).toBeVisible();
+  await expect.element(screen.getByText('Note 4')).toBeVisible();
+  // Ranks 11-12, excluded only by the merged cap.
+  await expect.element(screen.getByText('Highlight 5')).not.toBeInTheDocument();
+  await expect.element(screen.getByText('Note 5')).not.toBeInTheDocument();
+});
+
+test('a note with no linked book is left out, having no page to open', async () => {
+  const screen = await renderWithResults({
+    attention: {
+      notes: [
+        aNoteHit({ id: 100, score: 0.9, title: 'Homeless note', books: [] }),
+        aNoteHit({ id: 101, score: 0.8, title: 'Anchored note' }),
+      ],
+    },
+  });
+
+  await search(screen, 'attention');
+
+  await expect.element(screen.getByText('Anchored note')).toBeVisible();
+  await expect.element(screen.getByText('Homeless note')).not.toBeInTheDocument();
 });

--- a/frontend/src/components/search/GlobalSearch.test.tsx
+++ b/frontend/src/components/search/GlobalSearch.test.tsx
@@ -8,7 +8,7 @@ import { semanticSearchApi } from '@tests/msw/semanticSearchApi';
 import { worker } from '@tests/msw/worker';
 import { http, HttpResponse } from 'msw';
 import { expect, test } from 'vitest';
-import { userEvent } from 'vitest/browser';
+import { page, userEvent } from 'vitest/browser';
 
 const PLACEHOLDER = 'Search everything…';
 
@@ -45,6 +45,22 @@ const search = async (screen: Awaited<ReturnType<typeof renderApp>>, query: stri
   await userEvent.fill(screen.getByPlaceholder(PLACEHOLDER), query);
   await userEvent.keyboard('{Enter}');
 };
+
+/**
+ * A single highlight hit wired to a book with a matching chapter, shared by
+ * the desktop and mobile click-through tests.
+ */
+const renderWithHighlightResult = () =>
+  renderWithResults(
+    {
+      attention: {
+        highlights: [aHighlightHit({ id: 300, text: 'The map is not the territory.' })],
+      },
+    },
+    aBookDetails({
+      chapters: [aChapter({ id: 10, highlights: [aHighlight({ id: 300 })] })],
+    })
+  );
 
 test('results from every type are ranked together, not grouped by type', async () => {
   const screen = await renderWithResults({
@@ -110,16 +126,7 @@ test('a note with no linked book is left out, having no page to open', async () 
 });
 
 test('clicking a highlight row opens the highlight dialog on the book page', async () => {
-  const screen = await renderWithResults(
-    {
-      attention: {
-        highlights: [aHighlightHit({ id: 300, text: 'The map is not the territory.' })],
-      },
-    },
-    aBookDetails({
-      chapters: [aChapter({ id: 10, highlights: [aHighlight({ id: 300 })] })],
-    })
-  );
+  const screen = await renderWithHighlightResult();
 
   await search(screen, 'attention');
   await userEvent.click(screen.getByRole('option').first());
@@ -244,4 +251,113 @@ test('a failing search reports the failure', async () => {
   await search(screen, 'attention');
 
   await expect.element(screen.getByText('Search failed. Try again.')).toBeVisible();
+});
+
+/**
+ * Runs `fn` with the browser resized below `md`, always restoring the
+ * config's 1440×900 default afterward — even if `fn` throws — so a resize
+ * from one test can never leak into the next.
+ */
+const atCompactViewport = async (fn: () => Promise<void>) => {
+  await page.viewport(400, 800);
+  try {
+    await fn();
+  } finally {
+    await page.viewport(1440, 900);
+  }
+};
+
+/**
+ * Renders a book page below `md` with embeddings on, where only the search
+ * icon (not the inline field) is in the DOM, shared by the tests that only
+ * care about that icon rather than a query's results.
+ */
+const renderCompactSearchIcon = (
+  fn: (screen: Awaited<ReturnType<typeof renderApp>>) => Promise<void>
+) => {
+  const { handlers } = bookApi({ book: aBookDetails() });
+  worker.use(settingsWithEmbeddings(true), ...handlers);
+  return atCompactViewport(async () => {
+    const screen = await renderApp({ path: '/book/1' });
+    await fn(screen);
+  });
+};
+
+test('below md, a search icon replaces the inline field', async () => {
+  await renderCompactSearchIcon(async (screen) => {
+    await expect.element(screen.getByRole('button', { name: 'Search' })).toBeVisible();
+    await expect.element(screen.getByPlaceholder(PLACEHOLDER)).not.toBeInTheDocument();
+  });
+});
+
+test('tapping the search icon opens a full-screen dialog with the field', async () => {
+  await renderCompactSearchIcon(async (screen) => {
+    await userEvent.click(screen.getByRole('button', { name: 'Search' }));
+
+    await expect.element(screen.getByRole('dialog')).toBeVisible();
+    await expect.element(screen.getByPlaceholder(PLACEHOLDER)).toBeVisible();
+  });
+});
+
+test('the field is focused when the mobile dialog opens, so the keyboard appears without a second tap', async () => {
+  await renderCompactSearchIcon(async (screen) => {
+    await userEvent.click(screen.getByRole('button', { name: 'Search' }));
+
+    await expect.element(screen.getByPlaceholder(PLACEHOLDER)).toHaveFocus();
+  });
+});
+
+test('a query in the mobile dialog shows the same result rows as desktop', async () => {
+  await atCompactViewport(async () => {
+    const screen = await renderWithResults({
+      attention: { notes: [aNoteHit({ id: 100, title: 'Ada Lovelace' })] },
+    });
+
+    await userEvent.click(screen.getByRole('button', { name: 'Search' }));
+    await search(screen, 'attention');
+
+    await expect.element(screen.getByRole('option')).toHaveTextContent('Ada Lovelace');
+  });
+});
+
+test('selecting a row in the mobile dialog navigates and closes it', async () => {
+  await atCompactViewport(async () => {
+    const screen = await renderWithHighlightResult();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Search' }));
+    await search(screen, 'attention');
+    await userEvent.click(screen.getByRole('option').first());
+
+    expect(window.location.pathname).toBe('/book/1/highlights');
+    expect(window.location.search).toContain('highlightId=300');
+    await expect.element(screen.getByPlaceholder(PLACEHOLDER)).not.toBeInTheDocument();
+  });
+});
+
+test('a search with no results can still be dismissed via the close button', async () => {
+  await atCompactViewport(async () => {
+    const screen = await renderWithResults({});
+
+    await userEvent.click(screen.getByRole('button', { name: 'Search' }));
+    await search(screen, 'attention');
+    await expect.element(screen.getByText('No matches')).toBeVisible();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Close dialog' }));
+
+    await expect.element(screen.getByRole('dialog')).not.toBeInTheDocument();
+  });
+});
+
+test('with embeddings off, no search icon appears below md', async () => {
+  const { handlers } = bookApi({ book: aBookDetails() });
+  worker.use(settingsWithEmbeddings(false), ...handlers);
+
+  await atCompactViewport(async () => {
+    const screen = await renderApp({ path: '/book/1' });
+
+    await expect
+      .element(screen.getByRole('heading', { name: 'The Pragmatic Reader' }))
+      .toBeVisible();
+    await expect.element(screen.getByRole('button', { name: 'Search' })).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/search/GlobalSearch.test.tsx
+++ b/frontend/src/components/search/GlobalSearch.test.tsx
@@ -11,7 +11,7 @@ import { delay, http, HttpResponse } from 'msw';
 import { expect, test } from 'vitest';
 import { page, userEvent } from 'vitest/browser';
 
-const PLACEHOLDER = 'Search everything…';
+const PLACEHOLDER = 'Search...';
 
 test('the app bar offers a global search field when embeddings are on', async () => {
   const { handlers } = bookApi({ book: aBookDetails() });

--- a/frontend/src/components/search/GlobalSearch.test.tsx
+++ b/frontend/src/components/search/GlobalSearch.test.tsx
@@ -1,4 +1,5 @@
-import { aBookDetails } from '@tests/fixtures/book';
+import { aBookDetails, aChapter, aHighlight } from '@tests/fixtures/book';
+import { aNote } from '@tests/fixtures/notes';
 import { aDigestHit, aHighlightHit, aNoteHit } from '@tests/fixtures/semantic';
 import { renderApp } from '@tests/harness/renderApp';
 import { settingsWithEmbeddings } from '@tests/msw/auth';
@@ -30,8 +31,11 @@ test('the app bar has no search field when embeddings are off', async () => {
 });
 
 /** Renders the app at a book page with the app bar's search wired to `results`. */
-const renderWithResults = async (results: Parameters<typeof semanticSearchApi>[0]) => {
-  const { handlers } = bookApi({ book: aBookDetails() });
+const renderWithResults = async (
+  results: Parameters<typeof semanticSearchApi>[0],
+  book = aBookDetails()
+) => {
+  const { handlers } = bookApi({ book, notes: [] });
   worker.use(settingsWithEmbeddings(true), ...handlers, ...semanticSearchApi(results));
   return renderApp({ path: '/book/1' });
 };
@@ -102,4 +106,64 @@ test('a note with no linked book is left out, having no page to open', async () 
 
   await expect.element(screen.getByText('Anchored note')).toBeVisible();
   await expect.element(screen.getByText('Homeless note')).not.toBeInTheDocument();
+});
+
+test('clicking a highlight row opens the highlight dialog on the book page', async () => {
+  const screen = await renderWithResults(
+    {
+      attention: {
+        highlights: [aHighlightHit({ id: 300, text: 'The map is not the territory.' })],
+      },
+    },
+    aBookDetails({
+      chapters: [aChapter({ id: 10, highlights: [aHighlight({ id: 300 })] })],
+    })
+  );
+
+  await search(screen, 'attention');
+  await userEvent.click(screen.getByRole('option').first());
+
+  await expect
+    .element(screen.getByRole('dialog').getByText('The map is not the territory.'))
+    .toBeVisible();
+  expect(window.location.pathname).toBe('/book/1/highlights');
+  expect(window.location.search).toContain('highlightId=300');
+});
+
+test('clicking a note row opens the note dialog on the book page', async () => {
+  const { handlers } = bookApi({
+    book: aBookDetails(),
+    notes: [aNote({ id: 100, title: 'Ada Lovelace' })],
+  });
+  worker.use(
+    settingsWithEmbeddings(true),
+    ...handlers,
+    ...semanticSearchApi({ attention: { notes: [aNoteHit({ id: 100, title: 'Ada Lovelace' })] } })
+  );
+  const screen = await renderApp({ path: '/book/1' });
+
+  await search(screen, 'attention');
+  await userEvent.click(screen.getByRole('option').first());
+
+  await expect.element(screen.getByRole('dialog').getByText('Ada Lovelace')).toBeVisible();
+  expect(window.location.pathname).toBe('/book/1/notes');
+  expect(window.location.search).toContain('noteId=100');
+});
+
+test('clicking a chapter row opens the chapter dialog on the book page', async () => {
+  const screen = await renderWithResults(
+    {
+      attention: {
+        digests: [aDigestHit({ id: 500, chapter_id: 10, chapter_name: 'On Attention' })],
+      },
+    },
+    aBookDetails({ chapters: [aChapter({ id: 10, name: 'On Attention' })] })
+  );
+
+  await search(screen, 'attention');
+  await userEvent.click(screen.getByRole('option').first());
+
+  await expect.element(screen.getByRole('dialog').getByText('On Attention')).toBeVisible();
+  expect(window.location.pathname).toBe('/book/1/structure');
+  expect(window.location.search).toContain('chapterId=10');
 });

--- a/frontend/src/components/search/GlobalSearch.test.tsx
+++ b/frontend/src/components/search/GlobalSearch.test.tsx
@@ -4,9 +4,10 @@ import { aDigestHit, aHighlightHit, aNoteHit } from '@tests/fixtures/semantic';
 import { renderApp } from '@tests/harness/renderApp';
 import { settingsWithEmbeddings } from '@tests/msw/auth';
 import { bookApi } from '@tests/msw/bookApi';
+import { coversApi } from '@tests/msw/covers';
 import { semanticSearchApi } from '@tests/msw/semanticSearchApi';
 import { worker } from '@tests/msw/worker';
-import { http, HttpResponse } from 'msw';
+import { delay, http, HttpResponse } from 'msw';
 import { expect, test } from 'vitest';
 import { page, userEvent } from 'vitest/browser';
 
@@ -107,6 +108,7 @@ test('the list is capped at ten rows after merging, not per type', async () => {
   // Ranks 11-12, excluded only by the merged cap.
   await expect.element(screen.getByText('Highlight 5')).not.toBeInTheDocument();
   await expect.element(screen.getByText('Note 5')).not.toBeInTheDocument();
+  await expect.element(screen.getByText('Showing top 10')).toBeVisible();
 });
 
 test('a note with no linked book is left out, having no page to open', async () => {
@@ -123,6 +125,48 @@ test('a note with no linked book is left out, having no page to open', async () 
 
   await expect.element(screen.getByText('Anchored note')).toBeVisible();
   await expect.element(screen.getByText('Homeless note')).not.toBeInTheDocument();
+});
+
+test('a row with a cover renders it as an image from the covers endpoint', async () => {
+  const { handlers } = bookApi({ book: aBookDetails(), notes: [] });
+  worker.use(
+    settingsWithEmbeddings(true),
+    ...handlers,
+    ...coversApi(),
+    ...semanticSearchApi({
+      attention: {
+        highlights: [aHighlightHit({ id: 300, cover_file: 'cover-one.jpg' })],
+      },
+    })
+  );
+  const screen = await renderApp({ path: '/book/1' });
+
+  await search(screen, 'attention');
+
+  const cover = screen.getByRole('option').first().getByRole('img');
+  await expect.element(cover).toBeVisible();
+  await expect
+    .poll(() => cover.element().getAttribute('src'))
+    .toContain('/api/v1/covers/cover-one.jpg');
+});
+
+test('the initial fetch shows a spinner before any rows arrive', async () => {
+  const { handlers } = bookApi({ book: aBookDetails() });
+  worker.use(
+    settingsWithEmbeddings(true),
+    ...handlers,
+    // Never resolves: `waitForIdle` in the test harness bounds its wait, so
+    // this can't hang the run, and it keeps `isFetching` true for the whole
+    // test without a fake timer.
+    http.get('/api/v1/semantic/search', async () => {
+      await delay('infinite');
+    })
+  );
+  const screen = await renderApp({ path: '/book/1' });
+
+  await search(screen, 'attention');
+
+  await expect.element(screen.getByRole('progressbar', { name: 'Searching' })).toBeVisible();
 });
 
 test('clicking a highlight row opens the highlight dialog on the book page', async () => {
@@ -194,6 +238,19 @@ test('Escape closes the dropdown and keeps the query, a second Escape clears it'
   await expect.element(screen.getByPlaceholder(PLACEHOLDER)).toHaveValue('');
 });
 
+test('tabbing away closes the dropdown instead of reopening it', async () => {
+  const screen = await renderWithResults({
+    attention: { notes: [aNoteHit({ id: 100, title: 'Ada Lovelace' })] },
+  });
+
+  await search(screen, 'attention');
+  await expect.element(screen.getByRole('option').first()).toBeVisible();
+
+  await userEvent.tab();
+
+  await expect.element(screen.getByRole('listbox')).not.toBeInTheDocument();
+});
+
 test('arrowing down points aria-activedescendant at the first row', async () => {
   const screen = await renderWithResults({
     attention: { notes: [aNoteHit({ id: 100, title: 'Ada Lovelace' })] },
@@ -207,7 +264,7 @@ test('arrowing down points aria-activedescendant at the first row', async () => 
   await userEvent.keyboard('{ArrowDown}');
 
   await expect
-    .element(screen.getByRole('listbox'))
+    .element(screen.getByPlaceholder(PLACEHOLDER))
     .toHaveAttribute('aria-activedescendant', firstRowId);
 });
 

--- a/frontend/src/components/search/GlobalSearch.test.tsx
+++ b/frontend/src/components/search/GlobalSearch.test.tsx
@@ -167,3 +167,58 @@ test('clicking a chapter row opens the chapter dialog on the book page', async (
   expect(window.location.pathname).toBe('/book/1/structure');
   expect(window.location.search).toContain('chapterId=10');
 });
+
+test('Escape closes the dropdown and keeps the query, a second Escape clears it', async () => {
+  const screen = await renderWithResults({
+    attention: { notes: [aNoteHit({ id: 100, title: 'Ada Lovelace' })] },
+  });
+
+  await search(screen, 'attention');
+  await expect.element(screen.getByRole('option').first()).toBeVisible();
+
+  await userEvent.keyboard('{Escape}');
+
+  await expect.element(screen.getByRole('listbox')).not.toBeInTheDocument();
+  await expect.element(screen.getByPlaceholder(PLACEHOLDER)).toHaveValue('attention');
+
+  await userEvent.keyboard('{Escape}');
+
+  await expect.element(screen.getByPlaceholder(PLACEHOLDER)).toHaveValue('');
+});
+
+test('arrowing down points aria-activedescendant at the first row', async () => {
+  const screen = await renderWithResults({
+    attention: { notes: [aNoteHit({ id: 100, title: 'Ada Lovelace' })] },
+  });
+
+  await search(screen, 'attention');
+  const firstRow = screen.getByRole('option').first();
+  await expect.element(firstRow).toBeVisible();
+  const firstRowId = firstRow.element().id;
+
+  await userEvent.keyboard('{ArrowDown}');
+
+  await expect
+    .element(screen.getByRole('listbox'))
+    .toHaveAttribute('aria-activedescendant', firstRowId);
+});
+
+test('arrow keys move through results and Enter opens the active one', async () => {
+  const screen = await renderWithResults(
+    {
+      attention: {
+        notes: [aNoteHit({ id: 100, score: 0.9, title: 'Ada Lovelace' })],
+        digests: [
+          aDigestHit({ id: 500, score: 0.8, chapter_id: 10, chapter_name: 'On Attention' }),
+        ],
+      },
+    },
+    aBookDetails({ chapters: [aChapter({ id: 10, name: 'On Attention' })] })
+  );
+
+  await search(screen, 'attention');
+  await userEvent.keyboard('{ArrowDown}{ArrowDown}{Enter}');
+
+  expect(window.location.pathname).toBe('/book/1/structure');
+  expect(window.location.search).toContain('chapterId=10');
+});

--- a/frontend/src/components/search/GlobalSearch.test.tsx
+++ b/frontend/src/components/search/GlobalSearch.test.tsx
@@ -1,0 +1,28 @@
+import { aBookDetails } from '@tests/fixtures/book';
+import { renderApp } from '@tests/harness/renderApp';
+import { settingsWithEmbeddings } from '@tests/msw/auth';
+import { bookApi } from '@tests/msw/bookApi';
+import { semanticSearchApi } from '@tests/msw/semanticSearchApi';
+import { worker } from '@tests/msw/worker';
+import { expect, test } from 'vitest';
+
+const PLACEHOLDER = 'Search everything…';
+
+test('the app bar offers a global search field when embeddings are on', async () => {
+  const { handlers } = bookApi({ book: aBookDetails() });
+  worker.use(settingsWithEmbeddings(true), ...handlers, ...semanticSearchApi({}));
+
+  const screen = await renderApp({ path: '/book/1' });
+
+  await expect.element(screen.getByPlaceholder(PLACEHOLDER)).toBeVisible();
+});
+
+test('the app bar has no search field when embeddings are off', async () => {
+  const { handlers } = bookApi({ book: aBookDetails() });
+  worker.use(settingsWithEmbeddings(false), ...handlers);
+
+  const screen = await renderApp({ path: '/book/1' });
+
+  await expect.element(screen.getByRole('heading', { name: 'The Pragmatic Reader' })).toBeVisible();
+  await expect.element(screen.getByPlaceholder(PLACEHOLDER)).not.toBeInTheDocument();
+});

--- a/frontend/src/components/search/GlobalSearch.test.tsx
+++ b/frontend/src/components/search/GlobalSearch.test.tsx
@@ -6,6 +6,7 @@ import { settingsWithEmbeddings } from '@tests/msw/auth';
 import { bookApi } from '@tests/msw/bookApi';
 import { semanticSearchApi } from '@tests/msw/semanticSearchApi';
 import { worker } from '@tests/msw/worker';
+import { http, HttpResponse } from 'msw';
 import { expect, test } from 'vitest';
 import { userEvent } from 'vitest/browser';
 
@@ -221,4 +222,26 @@ test('arrow keys move through results and Enter opens the active one', async () 
 
   expect(window.location.pathname).toBe('/book/1/structure');
   expect(window.location.search).toContain('chapterId=10');
+});
+
+test('a query that matches nothing says so, rather than showing an empty box', async () => {
+  const screen = await renderWithResults({});
+
+  await search(screen, 'attention');
+
+  await expect.element(screen.getByText('No matches')).toBeVisible();
+});
+
+test('a failing search reports the failure', async () => {
+  const { handlers } = bookApi({ book: aBookDetails() });
+  worker.use(
+    settingsWithEmbeddings(true),
+    ...handlers,
+    http.get('/api/v1/semantic/search', () => new HttpResponse(null, { status: 500 }))
+  );
+  const screen = await renderApp({ path: '/book/1' });
+
+  await search(screen, 'attention');
+
+  await expect.element(screen.getByText('Search failed. Try again.')).toBeVisible();
 });

--- a/frontend/src/components/search/GlobalSearch.tsx
+++ b/frontend/src/components/search/GlobalSearch.tsx
@@ -23,13 +23,8 @@ import {
 import { useNavigate } from '@tanstack/react-router';
 import { useCallback, useId, useMemo, useState } from 'react';
 
-/**
- * Not exported: the test restates the copy rather than importing it, matching
- * `StructurePage.test.tsx`, and knip fails CI on an export nothing imports.
- */
-const GLOBAL_SEARCH_PLACEHOLDER = 'Search everything…';
+const GLOBAL_SEARCH_PLACEHOLDER = 'Search...';
 
-/** The field sits on `primary.main`, where the default outlined look vanishes. */
 const appBarFieldSx: SxProps<Theme> = (theme) => ({
   '& .MuiOutlinedInput-root': {
     backgroundColor: theme.customColors.whiteOverlay.light,
@@ -49,7 +44,6 @@ const appBarFieldSx: SxProps<Theme> = (theme) => ({
   },
 });
 
-/** Ten per type is enough to guarantee the true global top ten after merging. */
 const RESULTS_PER_TYPE = 10;
 
 /**
@@ -67,16 +61,12 @@ export const GlobalSearch = () => {
   const theme = useTheme();
   const isCompact = useMediaQuery(theme.breakpoints.down('md'));
   const [isMobileOpen, setIsMobileOpen] = useState(false);
-  // State, not a ref: `anchorEl` and the width below are read during render,
-  // and the lint rule for refs forbids reading `.current` there.
   const [anchorEl, setAnchorEl] = useState<HTMLDivElement | null>(null);
   const [query, setQuery] = useState('');
   // Closing keeps the query: the user scans the list, opens one hit, and comes
   // back for the next without retyping.
   const [isDismissed, setIsDismissed] = useState(false);
   const [activeIndex, setActiveIndex] = useState(-1);
-  // Stable across the component's lifetime, unlike a plain string constant:
-  // two instances (e.g. a future split of desktop/mobile) would never collide.
   const listboxId = useId();
 
   // Adjusted during render, not an effect: the mobile dialog only exists
@@ -102,12 +92,7 @@ export const GlobalSearch = () => {
   });
   const rows = useMemo(() => toGlobalSearchRows(results), [results]);
   const isOpen = hasQuery && !isDismissed;
-  // Absent rather than pointing nowhere when the cursor is in the field: a
-  // screen reader should not announce an active option that doesn't exist.
   const activeRow = activeIndex >= 0 ? rows[activeIndex] : undefined;
-  // Combobox wiring belongs on the input itself: assistive tech only honours
-  // `aria-activedescendant` on the element holding DOM focus, and focus stays
-  // in the field while the cursor moves through rows.
   const comboboxHtmlInputProps = {
     role: 'combobox',
     'aria-expanded': isOpen,
@@ -190,8 +175,6 @@ export const GlobalSearch = () => {
                 slotProps={{ htmlInput: comboboxHtmlInputProps }}
               />
             </Box>
-            {/* The only way to dismiss a dead-end search: Escape has no keyboard on
-                a phone, and a query with no results leaves no row to tap instead. */}
             <IconButton edge="end" color="inherit" onClick={closeMobile} aria-label="Close dialog">
               <CloseIcon />
             </IconButton>
@@ -216,8 +199,6 @@ export const GlobalSearch = () => {
       <ClickAwayListener onClickAway={close}>
         <Box
           ref={setAnchorEl}
-          // Capture phase: `SearchBar`'s own Escape handler runs on bubble and
-          // would clear the field before `stopPropagation` here could stop it.
           onKeyDownCapture={handleKeyDown}
           // Focus events bubble in React, so this reopens after a dismissal
           // without SearchBar having to expose an onFocus of its own.

--- a/frontend/src/components/search/GlobalSearch.tsx
+++ b/frontend/src/components/search/GlobalSearch.tsx
@@ -1,0 +1,55 @@
+import { EmbeddingFeature } from '@/components/features/EmbeddingFeature.tsx';
+import { SemanticSearchField } from '@/components/search/SemanticSearchField.tsx';
+import { Box, type SxProps, type Theme } from '@mui/material';
+import { useCallback, useState } from 'react';
+
+/**
+ * Not exported: the test restates the copy rather than importing it, matching
+ * `StructurePage.test.tsx`, and knip fails CI on an export nothing imports.
+ */
+const GLOBAL_SEARCH_PLACEHOLDER = 'Search everything…';
+
+/** The field sits on `primary.main`, where the default outlined look vanishes. */
+const appBarFieldSx: SxProps<Theme> = (theme) => ({
+  '& .MuiOutlinedInput-root': {
+    backgroundColor: theme.customColors.whiteOverlay.light,
+    color: theme.palette.primary.contrastText,
+    '&:hover': { backgroundColor: theme.customColors.whiteOverlay.hover },
+    '& .MuiOutlinedInput-notchedOutline': { borderColor: 'transparent' },
+    '&:hover .MuiOutlinedInput-notchedOutline': { borderColor: 'transparent' },
+    '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
+      borderColor: theme.palette.primary.contrastText,
+      borderWidth: 1,
+    },
+  },
+  '& .MuiInputBase-input': { py: 1 },
+  '& .MuiInputBase-input::placeholder': {
+    color: theme.palette.primary.contrastText,
+    opacity: 0.7,
+  },
+});
+
+/**
+ * Semantic search over every book, in the app bar.
+ *
+ * The query lives here rather than in the URL: each route validates its own
+ * search params, so a global `q` would mean editing every `validateSearch` and
+ * navigating on every submit — a steep price for a dropdown of ten rows.
+ */
+export const GlobalSearch = () => {
+  const [query, setQuery] = useState('');
+  const handleSearch = useCallback((value: string) => setQuery(value), []);
+
+  return (
+    <EmbeddingFeature>
+      <Box sx={{ flexGrow: 1, maxWidth: 480, mx: 'auto' }}>
+        <SemanticSearchField
+          value={query}
+          onChange={handleSearch}
+          placeholder={GLOBAL_SEARCH_PLACEHOLDER}
+          sx={appBarFieldSx}
+        />
+      </Box>
+    </EmbeddingFeature>
+  );
+};

--- a/frontend/src/components/search/GlobalSearch.tsx
+++ b/frontend/src/components/search/GlobalSearch.tsx
@@ -1,9 +1,10 @@
 import { EmbeddingFeature } from '@/components/features/EmbeddingFeature.tsx';
 import { GlobalSearchResults } from '@/components/search/GlobalSearchResults.tsx';
-import { toGlobalSearchRows } from '@/components/search/globalSearchRows.ts';
+import { rowLinkProps, toGlobalSearchRows } from '@/components/search/globalSearchRows.ts';
 import { SemanticSearchField } from '@/components/search/SemanticSearchField.tsx';
 import { useSemanticSearch } from '@/components/search/useSemanticSearch.ts';
-import { Box, Paper, Popper, type SxProps, type Theme } from '@mui/material';
+import { Box, ClickAwayListener, Paper, Popper, type SxProps, type Theme } from '@mui/material';
+import { useNavigate } from '@tanstack/react-router';
 import { useCallback, useMemo, useState } from 'react';
 
 /**
@@ -43,6 +44,7 @@ const RESULTS_PER_TYPE = 10;
  * navigating on every submit — a steep price for a dropdown of ten rows.
  */
 export const GlobalSearch = () => {
+  const navigate = useNavigate();
   // State, not a ref: `anchorEl` and the width below are read during render,
   // and the lint rule for refs forbids reading `.current` there.
   const [anchorEl, setAnchorEl] = useState<HTMLDivElement | null>(null);
@@ -50,10 +52,12 @@ export const GlobalSearch = () => {
   // Closing keeps the query: the user scans the list, opens one hit, and comes
   // back for the next without retyping.
   const [isDismissed, setIsDismissed] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(-1);
 
   const handleSearch = useCallback((value: string) => {
     setQuery(value);
     setIsDismissed(false);
+    setActiveIndex(-1);
   }, []);
 
   const { results, isFetching, isError, hasQuery } = useSemanticSearch({
@@ -61,33 +65,82 @@ export const GlobalSearch = () => {
     limit: RESULTS_PER_TYPE,
   });
   const rows = useMemo(() => toGlobalSearchRows(results), [results]);
+  const isOpen = hasQuery && !isDismissed;
+
+  const close = () => {
+    setIsDismissed(true);
+    setActiveIndex(-1);
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent) => {
+    if (!isOpen) return;
+
+    // `(index + 1) % 0` is NaN, so the arrow branches need rows to exist.
+    if (rows.length === 0 && event.key !== 'Escape') return;
+
+    if (event.key === 'Escape') {
+      // SearchBar clears the field on Escape. Stopping the event here makes the
+      // first press close the dropdown and the second one clear the query.
+      event.stopPropagation();
+      close();
+      return;
+    }
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      setActiveIndex((index) => (index + 1) % rows.length);
+      return;
+    }
+    if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      setActiveIndex((index) => (index <= 0 ? rows.length - 1 : index - 1));
+      return;
+    }
+    if (event.key === 'Enter' && activeIndex >= 0) {
+      // Stop SearchBar re-submitting the query the row is about to leave.
+      event.preventDefault();
+      event.stopPropagation();
+      void navigate(rowLinkProps(rows[activeIndex]));
+      close();
+    }
+  };
 
   return (
     <EmbeddingFeature>
-      <Box ref={setAnchorEl} sx={{ flexGrow: 1, maxWidth: 480, mx: 'auto' }}>
-        <SemanticSearchField
-          value={query}
-          onChange={handleSearch}
-          placeholder={GLOBAL_SEARCH_PLACEHOLDER}
-          sx={appBarFieldSx}
-        />
-        <Popper
-          open={hasQuery && !isDismissed}
-          anchorEl={anchorEl}
-          placement="bottom-start"
-          sx={{ zIndex: (theme) => theme.zIndex.appBar + 1, width: anchorEl?.clientWidth }}
+      <ClickAwayListener onClickAway={close}>
+        <Box
+          ref={setAnchorEl}
+          // Capture phase: `SearchBar`'s own Escape handler runs on bubble and
+          // would clear the field before `stopPropagation` here could stop it.
+          onKeyDownCapture={handleKeyDown}
+          // Focus events bubble in React, so this reopens after a dismissal
+          // without SearchBar having to expose an onFocus of its own.
+          onFocus={() => setIsDismissed(false)}
+          sx={{ flexGrow: 1, maxWidth: 480, mx: 'auto' }}
         >
-          <Paper elevation={8} sx={{ mt: 1, maxHeight: 480, overflowY: 'auto' }}>
-            <GlobalSearchResults
-              rows={rows}
-              isFetching={isFetching}
-              isError={isError}
-              activeIndex={-1}
-              onSelect={() => setIsDismissed(true)}
-            />
-          </Paper>
-        </Popper>
-      </Box>
+          <SemanticSearchField
+            value={query}
+            onChange={handleSearch}
+            placeholder={GLOBAL_SEARCH_PLACEHOLDER}
+            sx={appBarFieldSx}
+          />
+          <Popper
+            open={isOpen}
+            anchorEl={anchorEl}
+            placement="bottom-start"
+            sx={{ zIndex: (theme) => theme.zIndex.appBar + 1, width: anchorEl?.clientWidth }}
+          >
+            <Paper elevation={8} sx={{ mt: 1, maxHeight: 480, overflowY: 'auto' }}>
+              <GlobalSearchResults
+                rows={rows}
+                isFetching={isFetching}
+                isError={isError}
+                activeIndex={activeIndex}
+                onSelect={close}
+              />
+            </Paper>
+          </Popper>
+        </Box>
+      </ClickAwayListener>
     </EmbeddingFeature>
   );
 };

--- a/frontend/src/components/search/GlobalSearch.tsx
+++ b/frontend/src/components/search/GlobalSearch.tsx
@@ -237,7 +237,18 @@ export const GlobalSearch = () => {
               document.getElementById(listboxId)?.contains(nextFocus);
             if (!staysInWidget) close();
           }}
-          sx={{ flexGrow: 1, maxWidth: 480, mx: 'auto' }}
+          sx={{
+            flexGrow: 1,
+            width: {
+              md: 680,
+              lg: 800,
+            },
+            maxWidth: {
+              md: 680,
+              lg: 800,
+            },
+            mx: 'auto',
+          }}
         >
           <SemanticSearchField
             value={query}

--- a/frontend/src/components/search/GlobalSearch.tsx
+++ b/frontend/src/components/search/GlobalSearch.tsx
@@ -1,7 +1,10 @@
 import { EmbeddingFeature } from '@/components/features/EmbeddingFeature.tsx';
+import { GlobalSearchResults } from '@/components/search/GlobalSearchResults.tsx';
+import { toGlobalSearchRows } from '@/components/search/globalSearchRows.ts';
 import { SemanticSearchField } from '@/components/search/SemanticSearchField.tsx';
-import { Box, type SxProps, type Theme } from '@mui/material';
-import { useCallback, useState } from 'react';
+import { useSemanticSearch } from '@/components/search/useSemanticSearch.ts';
+import { Box, Paper, Popper, type SxProps, type Theme } from '@mui/material';
+import { useCallback, useMemo, useState } from 'react';
 
 /**
  * Not exported: the test restates the copy rather than importing it, matching
@@ -29,6 +32,9 @@ const appBarFieldSx: SxProps<Theme> = (theme) => ({
   },
 });
 
+/** Ten per type is enough to guarantee the true global top ten after merging. */
+const RESULTS_PER_TYPE = 10;
+
 /**
  * Semantic search over every book, in the app bar.
  *
@@ -37,18 +43,50 @@ const appBarFieldSx: SxProps<Theme> = (theme) => ({
  * navigating on every submit — a steep price for a dropdown of ten rows.
  */
 export const GlobalSearch = () => {
+  // State, not a ref: `anchorEl` and the width below are read during render,
+  // and the lint rule for refs forbids reading `.current` there.
+  const [anchorEl, setAnchorEl] = useState<HTMLDivElement | null>(null);
   const [query, setQuery] = useState('');
-  const handleSearch = useCallback((value: string) => setQuery(value), []);
+  // Closing keeps the query: the user scans the list, opens one hit, and comes
+  // back for the next without retyping.
+  const [isDismissed, setIsDismissed] = useState(false);
+
+  const handleSearch = useCallback((value: string) => {
+    setQuery(value);
+    setIsDismissed(false);
+  }, []);
+
+  const { results, isFetching, isError, hasQuery } = useSemanticSearch({
+    query,
+    limit: RESULTS_PER_TYPE,
+  });
+  const rows = useMemo(() => toGlobalSearchRows(results), [results]);
 
   return (
     <EmbeddingFeature>
-      <Box sx={{ flexGrow: 1, maxWidth: 480, mx: 'auto' }}>
+      <Box ref={setAnchorEl} sx={{ flexGrow: 1, maxWidth: 480, mx: 'auto' }}>
         <SemanticSearchField
           value={query}
           onChange={handleSearch}
           placeholder={GLOBAL_SEARCH_PLACEHOLDER}
           sx={appBarFieldSx}
         />
+        <Popper
+          open={hasQuery && !isDismissed}
+          anchorEl={anchorEl}
+          placement="bottom-start"
+          sx={{ zIndex: (theme) => theme.zIndex.appBar + 1, width: anchorEl?.clientWidth }}
+        >
+          <Paper elevation={8} sx={{ mt: 1, maxHeight: 480, overflowY: 'auto' }}>
+            <GlobalSearchResults
+              rows={rows}
+              isFetching={isFetching}
+              isError={isError}
+              activeIndex={-1}
+              onSelect={() => setIsDismissed(true)}
+            />
+          </Paper>
+        </Popper>
       </Box>
     </EmbeddingFeature>
   );

--- a/frontend/src/components/search/GlobalSearch.tsx
+++ b/frontend/src/components/search/GlobalSearch.tsx
@@ -3,7 +3,19 @@ import { GlobalSearchResults } from '@/components/search/GlobalSearchResults.tsx
 import { rowLinkProps, toGlobalSearchRows } from '@/components/search/globalSearchRows.ts';
 import { SemanticSearchField } from '@/components/search/SemanticSearchField.tsx';
 import { useSemanticSearch } from '@/components/search/useSemanticSearch.ts';
-import { Box, ClickAwayListener, Paper, Popper, type SxProps, type Theme } from '@mui/material';
+import { CloseIcon, SearchIcon } from '@/theme/Icons.tsx';
+import {
+  Box,
+  ClickAwayListener,
+  Dialog,
+  IconButton,
+  Paper,
+  Popper,
+  type SxProps,
+  type Theme,
+  useMediaQuery,
+  useTheme,
+} from '@mui/material';
 import { useNavigate } from '@tanstack/react-router';
 import { useCallback, useMemo, useState } from 'react';
 
@@ -42,9 +54,15 @@ const RESULTS_PER_TYPE = 10;
  * The query lives here rather than in the URL: each route validates its own
  * search params, so a global `q` would mean editing every `validateSearch` and
  * navigating on every submit — a steep price for a dropdown of ten rows.
+ *
+ * Below the `md` breakpoint the app bar has no room for a field, so a search
+ * icon opens the same state in a full-screen dialog instead.
  */
 export const GlobalSearch = () => {
   const navigate = useNavigate();
+  const theme = useTheme();
+  const isCompact = useMediaQuery(theme.breakpoints.down('md'));
+  const [isMobileOpen, setIsMobileOpen] = useState(false);
   // State, not a ref: `anchorEl` and the width below are read during render,
   // and the lint rule for refs forbids reading `.current` there.
   const [anchorEl, setAnchorEl] = useState<HTMLDivElement | null>(null);
@@ -103,6 +121,54 @@ export const GlobalSearch = () => {
       close();
     }
   };
+
+  const closeMobile = () => {
+    setIsMobileOpen(false);
+    close();
+  };
+
+  if (isCompact) {
+    return (
+      <EmbeddingFeature>
+        <IconButton
+          aria-label="Search"
+          onClick={() => setIsMobileOpen(true)}
+          sx={{ color: 'primary.contrastText' }}
+        >
+          <SearchIcon />
+        </IconButton>
+        <Dialog fullScreen open={isMobileOpen} onClose={closeMobile}>
+          <Box
+            onKeyDownCapture={handleKeyDown}
+            sx={{ p: 2, display: 'flex', alignItems: 'center', gap: 1 }}
+          >
+            <Box sx={{ flex: 1 }}>
+              <SemanticSearchField
+                value={query}
+                onChange={handleSearch}
+                placeholder={GLOBAL_SEARCH_PLACEHOLDER}
+                autoFocus
+              />
+            </Box>
+            {/* The only way to dismiss a dead-end search: Escape has no keyboard on
+                a phone, and a query with no results leaves no row to tap instead. */}
+            <IconButton edge="end" color="inherit" onClick={closeMobile} aria-label="Close dialog">
+              <CloseIcon />
+            </IconButton>
+          </Box>
+          {isOpen && (
+            <GlobalSearchResults
+              rows={rows}
+              isFetching={isFetching}
+              isError={isError}
+              activeIndex={activeIndex}
+              onSelect={closeMobile}
+            />
+          )}
+        </Dialog>
+      </EmbeddingFeature>
+    );
+  }
 
   return (
     <EmbeddingFeature>

--- a/frontend/src/components/search/GlobalSearch.tsx
+++ b/frontend/src/components/search/GlobalSearch.tsx
@@ -263,7 +263,7 @@ export const GlobalSearch = () => {
             placement="bottom-start"
             sx={{ zIndex: (theme) => theme.zIndex.appBar + 1, width: anchorEl?.clientWidth }}
           >
-            <Paper elevation={8} sx={{ mt: 1, maxHeight: 480, overflowY: 'auto' }}>
+            <Paper elevation={8} sx={{ mt: 1, maxHeight: 680, overflowY: 'auto' }}>
               <GlobalSearchResults
                 rows={rows}
                 isFetching={isFetching}

--- a/frontend/src/components/search/GlobalSearch.tsx
+++ b/frontend/src/components/search/GlobalSearch.tsx
@@ -1,6 +1,10 @@
 import { EmbeddingFeature } from '@/components/features/EmbeddingFeature.tsx';
 import { GlobalSearchResults } from '@/components/search/GlobalSearchResults.tsx';
-import { rowLinkProps, toGlobalSearchRows } from '@/components/search/globalSearchRows.ts';
+import {
+  globalSearchRowDomId,
+  rowLinkProps,
+  toGlobalSearchRows,
+} from '@/components/search/globalSearchRows.ts';
 import { SemanticSearchField } from '@/components/search/SemanticSearchField.tsx';
 import { useSemanticSearch } from '@/components/search/useSemanticSearch.ts';
 import { CloseIcon, SearchIcon } from '@/theme/Icons.tsx';
@@ -17,7 +21,7 @@ import {
   useTheme,
 } from '@mui/material';
 import { useNavigate } from '@tanstack/react-router';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useId, useMemo, useState } from 'react';
 
 /**
  * Not exported: the test restates the copy rather than importing it, matching
@@ -71,6 +75,20 @@ export const GlobalSearch = () => {
   // back for the next without retyping.
   const [isDismissed, setIsDismissed] = useState(false);
   const [activeIndex, setActiveIndex] = useState(-1);
+  // Stable across the component's lifetime, unlike a plain string constant:
+  // two instances (e.g. a future split of desktop/mobile) would never collide.
+  const listboxId = useId();
+
+  // Adjusted during render, not an effect: the mobile dialog only exists
+  // below `md`, so widening past it while open must not leave a phantom
+  // dialog behind when the viewport narrows again. Tracking the previous
+  // breakpoint is React's documented way to reset state on a prop change
+  // without an extra render.
+  const [prevIsCompact, setPrevIsCompact] = useState(isCompact);
+  if (isCompact !== prevIsCompact) {
+    setPrevIsCompact(isCompact);
+    if (!isCompact) setIsMobileOpen(false);
+  }
 
   const handleSearch = useCallback((value: string) => {
     setQuery(value);
@@ -84,6 +102,18 @@ export const GlobalSearch = () => {
   });
   const rows = useMemo(() => toGlobalSearchRows(results), [results]);
   const isOpen = hasQuery && !isDismissed;
+  // Absent rather than pointing nowhere when the cursor is in the field: a
+  // screen reader should not announce an active option that doesn't exist.
+  const activeRow = activeIndex >= 0 ? rows[activeIndex] : undefined;
+  // Combobox wiring belongs on the input itself: assistive tech only honours
+  // `aria-activedescendant` on the element holding DOM focus, and focus stays
+  // in the field while the cursor moves through rows.
+  const comboboxHtmlInputProps = {
+    role: 'combobox',
+    'aria-expanded': isOpen,
+    'aria-controls': listboxId,
+    'aria-activedescendant': activeRow ? globalSearchRowDomId(activeRow) : undefined,
+  } as const;
 
   const close = () => {
     setIsDismissed(true);
@@ -113,11 +143,17 @@ export const GlobalSearch = () => {
       setActiveIndex((index) => (index <= 0 ? rows.length - 1 : index - 1));
       return;
     }
-    if (event.key === 'Enter' && activeIndex >= 0) {
+    // Bounds-checked rather than a `row === undefined` guard after indexing:
+    // `noUncheckedIndexedAccess` is off project-wide, so the type checker
+    // sees `rows[activeIndex]` as always defined and flags such a guard as
+    // dead code. A background refetch can still shorten `rows` out from
+    // under a previously set index, so the bound is checked for real here.
+    if (event.key === 'Enter' && activeIndex >= 0 && activeIndex < rows.length) {
+      const row = rows[activeIndex];
       // Stop SearchBar re-submitting the query the row is about to leave.
       event.preventDefault();
       event.stopPropagation();
-      void navigate(rowLinkProps(rows[activeIndex]));
+      void navigate(rowLinkProps(row));
       close();
     }
   };
@@ -140,6 +176,9 @@ export const GlobalSearch = () => {
         <Dialog fullScreen open={isMobileOpen} onClose={closeMobile}>
           <Box
             onKeyDownCapture={handleKeyDown}
+            // Reopens the dropdown when the field regains focus with a query
+            // already in it, e.g. tapping the icon again after a prior visit.
+            onFocus={() => setIsDismissed(false)}
             sx={{ p: 2, display: 'flex', alignItems: 'center', gap: 1 }}
           >
             <Box sx={{ flex: 1 }}>
@@ -148,6 +187,7 @@ export const GlobalSearch = () => {
                 onChange={handleSearch}
                 placeholder={GLOBAL_SEARCH_PLACEHOLDER}
                 autoFocus
+                slotProps={{ htmlInput: comboboxHtmlInputProps }}
               />
             </Box>
             {/* The only way to dismiss a dead-end search: Escape has no keyboard on
@@ -163,6 +203,7 @@ export const GlobalSearch = () => {
               isError={isError}
               activeIndex={activeIndex}
               onSelect={closeMobile}
+              listboxId={listboxId}
             />
           )}
         </Dialog>
@@ -181,6 +222,21 @@ export const GlobalSearch = () => {
           // Focus events bubble in React, so this reopens after a dismissal
           // without SearchBar having to expose an onFocus of its own.
           onFocus={() => setIsDismissed(false)}
+          // A blur that lands outside both this box and the listbox (Tab to
+          // the next control, or a click elsewhere) is a genuine dismissal —
+          // never a reopen, which is what `SearchBar`'s own onBlur→onSearch
+          // would otherwise cause. The listbox itself needs a separate check:
+          // it renders through a `Popper`, portaled to `document.body`, so a
+          // row is never a DOM descendant of this box even though clicking
+          // one focuses it before the click fires — closing on that blur
+          // would unmount the row out from under its own click.
+          onBlur={(event) => {
+            const nextFocus = event.relatedTarget;
+            const staysInWidget =
+              event.currentTarget.contains(nextFocus) ||
+              document.getElementById(listboxId)?.contains(nextFocus);
+            if (!staysInWidget) close();
+          }}
           sx={{ flexGrow: 1, maxWidth: 480, mx: 'auto' }}
         >
           <SemanticSearchField
@@ -188,6 +244,7 @@ export const GlobalSearch = () => {
             onChange={handleSearch}
             placeholder={GLOBAL_SEARCH_PLACEHOLDER}
             sx={appBarFieldSx}
+            slotProps={{ htmlInput: comboboxHtmlInputProps }}
           />
           <Popper
             open={isOpen}
@@ -202,6 +259,7 @@ export const GlobalSearch = () => {
                 isError={isError}
                 activeIndex={activeIndex}
                 onSelect={close}
+                listboxId={listboxId}
               />
             </Paper>
           </Popper>

--- a/frontend/src/components/search/GlobalSearchResultRow.tsx
+++ b/frontend/src/components/search/GlobalSearchResultRow.tsx
@@ -46,31 +46,31 @@ export const GlobalSearchResultRow = ({ row, isActive, onSelect }: GlobalSearchR
     aria-selected={isActive}
     selected={isActive}
     onClick={onSelect}
-    sx={{ alignItems: 'flex-start', gap: 1.5, py: 1.5 }}
+    sx={{ alignItems: 'center', gap: 1.5, py: 1.5, display: 'flex' }}
   >
     <BookCover
       coverFile={row.coverFile}
       blurhash={row.coverBlurhash}
       title={row.bookTitle}
-      width={40}
-      height={56}
+      width={52}
+      height={72}
       objectFit="cover"
-      sx={{ borderRadius: 1, flexShrink: 0 }}
+      sx={{ borderRadius: 0.5, flexShrink: 0 }}
     />
     <Stack sx={{ minWidth: 0 }} spacing={0.25}>
-      <Box>
-        <Chip label={CHIP_LABELS[row.type]} size="small" variant="outlined" />
-      </Box>
       {row.title && (
         <Typography variant="subtitle2" noWrap>
           {row.title}
         </Typography>
       )}
-      <Typography variant="body2" sx={clampToTwoLines}>
+      <Box sx={{ gap: 1, display: 'flex', alignItems: 'center' }}>
+        <Chip label={CHIP_LABELS[row.type]} size="small" variant="outlined" />
+        <Typography variant="caption" color="text.secondary" noWrap>
+          {row.chapterLabel ? `${row.bookTitle} · ${row.chapterLabel}` : row.bookTitle}
+        </Typography>
+      </Box>
+      <Typography variant="body1" sx={clampToTwoLines}>
         {row.text}
-      </Typography>
-      <Typography variant="caption" color="text.secondary" noWrap>
-        {row.chapterLabel ? `${row.bookTitle} · ${row.chapterLabel}` : row.bookTitle}
       </Typography>
     </Stack>
   </LinkListItemButton>

--- a/frontend/src/components/search/GlobalSearchResultRow.tsx
+++ b/frontend/src/components/search/GlobalSearchResultRow.tsx
@@ -1,0 +1,93 @@
+import { BookCover } from '@/components/BookCover.tsx';
+import type { GlobalSearchRow } from '@/components/search/globalSearchRows.ts';
+import { Box, Chip, ListItemButton, Stack, Typography } from '@mui/material';
+import { Link, linkOptions } from '@tanstack/react-router';
+import type { ComponentProps } from 'react';
+
+const CHIP_LABELS: Record<GlobalSearchRow['type'], string> = {
+  highlight: 'Highlight',
+  note: 'Note',
+  chapter: 'Chapter',
+};
+
+/**
+ * Router props for a row, as a switch rather than strings on the row itself:
+ * TanStack Router types `to` against the route tree, and a `to: string` field
+ * would throw that away.
+ *
+ * Left un-exported until Task 6 imports it — knip fails CI on an export nothing
+ * references yet.
+ */
+const rowLinkProps = (row: GlobalSearchRow) => {
+  const params = { bookId: String(row.bookId) };
+  switch (row.type) {
+    case 'highlight':
+      return linkOptions({
+        to: '/book/$bookId/highlights',
+        params,
+        search: { highlightId: row.id },
+      });
+    case 'note':
+      return linkOptions({ to: '/book/$bookId/notes', params, search: { noteId: row.id } });
+    case 'chapter':
+      return linkOptions({
+        to: '/book/$bookId/structure',
+        params,
+        search: { chapterId: row.id },
+      });
+  }
+};
+
+/** Two lines of matched text, clamped rather than truncated in JS. */
+const clampToTwoLines = {
+  display: '-webkit-box',
+  WebkitLineClamp: 2,
+  WebkitBoxOrient: 'vertical' as const,
+  overflow: 'hidden',
+};
+
+interface GlobalSearchResultRowProps {
+  row: GlobalSearchRow;
+  /** Keyboard cursor position, not selection — the row is never checked. */
+  isActive: boolean;
+  onSelect: () => void;
+}
+
+export const GlobalSearchResultRow = ({ row, isActive, onSelect }: GlobalSearchResultRowProps) => (
+  <ListItemButton
+    component={Link}
+    {...(rowLinkProps(row) as unknown as ComponentProps<typeof Link>)}
+    id={`global-search-${row.key}`}
+    role="option"
+    aria-selected={isActive}
+    selected={isActive}
+    onClick={onSelect}
+    sx={{ alignItems: 'flex-start', gap: 1.5, py: 1.5 }}
+  >
+    <BookCover
+      coverFile={row.coverFile}
+      blurhash={row.coverBlurhash}
+      title={row.bookTitle}
+      width={40}
+      height={56}
+      objectFit="cover"
+      sx={{ borderRadius: 1, flexShrink: 0 }}
+    />
+    <Stack sx={{ minWidth: 0 }} spacing={0.25}>
+      <Box>
+        <Chip label={CHIP_LABELS[row.type]} size="small" variant="outlined" />
+      </Box>
+      {row.title && (
+        <Typography variant="subtitle2" noWrap>
+          {row.title}
+        </Typography>
+      )}
+      <Typography variant="body2" sx={clampToTwoLines}>
+        {row.text}
+      </Typography>
+      <Typography variant="caption" color="text.secondary" noWrap>
+        {row.chapterLabel ? `${row.bookTitle} · ${row.chapterLabel}` : row.bookTitle}
+      </Typography>
+    </Stack>
+  </ListItemButton>
+);

--- a/frontend/src/components/search/GlobalSearchResultRow.tsx
+++ b/frontend/src/components/search/GlobalSearchResultRow.tsx
@@ -1,7 +1,11 @@
 import { BookCover } from '@/components/BookCover.tsx';
-import type { GlobalSearchRow } from '@/components/search/globalSearchRows.ts';
+import {
+  globalSearchRowDomId,
+  rowLinkProps,
+  type GlobalSearchRow,
+} from '@/components/search/globalSearchRows.ts';
 import { Box, Chip, ListItemButton, Stack, Typography } from '@mui/material';
-import { createLink, linkOptions } from '@tanstack/react-router';
+import { createLink } from '@tanstack/react-router';
 
 const CHIP_LABELS: Record<GlobalSearchRow['type'], string> = {
   highlight: 'Highlight',
@@ -18,34 +22,6 @@ const CHIP_LABELS: Record<GlobalSearchRow['type'], string> = {
  * without that collision.
  */
 const LinkListItemButton = createLink(ListItemButton);
-
-/**
- * Router props for a row, as a switch rather than strings on the row itself:
- * TanStack Router types `to` against the route tree, and a `to: string` field
- * would throw that away.
- *
- * Left un-exported until Task 6 imports it — knip fails CI on an export nothing
- * references yet.
- */
-const rowLinkProps = (row: GlobalSearchRow) => {
-  const params = { bookId: String(row.bookId) };
-  switch (row.type) {
-    case 'highlight':
-      return linkOptions({
-        to: '/book/$bookId/highlights',
-        params,
-        search: { highlightId: row.id },
-      });
-    case 'note':
-      return linkOptions({ to: '/book/$bookId/notes', params, search: { noteId: row.id } });
-    case 'chapter':
-      return linkOptions({
-        to: '/book/$bookId/structure',
-        params,
-        search: { chapterId: row.id },
-      });
-  }
-};
 
 /** Two lines of matched text, clamped rather than truncated in JS. */
 const clampToTwoLines = {
@@ -65,7 +41,7 @@ interface GlobalSearchResultRowProps {
 export const GlobalSearchResultRow = ({ row, isActive, onSelect }: GlobalSearchResultRowProps) => (
   <LinkListItemButton
     {...rowLinkProps(row)}
-    id={`global-search-${row.key}`}
+    id={globalSearchRowDomId(row)}
     role="option"
     aria-selected={isActive}
     selected={isActive}

--- a/frontend/src/components/search/GlobalSearchResultRow.tsx
+++ b/frontend/src/components/search/GlobalSearchResultRow.tsx
@@ -1,14 +1,23 @@
 import { BookCover } from '@/components/BookCover.tsx';
 import type { GlobalSearchRow } from '@/components/search/globalSearchRows.ts';
 import { Box, Chip, ListItemButton, Stack, Typography } from '@mui/material';
-import { Link, linkOptions } from '@tanstack/react-router';
-import type { ComponentProps } from 'react';
+import { createLink, linkOptions } from '@tanstack/react-router';
 
 const CHIP_LABELS: Record<GlobalSearchRow['type'], string> = {
   highlight: 'Highlight',
   note: 'Note',
   chapter: 'Chapter',
 };
+
+/**
+ * MUI's `ListItemButton` injects an `href` prop when given `component={Link}`
+ * directly (it copies `to` to `href` for anchor semantics). TanStack Router's
+ * `Link` then treats that injected `href` as authoritative and re-parses
+ * `search` off its (empty) query string, silently dropping the real search
+ * params. `createLink` wires the component in the way the router expects,
+ * without that collision.
+ */
+const LinkListItemButton = createLink(ListItemButton);
 
 /**
  * Router props for a row, as a switch rather than strings on the row itself:
@@ -54,9 +63,8 @@ interface GlobalSearchResultRowProps {
 }
 
 export const GlobalSearchResultRow = ({ row, isActive, onSelect }: GlobalSearchResultRowProps) => (
-  <ListItemButton
-    component={Link}
-    {...(rowLinkProps(row) as unknown as ComponentProps<typeof Link>)}
+  <LinkListItemButton
+    {...rowLinkProps(row)}
     id={`global-search-${row.key}`}
     role="option"
     aria-selected={isActive}
@@ -89,5 +97,5 @@ export const GlobalSearchResultRow = ({ row, isActive, onSelect }: GlobalSearchR
         {row.chapterLabel ? `${row.bookTitle} · ${row.chapterLabel}` : row.bookTitle}
       </Typography>
     </Stack>
-  </ListItemButton>
+  </LinkListItemButton>
 );

--- a/frontend/src/components/search/GlobalSearchResults.tsx
+++ b/frontend/src/components/search/GlobalSearchResults.tsx
@@ -1,8 +1,9 @@
 import { EmptyStateText } from '@/components/EmptyStateText.tsx';
 import { GlobalSearchResultRow } from '@/components/search/GlobalSearchResultRow.tsx';
 import {
-  type GlobalSearchRow,
+  globalSearchRowDomId,
   MAX_GLOBAL_SEARCH_ROWS,
+  type GlobalSearchRow,
 } from '@/components/search/globalSearchRows.ts';
 import { Box, CircularProgress, LinearProgress, List, Typography } from '@mui/material';
 
@@ -54,11 +55,20 @@ export const GlobalSearchResults = ({
     );
   }
 
+  // Absent rather than pointing nowhere when the cursor is in the field: a
+  // screen reader should not announce an active option that doesn't exist.
+  const activeRow = activeIndex >= 0 ? rows[activeIndex] : undefined;
+
   return (
     <Box>
       {/* Old rows stay put while the next query runs; this is the only hint. */}
       {isFetching && <LinearProgress />}
-      <List role="listbox" aria-label="Search results" disablePadding>
+      <List
+        role="listbox"
+        aria-label="Search results"
+        aria-activedescendant={activeRow ? globalSearchRowDomId(activeRow) : undefined}
+        disablePadding
+      >
         {rows.map((row, index) => (
           <GlobalSearchResultRow
             key={row.key}

--- a/frontend/src/components/search/GlobalSearchResults.tsx
+++ b/frontend/src/components/search/GlobalSearchResults.tsx
@@ -1,0 +1,78 @@
+import { EmptyStateText } from '@/components/EmptyStateText.tsx';
+import { GlobalSearchResultRow } from '@/components/search/GlobalSearchResultRow.tsx';
+import {
+  type GlobalSearchRow,
+  MAX_GLOBAL_SEARCH_ROWS,
+} from '@/components/search/globalSearchRows.ts';
+import { Box, CircularProgress, LinearProgress, List, Typography } from '@mui/material';
+
+interface GlobalSearchResultsProps {
+  rows: GlobalSearchRow[];
+  isFetching: boolean;
+  isError: boolean;
+  /** Index of the keyboard cursor, or -1 when the cursor is in the field. */
+  activeIndex: number;
+  onSelect: () => void;
+}
+
+/**
+ * The dropdown's body, shared by the desktop popper and the mobile dialog.
+ *
+ * Renders only when there is a query, so "nothing matched" and "no search yet"
+ * never have to be told apart here — the caller decides whether to mount it.
+ */
+export const GlobalSearchResults = ({
+  rows,
+  isFetching,
+  isError,
+  activeIndex,
+  onSelect,
+}: GlobalSearchResultsProps) => {
+  if (isError) {
+    return (
+      <Box sx={{ p: 2 }}>
+        <Typography variant="body2" color="error">
+          Search failed. Try again.
+        </Typography>
+      </Box>
+    );
+  }
+
+  if (isFetching && rows.length === 0) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', p: 3 }}>
+        <CircularProgress size={24} />
+      </Box>
+    );
+  }
+
+  if (rows.length === 0) {
+    return (
+      <Box sx={{ p: 2 }}>
+        <EmptyStateText>No matches</EmptyStateText>
+      </Box>
+    );
+  }
+
+  return (
+    <Box>
+      {/* Old rows stay put while the next query runs; this is the only hint. */}
+      {isFetching && <LinearProgress />}
+      <List role="listbox" aria-label="Search results" disablePadding>
+        {rows.map((row, index) => (
+          <GlobalSearchResultRow
+            key={row.key}
+            row={row}
+            isActive={index === activeIndex}
+            onSelect={onSelect}
+          />
+        ))}
+      </List>
+      {rows.length === MAX_GLOBAL_SEARCH_ROWS && (
+        <Typography variant="caption" color="text.secondary" sx={{ display: 'block', p: 1.5 }}>
+          Showing top {MAX_GLOBAL_SEARCH_ROWS}
+        </Typography>
+      )}
+    </Box>
+  );
+};

--- a/frontend/src/components/search/GlobalSearchResults.tsx
+++ b/frontend/src/components/search/GlobalSearchResults.tsx
@@ -1,7 +1,6 @@
 import { EmptyStateText } from '@/components/EmptyStateText.tsx';
 import { GlobalSearchResultRow } from '@/components/search/GlobalSearchResultRow.tsx';
 import {
-  globalSearchRowDomId,
   MAX_GLOBAL_SEARCH_ROWS,
   type GlobalSearchRow,
 } from '@/components/search/globalSearchRows.ts';
@@ -14,6 +13,8 @@ interface GlobalSearchResultsProps {
   /** Index of the keyboard cursor, or -1 when the cursor is in the field. */
   activeIndex: number;
   onSelect: () => void;
+  /** DOM id for the listbox `<ul>`, matching the field's `aria-controls`. */
+  listboxId: string;
 }
 
 /**
@@ -28,6 +29,7 @@ export const GlobalSearchResults = ({
   isError,
   activeIndex,
   onSelect,
+  listboxId,
 }: GlobalSearchResultsProps) => {
   if (isError) {
     return (
@@ -42,7 +44,7 @@ export const GlobalSearchResults = ({
   if (isFetching && rows.length === 0) {
     return (
       <Box sx={{ display: 'flex', justifyContent: 'center', p: 3 }}>
-        <CircularProgress size={24} />
+        <CircularProgress size={24} aria-label="Searching" />
       </Box>
     );
   }
@@ -55,20 +57,11 @@ export const GlobalSearchResults = ({
     );
   }
 
-  // Absent rather than pointing nowhere when the cursor is in the field: a
-  // screen reader should not announce an active option that doesn't exist.
-  const activeRow = activeIndex >= 0 ? rows[activeIndex] : undefined;
-
   return (
     <Box>
       {/* Old rows stay put while the next query runs; this is the only hint. */}
       {isFetching && <LinearProgress />}
-      <List
-        role="listbox"
-        aria-label="Search results"
-        aria-activedescendant={activeRow ? globalSearchRowDomId(activeRow) : undefined}
-        disablePadding
-      >
+      <List id={listboxId} role="listbox" aria-label="Search results" disablePadding>
         {rows.map((row, index) => (
           <GlobalSearchResultRow
             key={row.key}

--- a/frontend/src/components/search/SemanticSearchField.tsx
+++ b/frontend/src/components/search/SemanticSearchField.tsx
@@ -11,6 +11,9 @@ interface SemanticSearchFieldProps {
   sx?: SxProps<Theme>;
   /** Off by default: only a caller that owns the field's only focus target (e.g. a just-opened dialog) should set this. */
   autoFocus?: boolean;
+  /** Extra attributes merged onto the native `<input>`, e.g. ARIA combobox
+   *  wiring for a caller that owns a listbox of its own. */
+  slotProps?: { htmlInput?: React.InputHTMLAttributes<HTMLInputElement> };
 }
 
 /**
@@ -28,6 +31,7 @@ export const SemanticSearchField = ({
   placeholder,
   sx,
   autoFocus,
+  slotProps,
 }: SemanticSearchFieldProps) => (
   <EmbeddingFeature>
     <Box>
@@ -38,6 +42,7 @@ export const SemanticSearchField = ({
         commitOn="submit"
         sx={sx}
         autoFocus={autoFocus}
+        slotProps={slotProps}
       />
     </Box>
   </EmbeddingFeature>

--- a/frontend/src/components/search/SemanticSearchField.tsx
+++ b/frontend/src/components/search/SemanticSearchField.tsx
@@ -1,12 +1,14 @@
 import { EmbeddingFeature } from '@/components/features/EmbeddingFeature.tsx';
 import { SearchBar } from '@/components/inputs/SearchBar.tsx';
-import { Box } from '@mui/material';
+import { Box, type SxProps, type Theme } from '@mui/material';
 
 interface SemanticSearchFieldProps {
   value: string;
   /** Called with the submitted query text. Must be a stable callback. */
   onChange: (value: string) => void;
   placeholder: string;
+  /** Applied to the input, for callers on a non-default background. */
+  sx?: SxProps<Theme>;
 }
 
 /**
@@ -18,7 +20,12 @@ interface SemanticSearchFieldProps {
  * nothing about results. Callers pair it with `useSemanticSearch` and decide
  * what a match means.
  */
-export const SemanticSearchField = ({ value, onChange, placeholder }: SemanticSearchFieldProps) => (
+export const SemanticSearchField = ({
+  value,
+  onChange,
+  placeholder,
+  sx,
+}: SemanticSearchFieldProps) => (
   <EmbeddingFeature>
     <Box>
       <SearchBar
@@ -26,6 +33,7 @@ export const SemanticSearchField = ({ value, onChange, placeholder }: SemanticSe
         placeholder={placeholder}
         initialValue={value}
         commitOn="submit"
+        sx={sx}
       />
     </Box>
   </EmbeddingFeature>

--- a/frontend/src/components/search/SemanticSearchField.tsx
+++ b/frontend/src/components/search/SemanticSearchField.tsx
@@ -9,6 +9,8 @@ interface SemanticSearchFieldProps {
   placeholder: string;
   /** Applied to the input, for callers on a non-default background. */
   sx?: SxProps<Theme>;
+  /** Off by default: only a caller that owns the field's only focus target (e.g. a just-opened dialog) should set this. */
+  autoFocus?: boolean;
 }
 
 /**
@@ -25,6 +27,7 @@ export const SemanticSearchField = ({
   onChange,
   placeholder,
   sx,
+  autoFocus,
 }: SemanticSearchFieldProps) => (
   <EmbeddingFeature>
     <Box>
@@ -34,6 +37,7 @@ export const SemanticSearchField = ({
         initialValue={value}
         commitOn="submit"
         sx={sx}
+        autoFocus={autoFocus}
       />
     </Box>
   </EmbeddingFeature>

--- a/frontend/src/components/search/globalSearchRows.ts
+++ b/frontend/src/components/search/globalSearchRows.ts
@@ -1,4 +1,5 @@
 import type { SemanticSearchResults } from '@/api/generated/model';
+import { linkOptions } from '@tanstack/react-router';
 
 /** Not exported: consumers index `GlobalSearchRow['type']`, and knip fails CI
  *  on an export nothing imports. */
@@ -96,4 +97,41 @@ export const toGlobalSearchRows = (
   return [...highlights, ...notes, ...chapters]
     .sort((a, b) => b.score - a.score)
     .slice(0, MAX_GLOBAL_SEARCH_ROWS);
+};
+
+/**
+ * The DOM id a row's element carries. Shared by the row itself and by
+ * `aria-activedescendant` on the listbox, so the two cannot drift apart.
+ */
+export const globalSearchRowDomId = (row: GlobalSearchRow) => `global-search-${row.key}`;
+
+/**
+ * Router props for a row, as a switch rather than strings on the row itself:
+ * TanStack Router types `to` against the route tree, and a `to: string` field
+ * would throw that away.
+ *
+ * Lives beside `GlobalSearchRow` rather than in the row component: it is a
+ * pure function of the row, and both `GlobalSearchResultRow` (click) and
+ * `GlobalSearch` (Enter) need it, so it can't be component-local without
+ * either duplicating it or exporting it from a component file — the latter
+ * trips `react-refresh/only-export-components`.
+ */
+export const rowLinkProps = (row: GlobalSearchRow) => {
+  const params = { bookId: String(row.bookId) };
+  switch (row.type) {
+    case 'highlight':
+      return linkOptions({
+        to: '/book/$bookId/highlights',
+        params,
+        search: { highlightId: row.id },
+      });
+    case 'note':
+      return linkOptions({ to: '/book/$bookId/notes', params, search: { noteId: row.id } });
+    case 'chapter':
+      return linkOptions({
+        to: '/book/$bookId/structure',
+        params,
+        search: { chapterId: row.id },
+      });
+  }
 };

--- a/frontend/src/components/search/globalSearchRows.ts
+++ b/frontend/src/components/search/globalSearchRows.ts
@@ -1,0 +1,99 @@
+import type { SemanticSearchResults } from '@/api/generated/model';
+
+/** Not exported: consumers index `GlobalSearchRow['type']`, and knip fails CI
+ *  on an export nothing imports. */
+type GlobalSearchRowType = 'highlight' | 'note' | 'chapter';
+
+export interface GlobalSearchRow {
+  /**
+   * React key. Content ids collide across types, and a digest's own id is not
+   * the chapter id it opens, so both are folded in.
+   */
+  key: string;
+  type: GlobalSearchRowType;
+  score: number;
+  /** The entity the row opens: a highlight, a note, or a chapter. */
+  id: number;
+  bookId: number;
+  /** Bold single line above the text. Only notes have one. */
+  title: string | null;
+  /** Clamped to two lines by CSS, never truncated here. */
+  text: string;
+  bookTitle: string;
+  chapterLabel: string | null;
+  coverFile: string | null;
+  coverBlurhash: string | null;
+}
+
+/** Rows in the app bar dropdown. A full results page will raise this. */
+export const MAX_GLOBAL_SEARCH_ROWS = 10;
+
+/**
+ * Flattens the endpoint's three groups into one list ranked by score.
+ *
+ * Scores are cosine similarity on one scale for all three types, which is what
+ * makes a merged ranking meaningful rather than a presentation trick.
+ *
+ * Notes with no linked book are dropped: their row would have no cover and no
+ * page to open, since a note view only exists inside a book. They stay
+ * invisible until a global note view exists.
+ */
+export const toGlobalSearchRows = (
+  results: SemanticSearchResults | undefined
+): GlobalSearchRow[] => {
+  if (!results) return [];
+
+  const highlights: GlobalSearchRow[] = results.highlights.map((hit) => ({
+    key: `highlight-${hit.id}`,
+    type: 'highlight',
+    score: hit.score,
+    id: hit.id,
+    bookId: hit.book_id,
+    title: null,
+    text: hit.text,
+    bookTitle: hit.book_title,
+    chapterLabel: hit.chapter_name,
+    coverFile: hit.cover_file,
+    coverBlurhash: hit.cover_blurhash,
+  }));
+
+  const notes: GlobalSearchRow[] = results.notes.flatMap((hit) => {
+    // `books[0]` is untyped as optional (noUncheckedIndexedAccess is off), so
+    // the emptiness check is on `.length`, not on `book` itself.
+    if (hit.books.length === 0) return [];
+    const book = hit.books[0];
+    return [
+      {
+        key: `note-${hit.id}`,
+        type: 'note',
+        score: hit.score,
+        id: hit.id,
+        bookId: book.id,
+        title: hit.title,
+        text: hit.body,
+        bookTitle: book.title,
+        chapterLabel: null,
+        coverFile: book.cover_file,
+        coverBlurhash: book.cover_blurhash,
+      },
+    ];
+  });
+
+  const chapters: GlobalSearchRow[] = results.digests.map((hit) => ({
+    key: `digest-${hit.id}`,
+    type: 'chapter',
+    score: hit.score,
+    id: hit.chapter_id,
+    bookId: hit.book_id,
+    title: null,
+    text: hit.summary,
+    bookTitle: hit.book_title,
+    chapterLabel: hit.chapter_name,
+    coverFile: hit.cover_file,
+    coverBlurhash: hit.cover_blurhash,
+  }));
+
+  return [...highlights, ...notes, ...chapters]
+    .sort((a, b) => b.score - a.score)
+    .slice(0, MAX_GLOBAL_SEARCH_ROWS);
+};

--- a/frontend/src/components/search/globalSearchRows.ts
+++ b/frontend/src/components/search/globalSearchRows.ts
@@ -1,24 +1,15 @@
 import type { SemanticSearchResults } from '@/api/generated/model';
 import { linkOptions } from '@tanstack/react-router';
 
-/** Not exported: consumers index `GlobalSearchRow['type']`, and knip fails CI
- *  on an export nothing imports. */
 type GlobalSearchRowType = 'highlight' | 'note' | 'chapter';
 
 export interface GlobalSearchRow {
-  /**
-   * React key. Content ids collide across types, and a digest's own id is not
-   * the chapter id it opens, so both are folded in.
-   */
   key: string;
   type: GlobalSearchRowType;
   score: number;
-  /** The entity the row opens: a highlight, a note, or a chapter. */
   id: number;
   bookId: number;
-  /** Bold single line above the text. Only notes have one. */
   title: string | null;
-  /** Clamped to two lines by CSS, never truncated here. */
   text: string;
   bookTitle: string;
   chapterLabel: string | null;
@@ -26,7 +17,6 @@ export interface GlobalSearchRow {
   coverBlurhash: string | null;
 }
 
-/** Rows in the app bar dropdown. A full results page will raise this. */
 export const MAX_GLOBAL_SEARCH_ROWS = 10;
 
 /**

--- a/frontend/src/components/search/useSemanticSearch.ts
+++ b/frontend/src/components/search/useSemanticSearch.ts
@@ -14,14 +14,16 @@ import { useMemo } from 'react';
  */
 const MIN_SCORE = 0.35;
 
-/** Results per content type. The endpoint's maximum is 100. */
-const LIMIT = 25;
+/** Default results per content type. The endpoint's maximum is 100. */
+const DEFAULT_LIMIT = 25;
 
 interface UseSemanticSearchOptions {
   /** Current query text. The caller owns where it is stored. */
   query: string;
   /** Scope to one book. Omit to search every book. */
   bookId?: number;
+  /** Results per content type. Defaults to 25; the endpoint's maximum is 100. */
+  limit?: number;
 }
 
 interface SemanticSearchState {
@@ -49,6 +51,7 @@ const strongEnough = <T extends { score: number }>(items: T[]) =>
 export const useSemanticSearch = ({
   query,
   bookId,
+  limit = DEFAULT_LIMIT,
 }: UseSemanticSearchOptions): SemanticSearchState => {
   const { featureFlags } = useSettings();
   const q = query.trim();
@@ -57,7 +60,7 @@ export const useSemanticSearch = ({
   const hasQuery = featureFlags?.embeddings === true && q.length > 0;
 
   const { data, isFetching, isError } = useSearchContent(
-    { q, book_id: bookId, limit: LIMIT },
+    { q, book_id: bookId, limit },
     // `q` is a required param with minLength 1; `enabled` is what keeps an
     // empty query (or a disabled feature) off the wire. keepPreviousData
     // stops the filtered list flashing empty between keystrokes.

--- a/frontend/src/theme/Icons.tsx
+++ b/frontend/src/theme/Icons.tsx
@@ -13,6 +13,7 @@ export {
   Menu as MenuIcon,
   MoreHoriz as MoreIcon,
   KeyboardArrowUp as ScrollToTopIcon,
+  Search as SearchIcon,
 } from '@mui/icons-material';
 
 // Content icons

--- a/frontend/src/theme/theme.ts
+++ b/frontend/src/theme/theme.ts
@@ -28,6 +28,7 @@ const customColors = {
   // Hover and interaction colors
   whiteOverlay: {
     light: 'rgba(255, 255, 255, 0.1)', // White overlay for hover effects (AppBar)
+    hover: 'rgba(255, 255, 255, 0.18)', // Search field surface on hover (AppBar)
     group: 'rgba(255, 255, 255, 0.6)', // Tag group surface over page background (TagsList)
     ungrouped: 'rgba(255, 255, 255, 0.4)', // Ungrouped tag bucket surface (TagsList)
   },

--- a/frontend/tests/fixtures/book.ts
+++ b/frontend/tests/fixtures/book.ts
@@ -1,4 +1,20 @@
-import type { BookDetails, ChapterWithHighlights } from '@/api/generated/model';
+import type { BookDetails, ChapterWithHighlights, Highlight } from '@/api/generated/model';
+
+export const aHighlight = (overrides: Partial<Highlight> = {}): Highlight => ({
+  id: 300,
+  book_id: 1,
+  chapter_id: 10,
+  chapter: 'Chapter One',
+  chapter_number: 1,
+  page: 42,
+  text: 'The map is not the territory.',
+  datetime: '2026-01-01 00:00:00',
+  tags: [],
+  flashcards: [],
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+  ...overrides,
+});
 
 export const aChapter = (
   overrides: Partial<ChapterWithHighlights> = {}

--- a/frontend/tests/fixtures/semantic.ts
+++ b/frontend/tests/fixtures/semantic.ts
@@ -1,4 +1,4 @@
-import type { DigestSearchItem, NoteSearchItem } from '@/api/generated/model';
+import type { DigestSearchItem, HighlightSearchItem, NoteSearchItem } from '@/api/generated/model';
 
 export const aDigestHit = (overrides: Partial<DigestSearchItem> = {}): DigestSearchItem => ({
   score: 0.7,
@@ -22,5 +22,23 @@ export const aNoteHit = (overrides: Partial<NoteSearchItem> = {}): NoteSearchIte
   title: 'Ada Lovelace',
   body: 'The first programmer.',
   kind: 'character',
+  ...overrides,
+});
+
+export const aHighlightHit = (
+  overrides: Partial<HighlightSearchItem> = {}
+): HighlightSearchItem => ({
+  score: 0.7,
+  id: 300,
+  book_id: 1,
+  book_title: 'The Pragmatic Reader',
+  chapter_id: 10,
+  chapter_name: 'Chapter One',
+  chapter_number: 1,
+  text: 'The map is not the territory.',
+  page: 42,
+  datetime: '2026-01-01 00:00:00',
+  cover_file: null,
+  cover_blurhash: null,
   ...overrides,
 });

--- a/frontend/tests/fixtures/semantic.ts
+++ b/frontend/tests/fixtures/semantic.ts
@@ -10,13 +10,15 @@ export const aDigestHit = (overrides: Partial<DigestSearchItem> = {}): DigestSea
   chapter_number: 1,
   summary: 'A summary of the chapter.',
   keypoints: [],
+  cover_file: null,
+  cover_blurhash: null,
   ...overrides,
 });
 
 export const aNoteHit = (overrides: Partial<NoteSearchItem> = {}): NoteSearchItem => ({
   score: 0.7,
   id: 100,
-  books: [{ id: 1, title: 'The Pragmatic Reader' }],
+  books: [{ id: 1, title: 'The Pragmatic Reader', cover_file: null, cover_blurhash: null }],
   title: 'Ada Lovelace',
   body: 'The first programmer.',
   kind: 'character',

--- a/frontend/tests/harness/renderApp.tsx
+++ b/frontend/tests/harness/renderApp.tsx
@@ -25,6 +25,19 @@ const createTestQueryClient = () =>
   });
 
 /**
+ * Every `QueryClient` a test has created since the last drain.
+ *
+ * A component can still have a request in flight for a moment after the test
+ * that triggered it has moved on — opening a dialog fires a fetch nothing in
+ * the test awaits, for instance. `tests/setup.ts`'s `afterEach` drains this
+ * list and gives each client a bounded chance to go idle before resetting MSW
+ * handlers, so that request lands on the handlers that were active when it
+ * was made rather than being orphaned onto whichever later test's `afterEach`
+ * happens to run when it finally resolves.
+ */
+export const pendingQueryClients: QueryClient[] = [];
+
+/**
  * Renders the whole app at `path`: the real route tree, the real auth gate and
  * the same providers `src/main.tsx` mounts, over a fresh QueryClient.
  *
@@ -37,6 +50,7 @@ export async function renderApp({ path }: RenderAppOptions) {
   window.history.pushState(null, '', path);
 
   const queryClient = createTestQueryClient();
+  pendingQueryClients.push(queryClient);
   const router = createRouter({
     routeTree,
     history: createBrowserHistory(),

--- a/frontend/tests/msw/bookApi.ts
+++ b/frontend/tests/msw/bookApi.ts
@@ -29,6 +29,8 @@ export function bookApi(initial: Partial<BookApiState> = {}) {
       HttpResponse.json({ items: [], total: 0, offset: 0, limit: 1 })
     ),
     http.get('/api/v1/jobs/books/:bookId/digest', () => HttpResponse.json(null)),
+    http.get('/api/v1/books/:bookId/tags', () => HttpResponse.json({ items: [] })),
+    http.get('/api/v1/books/:bookId/highlight-labels', () => HttpResponse.json({ items: [] })),
 
     http.get('/api/v1/notes/:noteId', ({ params }) => {
       const note = findNote(params.noteId);

--- a/frontend/tests/msw/covers.ts
+++ b/frontend/tests/msw/covers.ts
@@ -1,0 +1,26 @@
+import { http, HttpResponse } from 'msw';
+
+/**
+ * A 1x1 transparent PNG, so an `<img>` pointed at a mocked cover actually
+ * loads rather than firing `onError` and hiding itself — a hidden image drops
+ * out of the accessibility tree, which would make `getByRole('img')` fail to
+ * find it.
+ */
+const TRANSPARENT_PNG_BASE64 =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=';
+
+const transparentPngBytes = () =>
+  Uint8Array.from(atob(TRANSPARENT_PNG_BASE64), (char) => char.charCodeAt(0));
+
+/**
+ * `GET /covers/:file`, answering every request with the same placeholder
+ * image. `BookCover` builds the URL from `VITE_API_URL`, which is unset in
+ * tests, so it falls back to `http://localhost:8000` — the literal origin
+ * matched here.
+ */
+export const coversApi = () => [
+  http.get(
+    'http://localhost:8000/api/v1/covers/:file',
+    () => new HttpResponse(transparentPngBytes(), { headers: { 'Content-Type': 'image/png' } })
+  ),
+];

--- a/frontend/tests/setup.ts
+++ b/frontend/tests/setup.ts
@@ -2,6 +2,7 @@ import { AXIOS_INSTANCE } from '@/api/axios-instance';
 import { clearTokens } from '@/api/token-manager';
 import { afterAll, afterEach, beforeAll } from 'vitest';
 import { cleanup } from 'vitest-browser-react';
+import { pendingQueryClients } from './harness/renderApp';
 import { worker } from './msw/worker';
 
 // Relative URLs, so MSW handlers can be written against `/api/v1/...` paths.
@@ -24,8 +25,37 @@ beforeAll(async () => {
   });
 });
 
-afterEach(() => {
+/**
+ * Bounded, never-throwing wait for one `QueryClient` to have nothing in
+ * flight. Deliberately not `expect.poll`: a client that is *never* going to
+ * settle (a genuinely stuck request) must fall through to the unmocked-request
+ * check below rather than fail the teardown itself with a timeout.
+ */
+async function waitForIdle(
+  client: (typeof pendingQueryClients)[number],
+  timeoutMs = 2000,
+  intervalMs = 20
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  // Always yield at least once before the first check: a query mounted this
+  // tick (e.g. a dialog that just opened) may not have dispatched its fetch
+  // yet, so `isFetching()` can still read 0 the instant `cleanup()` returns,
+  // even though a request is about to go out.
+  do {
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  } while ((client.isFetching() > 0 || client.isMutating() > 0) && Date.now() < deadline);
+}
+
+afterEach(async () => {
   cleanup();
+
+  // Unmounting stops any query's own refetch scheduling, but a request already
+  // dispatched before unmount can still be in flight for a moment after. Give
+  // every client this test created a bounded chance to finish before the
+  // handlers it was relying on disappear underneath it.
+  const clients = pendingQueryClients.splice(0);
+  await Promise.all(clients.map((client) => waitForIdle(client)));
+
   worker.resetHandlers();
   clearTokens();
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -126,6 +126,7 @@
       "resolved": "https://registry.npmjs.org/@mui/material/-/material-9.2.0.tgz",
       "integrity": "sha512-+YTRSgGKGrrRo2XJZXs7JRA6qHoHWvNtxyqxnrRJTBmIuLOUpxxh7m4G9lF4tWberxGFY+EqkkRPgJCl+fSMJg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.29.2",
         "@mui/core-downloads-tracker": "^9.2.0",
@@ -409,6 +410,7 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -690,6 +692,7 @@
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
       "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -733,6 +736,7 @@
       "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.1.tgz",
       "integrity": "sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -2775,6 +2779,7 @@
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -3221,6 +3226,7 @@
       "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~8.3.0"
       }
@@ -3242,6 +3248,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
       "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3252,6 +3259,7 @@
       "integrity": "sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3323,6 +3331,7 @@
       "integrity": "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.65.0",
         "@typescript-eslint/types": "8.65.0",
@@ -3909,6 +3918,7 @@
       "integrity": "sha512-nMoXGEiRpT7m3W7NsbvrM2aKNwiNHZf+zEpUCvMteGjZFvfT96Q9fh7QyB98dvDWXiKvrLxA7bJ1mCOOv+JQPw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/browser": "4.1.10",
         "@vitest/mocker": "4.1.10",
@@ -4053,6 +4063,7 @@
       "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4287,6 +4298,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.42",
         "caniuse-lite": "^1.0.30001803",
@@ -4931,6 +4943,7 @@
       "integrity": "sha512-nuKKvN+oIBO0koN7Tm7dlkmnkc21mtt0QJLwAKzjLq14y6lRTdVG36MZHJ8eQHwdJMwZbQNMlPOYedMq/oVJvQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "workspaces": [
         "packages/*"
       ],
@@ -6271,6 +6284,7 @@
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7449,6 +7463,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@inquirer/confirm": "^6.0.11",
         "@mswjs/interceptors": "^0.41.3",
@@ -7672,6 +7687,7 @@
       "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=22.12.0"
       }
@@ -8087,6 +8103,7 @@
       "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -8191,6 +8208,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
       "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8210,6 +8228,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
       "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -8472,6 +8491,7 @@
       "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.5.6.tgz",
       "integrity": "sha512-rVQVWjjSvlINzaQPZH5JFqsqEsIWdTxY3iJZCnTL/5gQbXIRooVZKI60tVCkOVfzcRPejboxO2t0P89dg5mQaA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -8783,6 +8803,7 @@
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8882,27 +8903,6 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
-    "node_modules/tsx": {
-      "version": "4.23.1",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.1.tgz",
-      "integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "esbuild": "~0.28.0"
-      },
-      "bin": {
-        "tsx": "dist/cli.mjs"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.3"
-      }
-    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -8938,6 +8938,7 @@
       "integrity": "sha512-uSKqkh8Cr48vllnEy+jdaAgOeR6Y+QCBW7usgUsKj7gJEfR7stw9U/fE49LBnj2tPRKPY0c0EBJSWe9Appmplg==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@gerrit0/mini-shiki": "^3.23.0",
         "lunr": "^2.3.9",
@@ -9249,6 +9250,7 @@
       "integrity": "sha512-pn+CFpM0lwDeKwmOq1ZaBK/9sjorZcgqxki6MbY/jPEVd9vichIlmlD4HmQ5wdP5EgqQCFRaACBxMC7uEGc6lQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.33.0",
         "picomatch": "^4.0.5",
@@ -9340,6 +9342,7 @@
       "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.10",
         "@vitest/mocker": "4.1.10",
@@ -9686,6 +9689,7 @@
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
       ],
       "devDependencies": {
         "husky": "^9.1.7",
-        "lint-staged": "^17.2.0"
+        "lint-staged": "^17.2.0",
+        "typescript": "~6.0.3"
       }
     },
     "frontend": {
@@ -8984,9 +8985,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   },
   "devDependencies": {
     "husky": "^9.1.7",
-    "lint-staged": "^17.2.0"
+    "lint-staged": "^17.2.0",
+    "typescript": "~6.0.3"
   },
   "lint-staged": {
     "frontend/**/*.{ts,tsx}": [

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -50,6 +50,7 @@ export default defineConfig({
 						{ label: 'Chapter digests', slug: 'features/chapter-digests' },
 						{ label: 'Flashcards', slug: 'features/flashcards' },
 						{ label: 'Book reflections', slug: 'features/book-reflections' },
+						{ label: 'Semantic search', slug: 'features/semantic-search' },
 					],
 				},
 				{

--- a/site/src/content/docs/features/chapter-digests.md
+++ b/site/src/content/docs/features/chapter-digests.md
@@ -24,6 +24,9 @@ and its gist if you wrote one.
 - **Generate summaries for all chapters** runs the whole book at once. Progress
   is shown as it goes, and you can cancel a run partway.
 
+The Structure tab also has a [semantic search](../semantic-search/) field, which
+keeps the chapters whose digest matches what you are looking for.
+
 Batch generation is what the optional
 [background worker](../../getting-started/optional-components/) is for — it
 processes the jobs outside the request, so you can close the page.

--- a/site/src/content/docs/features/highlights.md
+++ b/site/src/content/docs/features/highlights.md
@@ -30,6 +30,10 @@ Click a highlight to open it. From there you can step to the previous or next
 highlight, copy its text, copy a link to it, add tags, delete it, and switch
 between its linked notes and its flashcards.
 
+The tab's own search matches the words in a highlight. To find a passage by what
+it was about, across every book, use [semantic search](../semantic-search/) in
+the app bar.
+
 ## Highlight styles and labels
 
 A **highlight style** is the highlighter appearance you used on the device — a

--- a/site/src/content/docs/features/notes.md
+++ b/site/src/content/docs/features/notes.md
@@ -36,7 +36,9 @@ Notes are most useful attached to something.
 
 ## Finding them again
 
-The Notes tab filters by note kind and by tag, and each note opens in a reader
+The Notes tab has a [semantic search](../semantic-search/) field that finds
+notes by meaning rather than by wording, and it filters by note kind and by tag.
+Each note opens in a reader
 view where you can step to the next and previous note, copy its content or a
 link to it, edit it, or delete it. Notes can also be turned into
 [flashcards](../flashcards/).

--- a/site/src/content/docs/features/semantic-search.md
+++ b/site/src/content/docs/features/semantic-search.md
@@ -1,0 +1,91 @@
+---
+title: Semantic search
+description: Searching your highlights, notes and chapter digests by meaning — across every book, and across languages.
+---
+
+Semantic search finds content by **meaning** rather than by the words you typed.
+Searching for *attention* surfaces a highlight about staying focused even though
+it never uses the word, and a query in one language matches content written in
+another.
+
+It is optional: the search fields do not appear at all until an embedding
+provider is configured. See [Turning it on](#turning-it-on).
+
+## Searching every book
+
+The search field in the app bar searches your whole library. Type a query and
+press Enter — the search runs when you submit it, not on every keystroke,
+because each query is a call to the embedding model.
+
+The results are one ranked list, best match first, mixing three kinds of
+content:
+
+- **Highlights**, with the book and chapter they came from.
+- **Notes**, with their title and the start of the body.
+- **Chapters**, matched through their [chapter digest](../chapter-digests/).
+
+Pick a row to open the highlight, note or chapter it came from. The arrow keys
+move through the list, Enter opens the row you are on, and Escape closes it.
+On a narrow screen the app bar shows a search icon instead, which opens the same
+search full-screen.
+
+Matches that are only weakly similar are dropped, so a query with nothing to
+match comes back empty rather than showing ten confident-looking non-answers.
+
+## Searching inside one book
+
+Two of a book's tabs have a search field of their own, scoped to that book:
+
+- The **Notes** tab filters the notes by meaning. It combines with the kind and
+  tag filters — a note has to pass all of them — and orders the survivors best
+  match first.
+- The **Structure** tab searches the chapter digests and keeps the chapters
+  whose digest matched, so a chapter is findable this way once it has a digest.
+
+## Indexing your library
+
+Content is embedded in the background as you produce it: uploading highlights,
+writing or editing a [note](../notes/), and generating a
+[chapter digest](../chapter-digests/) each queue an embedding job. This is work
+for the optional
+[background worker](../../getting-started/optional-components/).
+
+Anything that existed before you switched semantic search on needs a one-time
+pass. In **Settings → Background processes**, choose **Run text embedding for
+the library**. Progress is shown while it runs and you can cancel it partway.
+Only content that has not been embedded yet is processed, so running it again
+later — after importing a few more books, say — is cheap.
+
+## Turning it on
+
+Semantic search is off unless `EMBEDDING_PROVIDER` is set. The settings are
+independent of the `AI_*` ones, so chapter digests and embeddings can use
+different providers.
+
+Local, through Ollama:
+
+```
+EMBEDDING_PROVIDER=ollama
+EMBEDDING_MODEL_NAME=bge-m3
+EMBEDDING_BASE_URL=http://localhost:11434/v1
+```
+
+Hosted, through OpenRouter, reusing `OPENROUTER_API_KEY`:
+
+```
+EMBEDDING_PROVIDER=openrouter
+EMBEDDING_MODEL_NAME=baai/bge-m3
+```
+
+`EMBEDDING_BASE_URL` is required for `ollama` and optional for `openrouter`,
+where it defaults to `https://openrouter.ai/api/v1`.
+
+Two more things the feature needs:
+
+- **PostgreSQL with the `vector` extension, version 0.8 or newer.** The
+  `docker-compose.yml` uses the `pgvector/pgvector:pg18` image, which has it.
+- **The background worker**, which is what writes the embeddings.
+
+The stored vectors are 1024 numbers wide, which is what `bge-m3` produces.
+A model of a different width is a database migration and a full re-index rather
+than a change of setting, so pick the model before you index the library.

--- a/site/src/content/docs/getting-started/optional-components.md
+++ b/site/src/content/docs/getting-started/optional-components.md
@@ -13,13 +13,22 @@ same Docker image as the main app with a different entrypoint.
 
 The worker requires AI provider configuration (`AI_PROVIDER`, API keys) to
 process AI-related tasks. You can adjust concurrency via `WORKER_CONCURRENCY`
-(default: 5).
+(default: 5). It is also what writes the embeddings behind
+[semantic search](../../features/semantic-search/).
 
 For development, run the worker separately:
 
 ```bash
 make dev-worker
 ```
+
+## Semantic search
+
+Searching highlights, notes and chapter digests by meaning is off unless an
+embedding provider is configured. It also needs the background worker above and
+a PostgreSQL with pgvector 0.8 or newer — the `docker-compose.yml` database
+image already has it. The environment variables are in
+[Semantic search](../../features/semantic-search/#turning-it-on).
 
 ## S3-compatible storage
 

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -43,6 +43,11 @@ import { Card, CardGrid, LinkCard } from '@astrojs/starlight/components';
 		Turn highlights, chapters and notes into question-and-answer cards, let the
 		AI suggest them for you, and study them in Anki.
 	</Card>
+	<Card title="Search by meaning" icon="magnifier">
+		Find a highlight, note or chapter by what it was about rather than by the
+		words in it — across every book, and across languages. Optional: it needs an
+		embedding provider.
+	</Card>
 	<Card title="Book reflections" icon="approve-check-circle">
 		Answer Adler's four analytical-reading questions about a book, and track
 		where each book stands with a reading stage.


### PR DESCRIPTION
Adds a global semantic search box to the app bar. A natural-language query searches every book, the backend's three result groups merge into one list ranked by score, capped at ten rows, and each row links into the dialog that already displays that content.

Design: `docs/superpowers/specs/2026-08-09-global-semantic-search-design.md`

## What changed

**Backend** — `cover_file` and `cover_blurhash` on `HighlightSearchItem`, `DigestSearchItem`, and `SearchBookRef`. `SearchHydrationQuery` already joined `BookORM` in all three selects, so this is two columns and no extra statements.

**Frontend** — a `GlobalSearch` component in the app bar:

- `md` and up: an inline field, results in a `Popper` under it.
- Below `md`: a search icon opens a full-screen dialog with the same state.
- Rows carry a cover, a type chip, two clamped lines of matched text, and the book plus chapter.
- Deep links: `/book/{id}/highlights?highlightId=`, `/book/{id}/notes?noteId=`, `/book/{id}/structure?chapterId=`.
- Keyboard: arrows move an active row, Enter opens it, first Escape closes keeping the query, second clears the field.
- Hidden entirely behind the `embeddings` feature flag.

Notes linking to no book are dropped — they have no page to open. Notes linking to several use the lowest book id, since the schema has no primary book.

## Two bugs worth knowing about

**Row links silently dropped their search params.** `<ListItemButton component={Link}>` makes MUI inject `href`, and TanStack Router then re-derives `search` by parsing that href's empty query string. Every row navigated to the right path and opened no dialog. Fixed with `createLink(ListItemButton)`. The click-through tests are what caught it.

**Tabbing away trapped keyboard users.** `SearchBar`'s `onBlur` re-commits the query, which re-opened the dropdown. Since the `Popper` is portaled, Tab moved focus to the hamburger with the dropdown still covering the page and no way to dismiss it. Fixed with a focus-containment check.

## Test coverage

58 frontend tests, 789 backend. The frontend suite runs real headless Chromium at both 1440x900 and 400x800 — the mobile branch resizes per-test via `page.viewport()` and restores in a `finally`.

Also fixes a test-isolation bug that predates this branch: a query fired by a mounted dialog could outlive its own test's `afterEach`, get orphaned by `worker.resetHandlers()`, and fail whichever test's cleanup happened to be running. `renderApp` now registers its `QueryClient` and `tests/setup.ts` waits, bounded and non-throwing, for it to go idle before resetting handlers. The strict unmocked-request guard is unchanged.

## Follow-ups, none blocking

- `waitForIdle` exits on the first idle read after one 20ms yield. Narrows the race rather than eliminating it; a two-read debounce would close it.
- The `SettingsPage.test.tsx` flake on `semantic/backfill/active` has not recurred in ~45 runs since the harness change. Suggestive, not proven.
- The `Popper` width goes stale on window resize. Cosmetic.
- Nobody has eyeballed the mobile UI on a device. The tests assert behaviour, not appearance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
