### PR TITLE
Fix duplicate chapter rows from ambiguous TOC parent resolution

### DIFF
--- a/backend/alembic/versions/064_merge_duplicate_chapters.py
+++ b/backend/alembic/versions/064_merge_duplicate_chapters.py
@@ -1,0 +1,122 @@
+"""Merge duplicate chapter rows produced by ambiguous TOC parent resolution
+
+Chapter sync used to resolve a TOC entry's parent by bare name, so re-uploading
+an EPUB whose titles repeat could attach a run's chapters to a different parent
+row than the previous run and re-create an entire subtree. Books also carry an
+older duplicate shape: a legacy row (start_xpoint NULL) beside the modern row
+the legacy-migration path never matched because the legacy row had a parent.
+
+Both shapes look the same in the data: several rows sharing
+(book_id, name, chapter_number), of which at most one distinct non-null
+start_xpoint exists. Duplicates are not cosmetic -- chapter_number is an
+identity for the ereader plugin's digest cache and for highlight upload, so a
+twin silently misroutes highlights and rolls back cache writes.
+
+For each such group one row is kept (the one carrying an xpoint, lowest id
+first) and the others are merged into it: children, highlights, flashcards,
+chat sessions and note links are repointed, the keeper's digest wins over the
+twin's, and the twin row is deleted.
+
+Note: repointing a dropped parent's children onto the keeper could in principle
+collide with uq_chapter_per_book (book_id, parent_id, name) if the keeper
+already had a same-named child from a different group. No such case exists in
+the data this repairs; a collision would abort the migration in its transaction
+rather than half-apply it.
+
+Revision ID: 064
+Revises: 063
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "064"
+down_revision: str | Sequence[str] | None = "063"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+BUILD_MERGE_MAP = """
+CREATE TEMP TABLE chapter_merge_map AS
+WITH ranked AS (
+    SELECT
+        id,
+        first_value(id) OVER (
+            PARTITION BY book_id, name, chapter_number
+            ORDER BY (start_xpoint IS NULL), id
+        ) AS keeper_id,
+        count(*) OVER (PARTITION BY book_id, name, chapter_number) AS group_size
+    FROM chapters
+)
+SELECT id AS dropped_id, keeper_id
+FROM ranked
+WHERE group_size > 1 AND id <> keeper_id
+"""
+
+# Children first: chapters.parent_id cascades on delete, so a dropped parent
+# would take its subtree with it. Only surviving children are repointed -- a
+# dropped child is deleted anyway, and moving it under the keeper would collide
+# with the twin already sitting there.
+REPOINT_STATEMENTS = [
+    """
+    UPDATE chapters c SET parent_id = m.keeper_id
+    FROM chapter_merge_map m
+    WHERE c.parent_id = m.dropped_id
+      AND NOT EXISTS (SELECT 1 FROM chapter_merge_map d WHERE d.dropped_id = c.id)
+    """,
+    """
+    UPDATE highlights h SET chapter_id = m.keeper_id
+    FROM chapter_merge_map m WHERE h.chapter_id = m.dropped_id
+    """,
+    """
+    UPDATE flashcards f SET chapter_id = m.keeper_id
+    FROM chapter_merge_map m WHERE f.chapter_id = m.dropped_id
+    """,
+    """
+    UPDATE ai_chat_sessions s SET chapter_id = m.keeper_id
+    FROM chapter_merge_map m WHERE s.chapter_id = m.dropped_id
+    """,
+    # note_chapters is keyed by (note_id, chapter_id): drop the links that would
+    # collide with one the keeper already has, then move the rest.
+    """
+    DELETE FROM note_chapters n USING chapter_merge_map m
+    WHERE n.chapter_id = m.dropped_id
+      AND EXISTS (
+          SELECT 1 FROM note_chapters existing
+          WHERE existing.note_id = n.note_id AND existing.chapter_id = m.keeper_id
+      )
+    """,
+    """
+    UPDATE note_chapters n SET chapter_id = m.keeper_id
+    FROM chapter_merge_map m WHERE n.chapter_id = m.dropped_id
+    """,
+    # chapter_digests is unique per chapter: the keeper's digest wins, and the
+    # dropped digest's embeddings cascade away with it.
+    """
+    DELETE FROM chapter_digests d USING chapter_merge_map m
+    WHERE d.chapter_id = m.dropped_id
+      AND EXISTS (
+          SELECT 1 FROM chapter_digests existing WHERE existing.chapter_id = m.keeper_id
+      )
+    """,
+    """
+    UPDATE chapter_digests d SET chapter_id = m.keeper_id
+    FROM chapter_merge_map m WHERE d.chapter_id = m.dropped_id
+    """,
+    """
+    DELETE FROM chapters c USING chapter_merge_map m WHERE c.id = m.dropped_id
+    """,
+]
+
+
+def upgrade() -> None:
+    op.execute(BUILD_MERGE_MAP)
+    for statement in REPOINT_STATEMENTS:
+        op.execute(statement)
+    op.execute("DROP TABLE chapter_merge_map")
+
+
+def downgrade() -> None:
+    # Irreversible: the merged rows and their digests are gone.
+    pass

--- a/backend/src/application/library/commands/book_files/ebook_upload_use_case.py
+++ b/backend/src/application/library/commands/book_files/ebook_upload_use_case.py
@@ -145,6 +145,7 @@ class EbookUploadUseCase:
                         name=tc.name,
                         chapter_number=tc.chapter_number,
                         parent_name=tc.parent_name,
+                        parent_index=tc.parent_index,
                         start_xpoint=tc.start_xpoint,
                         end_xpoint=tc.end_xpoint,
                         start_position=start_pos,

--- a/backend/src/domain/library/entities/chapter.py
+++ b/backend/src/domain/library/entities/chapter.py
@@ -11,8 +11,10 @@ from src.domain.common.value_objects.position import Position
 class TocChapter:
     """A chapter entry parsed from an EPUB Table of Contents.
 
-    Parent relationships are expressed by name since DB IDs
-    aren't assigned yet during parsing.
+    Parent relationships are expressed by name since DB IDs aren't assigned yet
+    during parsing. Names repeat within a TOC, so `parent_index` -- the position
+    of the parent entry in the same flattened TOC list, None for roots -- is the
+    unambiguous link; `parent_name` remains for callers that have no index.
     """
 
     name: str
@@ -22,6 +24,7 @@ class TocChapter:
     end_xpoint: str | None
     start_position: Position | None = None
     end_position: Position | None = None
+    parent_index: int | None = None
 
 
 @dataclass

--- a/backend/src/infrastructure/library/repositories/chapter_repository.py
+++ b/backend/src/infrastructure/library/repositories/chapter_repository.py
@@ -174,13 +174,31 @@ class ChapterRepository:
             return chapter
         return None
 
+    @staticmethod
+    def _resolve_parent_id(
+        ch: TocChapter,
+        resolved: dict[int, ChapterORM],
+        tracker: _ChapterTracker,
+    ) -> int | None:
+        """Resolve the DB id of a TOC entry's parent.
+
+        `parent_index` points at a position in the TOC list being synced, and every
+        processed entry records the row it resolved to, so the parent is exact even
+        when several chapters share a name. Only callers that build TocChapter
+        without indexes fall back to the ambiguous by-name lookup.
+        """
+        if ch.parent_index is None:
+            return tracker.resolve_parent_id(ch.parent_name)
+        parent = resolved.get(ch.parent_index)
+        return parent.id if parent is not None else None
+
     async def _create_chapter_orm(
         self,
         book_id: BookId,
         ch: TocChapter,
         parent_id: int | None,
         tracker: _ChapterTracker,
-    ) -> None:
+    ) -> ChapterORM:
         """Create a new chapter ORM, persist it, and register in tracker."""
         chapter = ChapterORM(
             book_id=book_id.value,
@@ -196,6 +214,7 @@ class ChapterRepository:
         await self.db.commit()
         await self.db.refresh(chapter)
         tracker.register_new(chapter)
+        return chapter
 
     async def sync_chapters_from_toc(
         self,
@@ -236,14 +255,19 @@ class ChapterRepository:
         updated: list[ChapterORM] = []
         created_count = 0
 
-        # Stage 2: Process each TOC entry (sequential -- parents before children)
-        for ch in chapters:
-            parent_id = tracker.resolve_parent_id(ch.parent_name)
+        # Stage 2: Process each TOC entry (sequential -- parents before children).
+        # `resolved` maps a TOC entry's position to the row it resolved to, which is
+        # what a child's parent_index refers to.
+        resolved: dict[int, ChapterORM] = {}
+
+        for index, ch in enumerate(chapters):
+            parent_id = self._resolve_parent_id(ch, resolved, tracker)
             key = (ch.name, parent_id)
             existing_chapter = tracker.find_by_key(key)
 
             # Case 1: Exact match by (name, parent_id)
             if existing_chapter is not None:
+                resolved[index] = existing_chapter
                 if not tracker.is_from_db(key):
                     logger.warning(
                         f"Duplicate chapter '{ch.name}' in ToC with same parent "
@@ -262,10 +286,11 @@ class ChapterRepository:
                 self._apply_field_updates(legacy, ch, parent_id)
                 updated.append(legacy)
                 tracker.rekey_legacy(legacy, old_key=(ch.name, None), new_key=key)
+                resolved[index] = legacy
                 continue
 
             # Case 3: Truly new chapter
-            await self._create_chapter_orm(book_id, ch, parent_id, tracker)
+            resolved[index] = await self._create_chapter_orm(book_id, ch, parent_id, tracker)
             created_count += 1
 
         # Stage 3: Commit updates

--- a/backend/src/infrastructure/library/services/epub_parser_service.py
+++ b/backend/src/infrastructure/library/services/epub_parser_service.py
@@ -4,7 +4,7 @@
 
 import logging
 from io import BytesIO
-from typing import Any, cast
+from typing import Any, NamedTuple, cast
 from urllib.parse import unquote
 
 import ebooklib
@@ -17,44 +17,76 @@ from src.infrastructure.common.memory import trims_memory
 logger = logging.getLogger(__name__)
 
 
+class _TocEntry(NamedTuple):
+    """A flattened TOC entry; `parent_index` points into the same flattened list."""
+
+    title: str
+    chapter_number: int
+    parent_name: str | None
+    parent_index: int | None
+    href: str | None
+
+
 def _extract_toc_hierarchy(
-    toc_items: list[Any], current_number: int = 1, parent_name: str | None = None
-) -> list[tuple[str, int, str | None, str | None]]:
+    toc_items: list[Any],
+    entries: list[_TocEntry] | None = None,
+    parent_name: str | None = None,
+    parent_index: int | None = None,
+) -> list[_TocEntry]:
     """
-    Extract hierarchical TOC structure into a list preserving parent relationships.
+    Flatten the TOC tree into reading order, preserving parent relationships.
+
+    Entries are appended to one shared list, so an entry's position in that list
+    is its identity: children record the list index of their parent, which stays
+    unambiguous when several chapters share a title.
 
     Args:
         toc_items: List of TOC items from ebooklib (can be Link objects or tuples)
-        current_number: Starting chapter number (used for recursion)
+        entries: Accumulator shared across recursion levels (None starts a new list)
         parent_name: Name of the parent chapter (None for root-level chapters)
+        parent_index: Index of the parent entry in `entries` (None for root-level)
 
     Returns:
-        List of (chapter_title, chapter_number, parent_name, href) tuples in reading order.
+        The flattened list of TOC entries in reading order.
     """
-    chapters: list[tuple[str, int, str | None, str | None]] = []
+    if entries is None:
+        entries = []
 
     for item in toc_items:
         if isinstance(item, tuple):
             section, children = item[0], item[1] if len(item) > 1 else []
 
             if hasattr(section, "title"):
-                href = getattr(section, "href", None)
-                chapters.append((section.title, current_number, parent_name, href))
+                section_index = len(entries)
+                entries.append(
+                    _TocEntry(
+                        title=section.title,
+                        chapter_number=section_index + 1,
+                        parent_name=parent_name,
+                        parent_index=parent_index,
+                        href=getattr(section, "href", None),
+                    )
+                )
                 section_name = section.title
-                current_number += 1
             else:
+                # Untitled section: its children hang off the enclosing parent.
                 section_name = parent_name
+                section_index = parent_index
 
-            child_chapters = _extract_toc_hierarchy(children, current_number, section_name)
-            chapters.extend(child_chapters)
-            current_number += len(child_chapters)
+            _extract_toc_hierarchy(children, entries, section_name, section_index)
 
         elif hasattr(item, "title"):
-            href = getattr(item, "href", None)
-            chapters.append((item.title, current_number, parent_name, href))
-            current_number += 1
+            entries.append(
+                _TocEntry(
+                    title=item.title,
+                    chapter_number=len(entries) + 1,
+                    parent_name=parent_name,
+                    parent_index=parent_index,
+                    href=getattr(item, "href", None),
+                )
+            )
 
-    return chapters
+    return entries
 
 
 class EpubParserService:
@@ -105,7 +137,7 @@ class EpubParserService:
                 logger.info("EPUB has no table of contents")
                 return []
 
-            chapters_with_hrefs = _extract_toc_hierarchy(toc)
+            toc_entries = _extract_toc_hierarchy(toc)
 
             spine_mapping = self._build_href_to_spine_index(book)
             result: list[TocChapter] = []
@@ -113,15 +145,17 @@ class EpubParserService:
 
             # First pass: compute start_xpoints (with precise fragment resolution)
             start_xpoints: list[str | None] = []
-            for _title, _number, _parent, href in chapters_with_hrefs:
-                if href:
-                    xpoint = self._resolve_href_to_xpoint(book, href, spine_mapping, html_cache)
+            for entry in toc_entries:
+                if entry.href:
+                    xpoint = self._resolve_href_to_xpoint(
+                        book, entry.href, spine_mapping, html_cache
+                    )
                     start_xpoints.append(xpoint)
                 else:
                     start_xpoints.append(None)
 
             # Second pass: compute end_xpoints (next chapter's start_xpoint)
-            for i, (title, number, parent, _href) in enumerate(chapters_with_hrefs):
+            for i, entry in enumerate(toc_entries):
                 start_xpoint = start_xpoints[i]
                 end_xpoint = None
                 for j in range(i + 1, len(start_xpoints)):
@@ -130,9 +164,10 @@ class EpubParserService:
                         break
                 result.append(
                     TocChapter(
-                        name=title,
-                        chapter_number=number,
-                        parent_name=parent,
+                        name=entry.title,
+                        chapter_number=entry.chapter_number,
+                        parent_name=entry.parent_name,
+                        parent_index=entry.parent_index,
                         start_xpoint=start_xpoint,
                         end_xpoint=end_xpoint,
                     )

--- a/backend/tests/test_epub_toc_chapters.py
+++ b/backend/tests/test_epub_toc_chapters.py
@@ -30,6 +30,7 @@ def toc_ch(
     parent: str | None = None,
     start: str | None = None,
     end: str | None = None,
+    parent_index: int | None = None,
 ) -> TocChapter:
     """Shorthand for constructing TocChapter in tests."""
     return TocChapter(
@@ -38,6 +39,7 @@ def toc_ch(
         parent_name=parent,
         start_xpoint=start,
         end_xpoint=end,
+        parent_index=parent_index,
     )
 
 
@@ -513,6 +515,115 @@ class TestUpdatingExistingChapters:
 
         # Verify they are distinct chapters
         assert harjoitukset1.id != harjoitukset2.id
+
+
+class TestRepeatedSyncWithRepeatedNames:
+    """Test that re-syncing a TOC whose names repeat across levels is idempotent.
+
+    The KOReader plugin re-uploads the EPUB on every sync, so sync_chapters_from_toc
+    runs repeatedly over the same TOC. Resolving parents by bare name made run 2 pick a
+    different parent row than run 1 (last-write-wins over a repeated name), so the
+    (name, parent_id) keys missed and a whole subtree was created a second time. Every
+    duplicate chapter_number then breaks the plugin's digest cache and misroutes
+    highlights, which key chapters by number.
+    """
+
+    @staticmethod
+    def _repeated_name_toc() -> list[TocChapter]:
+        """A TOC repeating a parent name ("Luku") and a child name ("Yhteenveto").
+
+        Osa I / Luku / {Yhteenveto, Itsetuntemus}, Osa II / Luku / Yhteenveto.
+        """
+        return [
+            toc_ch("Osa I", 1, start="/body/DocFragment[1]/body"),
+            toc_ch("Luku", 2, "Osa I", "/body/DocFragment[2]/body", parent_index=0),
+            toc_ch("Yhteenveto", 3, "Luku", "/body/DocFragment[3]/body", parent_index=1),
+            toc_ch("Itsetuntemus", 4, "Luku", "/body/DocFragment[4]/body", parent_index=1),
+            toc_ch("Osa II", 5, start="/body/DocFragment[5]/body"),
+            toc_ch("Luku", 6, "Osa II", "/body/DocFragment[6]/body", parent_index=4),
+            toc_ch("Yhteenveto", 7, "Luku", "/body/DocFragment[7]/body", parent_index=5),
+        ]
+
+    async def test_second_sync_creates_no_duplicates(
+        self,
+        chapter_repo: ChapterRepository,
+        test_book_for_toc: models.Book,
+        db_session: AsyncSession,
+    ) -> None:
+        toc = self._repeated_name_toc()
+
+        first_count = await chapter_repo.sync_chapters_from_toc(
+            book_id=BookId(test_book_for_toc.id), user_id=UserId(1), chapters=toc
+        )
+        assert first_count == 7
+
+        result = await db_session.execute(
+            select(models.Chapter)
+            .filter_by(book_id=test_book_for_toc.id)
+            .order_by(models.Chapter.chapter_number)
+        )
+        ids_after_first = [ch.id for ch in result.scalars().all()]
+
+        second_count = await chapter_repo.sync_chapters_from_toc(
+            book_id=BookId(test_book_for_toc.id), user_id=UserId(1), chapters=toc
+        )
+
+        assert second_count == 0
+
+        result = await db_session.execute(
+            select(models.Chapter)
+            .filter_by(book_id=test_book_for_toc.id)
+            .order_by(models.Chapter.chapter_number)
+        )
+        db_chapters = result.scalars().all()
+
+        # Same rows as after the first sync -- nothing created, nothing orphaned
+        assert [ch.id for ch in db_chapters] == ids_after_first
+
+        # chapter_number is an identity for the ereader plugin: it must stay unique
+        numbers = [ch.chapter_number for ch in db_chapters]
+        assert numbers == [1, 2, 3, 4, 5, 6, 7]
+        pairs = [(ch.name, ch.chapter_number) for ch in db_chapters]
+        assert len(set(pairs)) == len(pairs)
+
+        osa1, luku1, yhteenveto1, itsetuntemus, osa2, luku2, yhteenveto2 = db_chapters
+        assert luku1.parent_id == osa1.id
+        assert luku2.parent_id == osa2.id
+        assert yhteenveto1.parent_id == luku1.id
+        assert itsetuntemus.parent_id == luku1.id
+        assert yhteenveto2.parent_id == luku2.id
+
+    async def test_repeated_names_are_placed_under_the_indexed_parent(
+        self,
+        chapter_repo: ChapterRepository,
+        test_book_for_toc: models.Book,
+        db_session: AsyncSession,
+    ) -> None:
+        """parent_index wins over parent_name when the name is ambiguous.
+
+        Both "Luku" sections carry parent_name "Osa I", but the indexes say otherwise;
+        the rows must follow the indexes.
+        """
+        toc = [
+            toc_ch("Osa I", 1),
+            toc_ch("Osa II", 2),
+            toc_ch("Luku", 3, "Osa I", parent_index=0),
+            toc_ch("Luku", 4, "Osa I", parent_index=1),
+        ]
+
+        created = await chapter_repo.sync_chapters_from_toc(
+            book_id=BookId(test_book_for_toc.id), user_id=UserId(1), chapters=toc
+        )
+
+        assert created == 4
+        result = await db_session.execute(
+            select(models.Chapter)
+            .filter_by(book_id=test_book_for_toc.id)
+            .order_by(models.Chapter.chapter_number)
+        )
+        osa1, osa2, luku_a, luku_b = result.scalars().all()
+        assert luku_a.parent_id == osa1.id
+        assert luku_b.parent_id == osa2.id
 
 
 class TestLegacyFlatChapterMigration:

--- a/backend/tests/unit/infrastructure/library/services/test_epub_parser_service.py
+++ b/backend/tests/unit/infrastructure/library/services/test_epub_parser_service.py
@@ -1,4 +1,4 @@
-"""Tests for EpubParserService.extract_cover."""
+"""Tests for EpubParserService cover extraction and TOC parsing."""
 
 from pathlib import Path
 
@@ -61,9 +61,103 @@ def _create_epub_without_cover(path: Path) -> Path:
     return _write_epub(book, path, "no_cover.epub")
 
 
+def _create_epub_with_repeated_toc_titles(path: Path) -> Path:
+    """Create an EPUB whose nested TOC repeats titles at two levels.
+
+    Shape (mirrors a real book that produced duplicate chapter rows)::
+
+        Osa I
+          Luku
+            Yhteenveto
+            Itsetuntemus
+        Osa II
+          Luku
+            Yhteenveto
+    """
+    book = epub.EpubBook()
+    book.set_identifier("test-repeated-toc")
+    book.set_title("Repeated TOC")
+    book.set_language("fi")
+
+    files = ["osa1", "luku1", "yhteenveto1", "itsetuntemus", "osa2", "luku2", "yhteenveto2"]
+    documents = []
+    for name in files:
+        document = epub.EpubHtml(title=name, file_name=f"{name}.xhtml", lang="fi")
+        document.content = f"<html><body><p>{name}</p></body></html>".encode()
+        book.add_item(document)
+        documents.append(document)
+
+    book.spine = documents
+    book.add_item(epub.EpubNcx())
+    book.add_item(epub.EpubNav())
+    book.toc = [
+        (
+            epub.Section("Osa I", href="osa1.xhtml"),
+            (
+                (
+                    epub.Section("Luku", href="luku1.xhtml"),
+                    (
+                        epub.Link("yhteenveto1.xhtml", "Yhteenveto", "y1"),
+                        epub.Link("itsetuntemus.xhtml", "Itsetuntemus", "i1"),
+                    ),
+                ),
+            ),
+        ),
+        (
+            epub.Section("Osa II", href="osa2.xhtml"),
+            (
+                (
+                    epub.Section("Luku", href="luku2.xhtml"),
+                    (epub.Link("yhteenveto2.xhtml", "Yhteenveto", "y2"),),
+                ),
+            ),
+        ),
+    ]
+
+    epub_path = path / "repeated_toc.epub"
+    epub.write_epub(str(epub_path), book)
+    return epub_path
+
+
 @pytest.fixture
 def service() -> EpubParserService:
     return EpubParserService()
+
+
+class TestParseTocHierarchy:
+    """Test that parse_toc flattens a nested TOC with unambiguous parent links."""
+
+    def test_repeated_titles_get_distinct_parent_indexes(
+        self, service: EpubParserService, tmp_path: Path
+    ) -> None:
+        epub_path = _create_epub_with_repeated_toc_titles(tmp_path)
+
+        chapters = service.parse_toc(epub_path.read_bytes())
+
+        assert [ch.name for ch in chapters] == [
+            "Osa I",
+            "Luku",
+            "Yhteenveto",
+            "Itsetuntemus",
+            "Osa II",
+            "Luku",
+            "Yhteenveto",
+        ]
+        # Chapter numbers are sequential and unique across the whole TOC
+        assert [ch.chapter_number for ch in chapters] == [1, 2, 3, 4, 5, 6, 7]
+        # Each entry points at its parent's position, so the two "Luku" sections
+        # and the two "Yhteenveto" leaves stay distinguishable despite the names
+        assert [ch.parent_index for ch in chapters] == [None, 0, 1, 1, None, 4, 5]
+        # parent_name is kept for callers without indexes
+        assert [ch.parent_name for ch in chapters] == [
+            None,
+            "Osa I",
+            "Luku",
+            "Luku",
+            None,
+            "Osa II",
+            "Luku",
+        ]
 
 
 class TestExtractCoverFromOPFMeta:


### PR DESCRIPTION
## Problem

Chapter TOC sync resolved a parent by bare name. Books that repeat chapter names at several levels (e.g. book 50, "Yhteenveto" ×9) resolved parents differently across repeated EPUB uploads, re-creating entire subtrees: 68 duplicate `(book_id, name, chapter_number)` groups existed in production (37 in book 50 alone, plus older legacy-row twins in books 3/9/12/42).

Duplicate `chapter_number`s are not cosmetic: the KOReader plugin's offline digest cache uses `(client_book_id, chapter_number)` as its primary key — one duplicate rolled back the whole cache write, leaving "no digest generated for this book yet" permanently — and `get_by_numbers` misroutes highlights on upload.

## Changes

- **Parser**: the flattened TOC now records each entry's `parent_index` (position of the parent in the same list), so parent identity survives repeated names. `chapter_number` is assigned from list position (unchanged for well-formed TOCs).
- **Repository**: `sync_chapters_from_toc` resolves parents through the toc-index map; the by-name lookup remains only as a fallback for callers without indexes. Repeated syncs are now idempotent — covered by a test that fails against the old resolution.
- **Migration 064**: merges existing duplicate groups. Keeper = the row with a non-null `start_xpoint` (lowest id). Children, highlights, flashcards, chat sessions and note links are repointed; the keeper's digest wins over a twin's (twin digests and their embeddings are removed); twins deleted. Verified on a production clone: 68 → 0 duplicate groups, 78 highlights repointed, no orphans, re-runnable.

## Verification

- pyright: 0 errors; full suite: 803 passed; import-linter: 5 contracts kept; jscpd unchanged.
- Migration applied to a prod clone and spot-checked (book 50 subtree intact under surviving parents).

🤖 Generated with [Claude Code](https://claude.com/claude-code)