### PR TITLE
Replace dialog swipe navigation with explicit controls

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -36,8 +36,7 @@
     "react-blurhash": "^0.3.0",
     "react-dom": "^19.2.8",
     "react-hook-form": "^7.83.0",
-    "react-markdown": "^10.1.0",
-    "react-swipeable": "^7.0.2"
+    "react-markdown": "^10.1.0"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/frontend/src/components/dialogs/CommonDialog.test.tsx
+++ b/frontend/src/components/dialogs/CommonDialog.test.tsx
@@ -1,0 +1,72 @@
+import { CommonDialog } from '@/components/dialogs/CommonDialog';
+import { theme } from '@/theme/theme';
+import { ThemeProvider } from '@mui/material/styles';
+import { afterEach, expect, test, vi } from 'vitest';
+import { render } from 'vitest-browser-react';
+import { page, userEvent } from 'vitest/browser';
+
+/** The suite's own viewport, restored so a resize here can't leak sideways. */
+const DESKTOP = { width: 1440, height: 900 };
+const PHONE = { width: 390, height: 844 };
+
+afterEach(async () => {
+  await page.viewport(DESKTOP.width, DESKTOP.height);
+});
+
+const renderDialog = (props: Partial<Parameters<typeof CommonDialog>[0]> = {}) =>
+  render(
+    <ThemeProvider theme={theme}>
+      <CommonDialog open onClose={vi.fn()} title="Chapter three" {...props}>
+        <p>Body</p>
+      </CommonDialog>
+    </ThemeProvider>
+  );
+
+const aNavigation = (overrides = {}) => ({
+  hasPrevious: true,
+  hasNext: true,
+  onPrevious: vi.fn(),
+  onNext: vi.fn(),
+  ...overrides,
+});
+
+test('a phone pages between entities from arrows in the footer', async () => {
+  await page.viewport(PHONE.width, PHONE.height);
+  const navigation = aNavigation();
+  const screen = await renderDialog({ navigation });
+
+  await userEvent.click(screen.getByRole('button', { name: 'Next' }));
+  expect(navigation.onNext).toHaveBeenCalled();
+
+  await userEvent.click(screen.getByRole('button', { name: 'Previous' }));
+  expect(navigation.onPrevious).toHaveBeenCalled();
+});
+
+test('an end of the list retires its arrow rather than hiding it', async () => {
+  await page.viewport(PHONE.width, PHONE.height);
+  const screen = await renderDialog({ navigation: aNavigation({ hasPrevious: false }) });
+
+  await expect.element(screen.getByRole('button', { name: 'Previous' })).toBeDisabled();
+  await expect.element(screen.getByRole('button', { name: 'Next' })).toBeEnabled();
+});
+
+/**
+ * A wide screen navigates from the controls beside the content instead, so a
+ * footer holding nothing but hidden arrows would be an empty bar under the
+ * dialog — the reason the footer is conditional on having something to show.
+ */
+test('a wide screen renders no footer for navigation alone', async () => {
+  const screen = await renderDialog({ navigation: aNavigation() });
+
+  expect(screen.getByRole('button', { name: 'Next' }).elements()).toHaveLength(0);
+  expect(screen.getByRole('button', { name: 'Previous' }).elements()).toHaveLength(0);
+});
+
+test('footer actions still render on a wide screen', async () => {
+  const screen = await renderDialog({
+    navigation: aNavigation(),
+    footerActions: <button type="button">Save</button>,
+  });
+
+  await expect.element(screen.getByRole('button', { name: 'Save' })).toBeVisible();
+});

--- a/frontend/src/components/dialogs/CommonDialog.test.tsx
+++ b/frontend/src/components/dialogs/CommonDialog.test.tsx
@@ -30,8 +30,11 @@ const aNavigation = (overrides = {}) => ({
   ...overrides,
 });
 
-test('a phone pages between entities from arrows in the footer', async () => {
-  await page.viewport(PHONE.width, PHONE.height);
+test.for([
+  ['a phone', PHONE],
+  ['a wide screen', DESKTOP],
+] as const)('%s pages between entities from arrows in the footer', async ([, viewport]) => {
+  await page.viewport(viewport.width, viewport.height);
   const navigation = aNavigation();
   const screen = await renderDialog({ navigation });
 
@@ -51,22 +54,28 @@ test('an end of the list retires its arrow rather than hiding it', async () => {
 });
 
 /**
- * A wide screen navigates from the controls beside the content instead, so a
- * footer holding nothing but hidden arrows would be an empty bar under the
- * dialog — the reason the footer is conditional on having something to show.
+ * The footer is the one place paging is always available, so it carries the
+ * arrows even for a dialog that has no actions of its own to put beside them.
  */
-test('a wide screen renders no footer for navigation alone', async () => {
+test('navigation alone is enough to render the footer', async () => {
   const screen = await renderDialog({ navigation: aNavigation() });
+
+  await expect.element(screen.getByRole('button', { name: 'Next' })).toBeVisible();
+});
+
+test('a dialog with neither actions nor navigation renders no footer at all', async () => {
+  const screen = await renderDialog();
 
   expect(screen.getByRole('button', { name: 'Next' }).elements()).toHaveLength(0);
   expect(screen.getByRole('button', { name: 'Previous' }).elements()).toHaveLength(0);
 });
 
-test('footer actions still render on a wide screen', async () => {
+test('footer actions sit alongside the arrows', async () => {
   const screen = await renderDialog({
     navigation: aNavigation(),
     footerActions: <button type="button">Save</button>,
   });
 
   await expect.element(screen.getByRole('button', { name: 'Save' })).toBeVisible();
+  await expect.element(screen.getByRole('button', { name: 'Next' })).toBeVisible();
 });

--- a/frontend/src/components/dialogs/CommonDialog.tsx
+++ b/frontend/src/components/dialogs/CommonDialog.tsx
@@ -25,9 +25,10 @@ interface CommonDialogProps {
   children: ReactNode;
   footerActions?: ReactNode;
   /**
-   * Paging to the previous/next entity, rendered centred in the footer on
-   * phones only — wider screens have room for the controls beside the content
-   * (`CommonDialogHorizontalNavigation`).
+   * Paging to the previous/next entity, rendered centred in the footer at
+   * every width. Wider screens additionally get the controls beside the
+   * content (`CommonDialogHorizontalNavigation`); the footer is the pair that
+   * is always in the same place, whatever the dialog is showing.
    */
   navigation?: DialogNavigation;
   maxWidth?: 'xs' | 'sm' | 'md' | 'lg' | 'xl';
@@ -57,25 +58,24 @@ export const CommonDialog = ({
   const theme = useTheme();
   const fullScreen = useMediaQuery(theme.breakpoints.down('sm'));
 
-  const footerNavigation =
-    navigation && fullScreen ? (
-      <Box sx={{ display: 'flex', gap: 1 }}>
-        <IconButton
-          onClick={navigation.onPrevious}
-          disabled={!navigation.hasPrevious || isLoading}
-          aria-label="Previous"
-        >
-          <ArrowBackIcon />
-        </IconButton>
-        <IconButton
-          onClick={navigation.onNext}
-          disabled={!navigation.hasNext || isLoading}
-          aria-label="Next"
-        >
-          <ArrowForwardIcon />
-        </IconButton>
-      </Box>
-    ) : null;
+  const footerNavigation = navigation ? (
+    <Box sx={{ display: 'flex', gap: 1 }}>
+      <IconButton
+        onClick={navigation.onPrevious}
+        disabled={!navigation.hasPrevious || isLoading}
+        aria-label="Previous"
+      >
+        <ArrowBackIcon />
+      </IconButton>
+      <IconButton
+        onClick={navigation.onNext}
+        disabled={!navigation.hasNext || isLoading}
+        aria-label="Next"
+      >
+        <ArrowForwardIcon />
+      </IconButton>
+    </Box>
+  ) : null;
 
   // Lock body scroll when dialog is open
   useEffect(() => {

--- a/frontend/src/components/dialogs/CommonDialog.tsx
+++ b/frontend/src/components/dialogs/CommonDialog.tsx
@@ -1,4 +1,4 @@
-import { CloseIcon } from '@/theme/Icons.tsx';
+import { ArrowBackIcon, ArrowForwardIcon, CloseIcon } from '@/theme/Icons.tsx';
 import {
   Box,
   Dialog,
@@ -11,12 +11,25 @@ import {
 } from '@mui/material';
 import { useEffect, type ReactNode } from 'react';
 
+interface DialogNavigation {
+  hasPrevious: boolean;
+  hasNext: boolean;
+  onPrevious: () => void;
+  onNext: () => void;
+}
+
 interface CommonDialogProps {
   open: boolean;
   onClose: () => void;
   title: ReactNode;
   children: ReactNode;
   footerActions?: ReactNode;
+  /**
+   * Paging to the previous/next entity, rendered centred in the footer on
+   * phones only — wider screens have room for the controls beside the content
+   * (`CommonDialogHorizontalNavigation`).
+   */
+  navigation?: DialogNavigation;
   maxWidth?: 'xs' | 'sm' | 'md' | 'lg' | 'xl';
   isLoading?: boolean;
   headerElement?: ReactNode;
@@ -26,7 +39,7 @@ interface CommonDialogProps {
  * Common dialog component with standard structure:
  * - Header with title and close button
  * - Scrollable content area
- * - Optional footer with action buttons
+ * - Optional footer with action buttons and, on phones, entity paging
  * - Mobile-friendly with fullscreen mode on small screens
  * - Safe-area padding for devices with rounded corners (iPhone)
  */
@@ -36,12 +49,33 @@ export const CommonDialog = ({
   title,
   children,
   footerActions,
+  navigation,
   maxWidth = 'sm',
   isLoading = false,
   headerElement,
 }: CommonDialogProps) => {
   const theme = useTheme();
   const fullScreen = useMediaQuery(theme.breakpoints.down('sm'));
+
+  const footerNavigation =
+    navigation && fullScreen ? (
+      <Box sx={{ display: 'flex', gap: 1 }}>
+        <IconButton
+          onClick={navigation.onPrevious}
+          disabled={!navigation.hasPrevious || isLoading}
+          aria-label="Previous"
+        >
+          <ArrowBackIcon />
+        </IconButton>
+        <IconButton
+          onClick={navigation.onNext}
+          disabled={!navigation.hasNext || isLoading}
+          aria-label="Next"
+        >
+          <ArrowForwardIcon />
+        </IconButton>
+      </Box>
+    ) : null;
 
   // Lock body scroll when dialog is open
   useEffect(() => {
@@ -169,7 +203,7 @@ export const CommonDialog = ({
         <Box sx={{ px: 3 }}>{children}</Box>
       </DialogContent>
 
-      {footerActions && (
+      {(footerActions || footerNavigation) && (
         <DialogActions
           sx={{
             justifyContent: 'space-between',
@@ -180,7 +214,19 @@ export const CommonDialog = ({
             pl: 2,
           }}
         >
-          {footerActions}
+          {footerNavigation ? (
+            <>
+              {/* Spacer opposite the actions, so the arrows sit on the bar's
+                  centre rather than the centre of whatever is left over. */}
+              <Box sx={{ flex: 1 }} />
+              {footerNavigation}
+              <Box sx={{ flex: 1, display: 'flex', justifyContent: 'flex-end' }}>
+                {footerActions}
+              </Box>
+            </>
+          ) : (
+            footerActions
+          )}
         </DialogActions>
       )}
     </Dialog>

--- a/frontend/src/components/dialogs/CommonDialogHorizontalNavigation.tsx
+++ b/frontend/src/components/dialogs/CommonDialogHorizontalNavigation.tsx
@@ -12,10 +12,10 @@ interface CommonDialogHorizontalNavigationProps {
 /**
  * Previous/next controls flanking a modal's content.
  *
- * Only from `sm` up, where there is room beside the content for them. Narrower
- * than that the same navigation lives in the dialog footer, which `CommonDialog`
- * renders — a phone has no spare horizontal room, and the footer is within
- * thumb reach in a way the content's edges are not.
+ * Only from `sm` up, where there is room beside the content for them; a phone
+ * has none to spare. They duplicate the footer's arrows, which `CommonDialog`
+ * renders at every width — the same action within reach of where the eye
+ * already is, rather than only at the bottom of the dialog.
  *
  * An arrow at the end of the list stays in place and turns invisible rather
  * than unmounting, so the content column does not shift sideways as the reader

--- a/frontend/src/components/dialogs/CommonDialogHorizontalNavigation.tsx
+++ b/frontend/src/components/dialogs/CommonDialogHorizontalNavigation.tsx
@@ -1,104 +1,72 @@
+import type { DialogNavigation } from '@/components/dialogs/useDialogHorizontalNavigation.ts';
 import { ArrowBackIcon, ArrowForwardIcon } from '@/theme/Icons.tsx';
-import { Box, Button, IconButton } from '@mui/material';
+import { Box, IconButton } from '@mui/material';
 import type { ReactNode } from 'react';
-import type { SwipeableHandlers } from 'react-swipeable';
 
 interface CommonDialogHorizontalNavigationProps {
-  hasNavigation: boolean | undefined | ((newIndex: number) => void);
-  hasPrevious: boolean | undefined | ((newIndex: number) => void);
-  hasNext: boolean | undefined | ((newIndex: number) => void);
-  onPrevious: () => void;
-  onNext: () => void;
-  swipeHandlers?: SwipeableHandlers;
+  navigation?: DialogNavigation;
   disabled?: boolean;
   children: ReactNode;
 }
 
+/**
+ * Previous/next controls flanking a modal's content.
+ *
+ * Only from `sm` up, where there is room beside the content for them. Narrower
+ * than that the same navigation lives in the dialog footer, which `CommonDialog`
+ * renders — a phone has no spare horizontal room, and the footer is within
+ * thumb reach in a way the content's edges are not.
+ *
+ * An arrow at the end of the list stays in place and turns invisible rather
+ * than unmounting, so the content column does not shift sideways as the reader
+ * pages into the first or last entity.
+ */
 export const CommonDialogHorizontalNavigation = ({
-  hasNavigation,
-  hasPrevious,
-  hasNext,
-  onPrevious,
-  onNext,
-  swipeHandlers,
+  navigation,
   disabled,
   children,
 }: CommonDialogHorizontalNavigationProps) => (
-  <>
-    <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
-      {hasNavigation && (
-        <IconButton
-          onClick={onPrevious}
-          disabled={!hasPrevious || disabled}
-          sx={{
-            flexShrink: 0,
-            display: { xs: 'none', sm: 'inline-flex' },
-            visibility: hasPrevious ? 'visible' : 'hidden',
-          }}
-          aria-label="Previous"
-        >
-          <ArrowBackIcon />
-        </IconButton>
-      )}
-
-      <Box
-        {...swipeHandlers}
+  <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+    {navigation && (
+      <IconButton
+        onClick={navigation.onPrevious}
+        disabled={!navigation.hasPrevious || disabled}
         sx={{
-          display: 'flex',
-          flexDirection: 'column',
-          gap: 3,
-          flex: 1,
-          minWidth: 0,
+          flexShrink: 0,
+          display: { xs: 'none', sm: 'inline-flex' },
+          visibility: navigation.hasPrevious ? 'visible' : 'hidden',
         }}
+        aria-label="Previous"
       >
-        {children}
-      </Box>
+        <ArrowBackIcon />
+      </IconButton>
+    )}
 
-      {hasNavigation && (
-        <IconButton
-          onClick={onNext}
-          disabled={!hasNext || disabled}
-          sx={{
-            flexShrink: 0,
-            display: { xs: 'none', sm: 'inline-flex' },
-            visibility: hasNext ? 'visible' : 'hidden',
-          }}
-          aria-label="Next"
-        >
-          <ArrowForwardIcon />
-        </IconButton>
-      )}
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 3,
+        flex: 1,
+        minWidth: 0,
+      }}
+    >
+      {children}
     </Box>
 
-    {hasNavigation && (
-      <Box
+    {navigation && (
+      <IconButton
+        onClick={navigation.onNext}
+        disabled={!navigation.hasNext || disabled}
         sx={{
-          display: { xs: 'flex', sm: 'none' },
-          justifyContent: 'center',
-          gap: 2,
-          mt: 3,
-          pt: 1,
+          flexShrink: 0,
+          display: { xs: 'none', sm: 'inline-flex' },
+          visibility: navigation.hasNext ? 'visible' : 'hidden',
         }}
+        aria-label="Next"
       >
-        <Button
-          onClick={onPrevious}
-          disabled={!hasPrevious || disabled}
-          startIcon={<ArrowBackIcon />}
-          variant="outlined"
-          sx={{ flex: 1, maxWidth: '200px' }}
-        >
-          Previous
-        </Button>
-        <Button
-          onClick={onNext}
-          disabled={!hasNext || disabled}
-          endIcon={<ArrowForwardIcon />}
-          variant="outlined"
-          sx={{ flex: 1, maxWidth: '200px' }}
-        >
-          Next
-        </Button>
-      </Box>
+        <ArrowForwardIcon />
+      </IconButton>
     )}
-  </>
+  </Box>
 );

--- a/frontend/src/components/dialogs/DialogTabs.test.tsx
+++ b/frontend/src/components/dialogs/DialogTabs.test.tsx
@@ -9,7 +9,7 @@ import { userEvent } from 'vitest/browser';
  * arrow keys page to the previous/next entity.
  */
 const NavigableDialog = ({ onNavigate }: { onNavigate: (newIndex: number) => void }) => {
-  const { swipeHandlers } = useDialogHorizontalNavigation({
+  useDialogHorizontalNavigation({
     open: true,
     currentIndex: 1,
     totalCount: 3,
@@ -20,7 +20,6 @@ const NavigableDialog = ({ onNavigate }: { onNavigate: (newIndex: number) => voi
     <div>
       <button type="button">Body control</button>
       <DialogTabs
-        panelSwipeHandlers={swipeHandlers}
         tabs={[
           { key: 'notes', label: 'Notes', count: 1, content: <div>Linked notes</div> },
           { key: 'flashcards', label: 'Flashcards', count: 2, content: <div>Flashcard list</div> },

--- a/frontend/src/components/dialogs/DialogTabs.tsx
+++ b/frontend/src/components/dialogs/DialogTabs.tsx
@@ -1,6 +1,5 @@
 import { Box, Tab, Tabs } from '@mui/material';
 import { type ReactNode, useId, useState } from 'react';
-import type { SwipeableHandlers } from 'react-swipeable';
 
 export interface DialogTabItem {
   key: string;
@@ -12,8 +11,6 @@ export interface DialogTabItem {
 
 interface DialogTabsProps {
   tabs: DialogTabItem[];
-  /** Spread on the tab panel so swipes there can drive modal navigation. */
-  panelSwipeHandlers?: SwipeableHandlers;
   /**
    * Controlled mode: lift the tab state to the caller when it must survive
    * remounts (e.g. content wrapped in a keyed `FadeInOut`).
@@ -29,15 +26,8 @@ const formatTabLabel = (label: string, count?: number) =>
  * Shared tab strip + panel for the entity detail modals (highlight, note,
  * chapter). All tabs stay visible with an optional count suffix; only the
  * active tab's content is mounted, so sections can keep fetching lazily.
- * Touch events on the strip stop propagating so tab gestures don't trigger
- * the modals' horizontal swipe navigation.
  */
-export const DialogTabs = ({
-  tabs,
-  panelSwipeHandlers,
-  activeTab,
-  onTabChange,
-}: DialogTabsProps) => {
+export const DialogTabs = ({ tabs, activeTab, onTabChange }: DialogTabsProps) => {
   const [internalTab, setInternalTab] = useState(0);
   const instanceId = useId();
   const currentTab = activeTab ?? internalTab;
@@ -54,9 +44,6 @@ export const DialogTabs = ({
         variant="scrollable"
         scrollButtons="auto"
         sx={{ borderBottom: 1, borderColor: 'divider' }}
-        onTouchStart={(e) => e.stopPropagation()}
-        onTouchMove={(e) => e.stopPropagation()}
-        onTouchEnd={(e) => e.stopPropagation()}
         // Arrow keys belong to the tab strip while it holds focus; without this
         // the enclosing modal steals them to page to the previous/next entity.
         data-prevent-navigation="true"
@@ -75,7 +62,6 @@ export const DialogTabs = ({
         id={`${instanceId}-panel-${safeActiveTab}`}
         aria-labelledby={`${instanceId}-tab-${safeActiveTab}`}
         sx={{ pt: 2, pb: 2 }}
-        {...panelSwipeHandlers}
       >
         {tabs[safeActiveTab]?.content}
       </Box>

--- a/frontend/src/components/dialogs/useDialogHorizontalNavigation.ts
+++ b/frontend/src/components/dialogs/useDialogHorizontalNavigation.ts
@@ -1,9 +1,21 @@
-import { useCallback, useEffect, useRef } from 'react';
-import { useSwipeable } from 'react-swipeable';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 
 // Module-level stack to track active navigation dialogs.
 // Only the topmost dialog should handle keyboard navigation.
 let activeNavigationStack: symbol[] = [];
+
+/**
+ * Everything a previous/next control needs, or `undefined` when there is
+ * nothing to page between. One object so the dialog shell and the beside-the-
+ * content arrows are wired from the same value rather than five loose props
+ * restated at each dialog.
+ */
+export interface DialogNavigation {
+  hasPrevious: boolean;
+  hasNext: boolean;
+  onPrevious: () => void;
+  onNext: () => void;
+}
 
 interface UseDialogHorizontalNavigationOptions {
   open: boolean;
@@ -12,43 +24,17 @@ interface UseDialogHorizontalNavigationOptions {
   onNavigate?: (newIndex: number) => void;
 }
 
-export const useDialogSwipeNavigation = ({
-  currentIndex,
-  totalCount,
-  onNavigate,
-}: Omit<UseDialogHorizontalNavigationOptions, 'open'>) => {
-  const hasNavigation = totalCount > 1 && onNavigate;
-  const hasPrevious = hasNavigation && currentIndex > 0;
-  const hasNext = hasNavigation && currentIndex < totalCount - 1;
-
-  const handlePrevious = useCallback(() => {
-    if (hasPrevious) {
-      onNavigate!(currentIndex - 1);
-    }
-  }, [currentIndex, hasPrevious, onNavigate]);
-
-  const handleNext = useCallback(() => {
-    if (hasNext) {
-      onNavigate!(currentIndex + 1);
-    }
-  }, [currentIndex, hasNext, onNavigate]);
-
-  const swipeHandlers = useSwipeable({
-    onSwipedLeft: () => {
-      if (hasNext) handleNext();
-    },
-    onSwipedRight: () => {
-      if (hasPrevious) handlePrevious();
-    },
-    swipeDuration: 500,
-    preventScrollOnSwipe: false,
-  });
-
-  return {
-    swipeHandlers,
-  };
-};
-
+/**
+ * Paging between sibling entities in a detail modal: arrow keys, plus the
+ * flags its previous/next controls render from.
+ *
+ * Deliberately no swipe gesture. A horizontal drag anywhere in the dialog used
+ * to page the whole modal, which put it in competition with every horizontally
+ * scrollable thing inside one — carousels most of all, where the gesture to
+ * scroll a strip is exactly the gesture to leave the entity it belongs to. The
+ * controls are explicit instead: arrows in the footer on mobile, beside the
+ * content on wider screens.
+ */
 export const useDialogHorizontalNavigation = ({
   open,
   currentIndex,
@@ -117,18 +103,18 @@ export const useDialogHorizontalNavigation = ({
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, [open, hasNavigation, hasPrevious, hasNext, handlePrevious, handleNext]);
 
-  const { swipeHandlers } = useDialogSwipeNavigation({
-    currentIndex,
-    totalCount,
-    onNavigate,
-  });
+  const navigation: DialogNavigation | undefined = useMemo(
+    () =>
+      hasNavigation
+        ? {
+            hasPrevious: !!hasPrevious,
+            hasNext: !!hasNext,
+            onPrevious: handlePrevious,
+            onNext: handleNext,
+          }
+        : undefined,
+    [hasNavigation, hasPrevious, hasNext, handlePrevious, handleNext]
+  );
 
-  return {
-    hasNavigation,
-    hasPrevious,
-    hasNext,
-    handlePrevious,
-    handleNext,
-    swipeHandlers,
-  };
+  return { hasNavigation, navigation };
 };

--- a/frontend/src/components/search/RelatedContentSection.tsx
+++ b/frontend/src/components/search/RelatedContentSection.tsx
@@ -22,12 +22,7 @@ export const RelatedContentSection = ({ title, rows }: RelatedContentSectionProp
   if (rows.length === 0) return null;
 
   return (
-    <Box
-      sx={{ mt: 4, gap: 2, display: 'flex', flexDirection: 'column' }}
-      onTouchStart={(e) => e.stopPropagation()}
-      onTouchMove={(e) => e.stopPropagation()}
-      onTouchEnd={(e) => e.stopPropagation()}
-    >
+    <Box sx={{ mt: 4, gap: 2, display: 'flex', flexDirection: 'column' }}>
       <SectionTitle component="h3">{title}</SectionTitle>
       <Carousel aria-label={title}>
         {rows.map((row) => (

--- a/frontend/src/pages/BookPage/Highlights/HighlightViewDialog/HighlightViewDialog.tsx
+++ b/frontend/src/pages/BookPage/Highlights/HighlightViewDialog/HighlightViewDialog.tsx
@@ -12,7 +12,7 @@ import { useMutationErrorHandler } from '@/hooks/useMutationErrorHandler.ts';
 import { useCacheEvents } from '@/lib/cacheEvents.ts';
 import { useImmediateTagMutation } from '@/pages/BookPage/Highlights/HighlightViewDialog/hooks/useImmediateTagMutation.ts';
 import type { HighlightDialogController } from '@/pages/BookPage/Highlights/hooks/useHighlightDialog.ts';
-import { Box, Button, Stack } from '@mui/material';
+import { Box, Stack } from '@mui/material';
 import { useState } from 'react';
 import { HighlightContent } from '../../common/HighlightContent.tsx';
 import { HighlightTabs } from './components/HighlightTabs.tsx';
@@ -49,7 +49,7 @@ export const HighlightViewDialog = ({
     initialTags: highlight.tags,
   });
 
-  const { hasNavigation, hasPrevious, hasNext, handlePrevious, handleNext, swipeHandlers } =
+  const { hasNavigation, navigation } =
     useDialogHorizontalNavigation({
       open,
       currentIndex: controller.activeIndex,
@@ -135,23 +135,9 @@ export const HighlightViewDialog = ({
           <ProgressBar currentIndex={controller.activeIndex} totalCount={controller.totalCount} />
         ) : undefined
       }
-      footerActions={
-        <Box sx={{ display: 'flex', justifyContent: 'flex-end', width: '100%' }}>
-          <Button onClick={handleClose} disabled={isLoading}>
-            Close
-          </Button>
-        </Box>
-      }
+      navigation={navigation}
     >
-      <CommonDialogHorizontalNavigation
-        hasNavigation={hasNavigation}
-        hasPrevious={hasPrevious}
-        hasNext={hasNext}
-        onPrevious={handlePrevious}
-        onNext={handleNext}
-        swipeHandlers={swipeHandlers}
-        disabled={isLoading}
-      >
+      <CommonDialogHorizontalNavigation navigation={navigation} disabled={isLoading}>
         <FadeInOut ekey={highlight.id}>
           <HighlightContent highlight={highlight} onLabelClick={handleLabelClick} />
         </FadeInOut>

--- a/frontend/src/pages/BookPage/Highlights/HighlightViewDialog/HighlightViewDialog.tsx
+++ b/frontend/src/pages/BookPage/Highlights/HighlightViewDialog/HighlightViewDialog.tsx
@@ -49,13 +49,12 @@ export const HighlightViewDialog = ({
     initialTags: highlight.tags,
   });
 
-  const { hasNavigation, navigation } =
-    useDialogHorizontalNavigation({
-      open,
-      currentIndex: controller.activeIndex,
-      totalCount: controller.totalCount,
-      onNavigate: controller.navigateToIndex,
-    });
+  const { hasNavigation, navigation } = useDialogHorizontalNavigation({
+    open,
+    currentIndex: controller.activeIndex,
+    totalCount: controller.totalCount,
+    onNavigate: controller.navigateToIndex,
+  });
 
   const deleteHighlightMutation = useDeleteHighlights({
     mutation: {

--- a/frontend/src/pages/BookPage/Notes/NoteViewDialog.tsx
+++ b/frontend/src/pages/BookPage/Notes/NoteViewDialog.tsx
@@ -90,7 +90,7 @@ export const NoteViewDialog = ({
     setDeleteConfirmOpen(false);
   }
 
-  const { hasNavigation, hasPrevious, hasNext, handlePrevious, handleNext, swipeHandlers } =
+  const { navigation } =
     useDialogHorizontalNavigation({
       open: true,
       currentIndex: currentIndex ?? 0,
@@ -154,8 +154,10 @@ export const NoteViewDialog = ({
       .filter((highlight): highlight is Highlight => highlight !== undefined);
   }, [book.chapters, activeNote]);
 
+  // Only while editing: viewing has nothing to confirm, and the header's close
+  // button is the way out.
   const footerActions = isEditing ? (
-    <Box sx={{ display: 'flex', gap: 1, width: '100%', justifyContent: 'flex-end' }}>
+    <Box sx={{ display: 'flex', gap: 1, justifyContent: 'flex-end' }}>
       <Button onClick={() => setIsEditing(false)} disabled={formStatus.isSaving}>
         Cancel
       </Button>
@@ -167,13 +169,7 @@ export const NoteViewDialog = ({
         {formStatus.isSaving ? 'Saving...' : 'Save'}
       </Button>
     </Box>
-  ) : (
-    <Box sx={{ display: 'flex', justifyContent: 'flex-end', width: '100%' }}>
-      <Button onClick={onClose} disabled={isDeleting}>
-        Close
-      </Button>
-    </Box>
-  );
+  ) : undefined;
 
   return (
     <CommonDialog
@@ -199,16 +195,9 @@ export const NoteViewDialog = ({
         </CommonDialogTitle>
       }
       footerActions={footerActions}
+      navigation={navigation}
     >
-      <CommonDialogHorizontalNavigation
-        hasNavigation={hasNavigation}
-        hasPrevious={hasPrevious}
-        hasNext={hasNext}
-        onPrevious={handlePrevious}
-        onNext={handleNext}
-        swipeHandlers={swipeHandlers}
-        disabled={isDeleting}
-      >
+      <CommonDialogHorizontalNavigation navigation={navigation} disabled={isDeleting}>
         <Box
           sx={{
             mt: 2,

--- a/frontend/src/pages/BookPage/Notes/NoteViewDialog.tsx
+++ b/frontend/src/pages/BookPage/Notes/NoteViewDialog.tsx
@@ -90,14 +90,13 @@ export const NoteViewDialog = ({
     setDeleteConfirmOpen(false);
   }
 
-  const { navigation } =
-    useDialogHorizontalNavigation({
-      open: true,
-      currentIndex: currentIndex ?? 0,
-      totalCount: totalCount ?? 1,
-      // Suspend navigation while editing so arrows/swipes can't discard edits.
-      onNavigate: isEditing ? undefined : onNavigate,
-    });
+  const { navigation } = useDialogHorizontalNavigation({
+    open: true,
+    currentIndex: currentIndex ?? 0,
+    totalCount: totalCount ?? 1,
+    // Suspend navigation while editing so arrows/swipes can't discard edits.
+    onNavigate: isEditing ? undefined : onNavigate,
+  });
 
   const { data: activeNote, isLoading, isError } = useGetNote(noteId);
 

--- a/frontend/src/pages/BookPage/Notes/NotesPage.test.tsx
+++ b/frontend/src/pages/BookPage/Notes/NotesPage.test.tsx
@@ -48,7 +48,7 @@ test('renaming a note updates the notes list', async () => {
   const dialog = screen.getByRole('dialog');
   await userEvent.fill(dialog.getByRole('textbox', { name: 'Title' }), 'Difference Engine');
   await userEvent.click(dialog.getByRole('button', { name: 'Save' }));
-  await userEvent.click(dialog.getByRole('button', { name: 'Close', exact: true }));
+  await userEvent.click(dialog.getByRole('button', { name: 'Close dialog' }));
 
   await expect.element(screen.getByRole('heading', { name: 'Difference Engine' })).toBeVisible();
   expect(screen.getByRole('heading', { name: 'Analytical Engine' }).elements()).toHaveLength(0);
@@ -76,7 +76,7 @@ test('a failed save reports the error and leaves the note unchanged', async () =
     .toBeVisible();
 
   await userEvent.click(dialog.getByRole('button', { name: 'Cancel' }));
-  await userEvent.click(dialog.getByRole('button', { name: 'Close', exact: true }));
+  await userEvent.click(dialog.getByRole('button', { name: 'Close dialog' }));
 
   await expect.element(screen.getByRole('heading', { name: 'Analytical Engine' })).toBeVisible();
   expect(screen.getByRole('heading', { name: 'Difference Engine' }).elements()).toHaveLength(0);

--- a/frontend/src/pages/BookPage/Structure/ChapterDetailDialog/ChapterDetailDialog.tsx
+++ b/frontend/src/pages/BookPage/Structure/ChapterDetailDialog/ChapterDetailDialog.tsx
@@ -57,13 +57,12 @@ export const ChapterDetailDialog = ({
   const chapter = controller.activeItem!;
   const { activeIndex, totalCount, navigateToIndex } = controller;
 
-  const { hasNavigation, navigation } =
-    useDialogHorizontalNavigation({
-      open: controller.activeId !== null,
-      currentIndex: activeIndex,
-      totalCount,
-      onNavigate: navigateToIndex,
-    });
+  const { hasNavigation, navigation } = useDialogHorizontalNavigation({
+    open: controller.activeId !== null,
+    currentIndex: activeIndex,
+    totalCount,
+    onNavigate: navigateToIndex,
+  });
 
   const digestSummary = digestByChapterId[chapter.id];
 

--- a/frontend/src/pages/BookPage/Structure/ChapterDetailDialog/ChapterDetailDialog.tsx
+++ b/frontend/src/pages/BookPage/Structure/ChapterDetailDialog/ChapterDetailDialog.tsx
@@ -12,15 +12,12 @@ import { CommonDialogHorizontalNavigation } from '@/components/dialogs/CommonDia
 import { CommonDialogTitle } from '@/components/dialogs/CommonDialogTitle.tsx';
 import { DialogTabs, type DialogTabItem } from '@/components/dialogs/DialogTabs.tsx';
 import { ProgressBar } from '@/components/dialogs/ProgressBar.tsx';
-import {
-  useDialogHorizontalNavigation,
-  useDialogSwipeNavigation,
-} from '@/components/dialogs/useDialogHorizontalNavigation.ts';
+import { useDialogHorizontalNavigation } from '@/components/dialogs/useDialogHorizontalNavigation.ts';
 import type { UrlEntityDialogController } from '@/components/dialogs/useUrlEntityDialog.ts';
 import { useRelatedItems } from '@/components/search/useRelatedItems.ts';
 import { LinkedNotesSection } from '@/pages/BookPage/Notes/components/LinkedNotesSection.tsx';
 import { NoteEditorDialog } from '@/pages/BookPage/Notes/NoteEditorDialog';
-import { Box, Button } from '@mui/material';
+import { Box } from '@mui/material';
 import { sumBy } from 'lodash';
 import { useMemo, useState } from 'react';
 import { ChapterGistSection } from './ChapterGistSection.tsx';
@@ -60,25 +57,13 @@ export const ChapterDetailDialog = ({
   const chapter = controller.activeItem!;
   const { activeIndex, totalCount, navigateToIndex } = controller;
 
-  const { hasNavigation, hasPrevious, hasNext, handlePrevious, handleNext } =
+  const { hasNavigation, navigation } =
     useDialogHorizontalNavigation({
       open: controller.activeId !== null,
       currentIndex: activeIndex,
       totalCount,
       onNavigate: navigateToIndex,
     });
-
-  const { swipeHandlers: summarySwipeHandlers } = useDialogSwipeNavigation({
-    currentIndex: activeIndex,
-    totalCount,
-    onNavigate: navigateToIndex,
-  });
-
-  const { swipeHandlers: tabSwipeHandlers } = useDialogSwipeNavigation({
-    currentIndex: activeIndex,
-    totalCount,
-    onNavigate: navigateToIndex,
-  });
 
   const digestSummary = digestByChapterId[chapter.id];
 
@@ -166,18 +151,11 @@ export const ChapterDetailDialog = ({
     <Box>
       <ChapterGistSection chapterId={chapter.id} chapterName={chapter.name} notes={notes} />
 
-      <Box {...summarySwipeHandlers}>
-        <DigestSummarySection digestSummary={digestSummary} defaultExpanded={true} />
-      </Box>
+      <DigestSummarySection digestSummary={digestSummary} defaultExpanded={true} />
 
       <ChapterToolbar chapterId={chapter.id} bookId={bookId} hasSummary={!!digestSummary} />
 
-      <DialogTabs
-        tabs={tabs}
-        activeTab={activeTab}
-        onTabChange={setActiveTab}
-        panelSwipeHandlers={tabSwipeHandlers}
-      />
+      <DialogTabs tabs={tabs} activeTab={activeTab} onTabChange={setActiveTab} />
     </Box>
   );
 
@@ -193,19 +171,9 @@ export const ChapterDetailDialog = ({
             <ProgressBar currentIndex={activeIndex} totalCount={totalCount} />
           ) : undefined
         }
-        footerActions={
-          <Box sx={{ display: 'flex', justifyContent: 'flex-end', width: '100%' }}>
-            <Button onClick={controller.close}>Close</Button>
-          </Box>
-        }
+        navigation={navigation}
       >
-        <CommonDialogHorizontalNavigation
-          hasNavigation={hasNavigation}
-          hasPrevious={hasPrevious}
-          hasNext={hasNext}
-          onPrevious={handlePrevious}
-          onNext={handleNext}
-        >
+        <CommonDialogHorizontalNavigation navigation={navigation}>
           <FadeInOut ekey={chapter.id}>{renderContent()}</FadeInOut>
         </CommonDialogHorizontalNavigation>
       </CommonDialog>

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,8 +34,7 @@
         "react-blurhash": "^0.3.0",
         "react-dom": "^19.2.8",
         "react-hook-form": "^7.83.0",
-        "react-markdown": "^10.1.0",
-        "react-swipeable": "^7.0.2"
+        "react-markdown": "^10.1.0"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -8284,15 +8283,6 @@
       "peerDependencies": {
         "@types/react": ">=18",
         "react": ">=18"
-      }
-    },
-    "node_modules/react-swipeable": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/react-swipeable/-/react-swipeable-7.0.2.tgz",
-      "integrity": "sha512-v1Qx1l+aC2fdxKa9aKJiaU/ZxmJ5o98RMoFwUqAAzVWUcxgfHFXDDruCKXhw6zIYXm6V64JiHgP9f6mlME5l8w==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8.3 || ^17 || ^18 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/react-transition-group": {


### PR DESCRIPTION
Stacked on `implement-related-entries` (#577) — that branch is the base, since the carousel this reacts to lives there.

## Why

A horizontal drag anywhere in a detail modal paged the whole modal. That gesture is in direct competition with everything horizontally scrollable inside one, and the related-content carousels made it unworkable: the drag that scrolls a strip is the drag that leaves the entity the strip belongs to. The strip had already grown a touch-propagation guard just to survive, and the tab strip carried one before that — a sign the gesture was costing more than it earned.

## What changed

**Swipe is gone.** `react-swipeable` is removed as a dependency; with it go `useDialogSwipeNavigation`, `DialogTabs`' `panelSwipeHandlers`, and both touch-propagation guards that only existed to defend against it. Arrow-key paging is untouched.

**Paging is explicit, and the footer always has it.** Arrows sit centred in the dialog footer at every width — that's the one place they're always in, whatever the dialog is showing and however far it has scrolled. The arrows beside the content stay from `sm` up, putting the same action within reach of where the eye already is. Previously the mobile Previous/Next pair lived at the bottom of the *scrolling content*, so you had to scroll to the end of a chapter to page away from it.

**The footer's Close button is gone.** The header's close button already does that job. Note editing keeps its Cancel/Save: that's a real decision, not a second way out. A dialog with neither actions nor navigation renders no footer at all.

**One navigation object.** `useDialogHorizontalNavigation` returns `navigation` (or `undefined`) instead of five loose values, so the dialog shell and the beside-the-content arrows are wired from the same value. This replaced a ternary that was about to be restated at all three dialogs — jscpd caught it as a 19-line clone between the highlight and note dialogs, and collapsing it took the repo from 22 clones to 21.

## Worth a reviewer's eye

From `sm` up there are now **two** buttons named "Previous" and two named "Next" — the footer pair and the beside-content pair. That's the usual duplicated-pagination pattern and the labels are deliberately identical, but it does mean a `getByRole('button', { name: 'Next' })` against a whole dialog is ambiguous at desktop width. Worth knowing before writing app-level tests that page a dialog.

## Verification

65/66 tests, type-check, lint, knip clean. Duplication 1.5%, one clone below where this branch started.

New `CommonDialog.test.tsx` drives the footer at both 390×844 and 1440×900 (the suite runs at the latter, so it resizes and restores): arrows page in both directions at both widths, an end of the list disables its arrow rather than hiding it, navigation alone is enough to render the footer, and a dialog with neither actions nor navigation renders none.

`NotesPage.test.tsx` now closes via the header button, since the footer Close it used to click no longer exists.

**Not verified visually** — no browser available in this environment. Worth a look on a real phone, particularly that the arrows clear the safe-area padding.

The one failing test is `Carousel.test.tsx`'s paging-back case, which flakes here about half the time. It predates this branch — tracked in #578.

🤖 Generated with [Claude Code](https://claude.com/claude-code)