### PR TITLE
Bring the MCP server up to date with the current API

### DIFF
--- a/.claude/hooks/format-all.sh
+++ b/.claude/hooks/format-all.sh
@@ -11,7 +11,7 @@ root="${CLAUDE_PROJECT_DIR:-$(git -C "$(dirname "$file_path")" rev-parse --show-
 [[ -z "$root" ]] && exit 0
 
 # Backend Python files
-if [[ "$file_path" == *.py ]]; then
+if [[ "$file_path" == "$root/backend/"*.py ]]; then
   (cd "$root/backend" && uv run ruff format "$file_path" && uv run ruff check --fix "$file_path" && uv run pyright "$file_path")
 fi
 

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -13,6 +13,7 @@ Model Context Protocol (MCP) server that exposes the Crossbill reading companion
 - View reading sessions
 - Semantic search over highlights, notes, and chapter digests
 - Create, read, update, and delete markdown notes
+- Generate chapter digests and AI flashcard suggestions
 
 ## Installation
 
@@ -111,14 +112,33 @@ crossbill-mcp
 ### Flashcards
 
 - **get_flashcards** - Get all flashcards for a book
-- **create_flashcard** - Create a flashcard, optionally linked to a highlight
+- **create_flashcard** - Create a flashcard, optionally anchored to a `highlight_id`, `note_id`, or `chapter_id` (give at most one)
 - **update_flashcard** - Update a flashcard's question and/or answer
 - **delete_flashcard** - Delete a flashcard
+
+The three suggestion tools below require an AI provider configured on the Crossbill server; without one they report that AI features are not enabled. They only suggest question/answer pairs — nothing is saved until you pass one to `create_flashcard`.
+
+- **suggest_flashcards_for_chapter** - Suggest flashcards from a chapter's digest (the chapter must already have one)
+- **suggest_flashcards_for_highlight** - Suggest flashcards from a highlight's text
+- **suggest_flashcards_for_note** - Suggest flashcards from a note and its linked highlights
 
 ### Reading
 
 - **get_reading_sessions** - Get reading sessions for a book
 - **get_chapter_content** - Get full text content of a chapter from the EPUB
+
+### Chapter Digests
+
+A digest is an AI-written study aid for one chapter: a summary, a list of keypoints, and comprehension questions with answers. Generating one requires an AI provider configured on the Crossbill server; without one, `generate_chapter_digest` and `generate_book_digests` report that AI features are not enabled.
+
+- **get_chapter_digest** - Get a chapter's existing digest, or a note that it has none yet
+- **generate_chapter_digest** - Generate one chapter's digest synchronously; this makes an AI call and can take tens of seconds
+- **answer_digest_question** - Record the user's answer to one question, by its zero-based index into the digest's questions
+- **get_book_digests** - Get every chapter digest a book has
+- **generate_book_digests** - Enqueue digest generation for all of a book's chapters as a background job batch
+- **get_digest_generation_status** - Get the active digest batch for a book, for polling progress
+- **get_job_batch** - Get any job batch by ID, with its status and progress counts
+- **cancel_job_batch** - Cancel a job batch and abort the jobs in it that have not run yet
 
 ### Bookmarks
 

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -15,6 +15,7 @@ Model Context Protocol (MCP) server that exposes the Crossbill reading companion
 - Semantic search over highlights, notes, and chapter digests
 - Create, read, update, and delete markdown notes
 - Generate chapter digests and AI flashcard suggestions
+- Delete books and highlights, behind a confirmation prompt the server enforces
 
 ## Installation
 
@@ -88,6 +89,27 @@ export CROSSBILL_PASSWORD=your-password
 crossbill-mcp
 ```
 
+## Deleting data
+
+Two tools throw content away rather than change it:
+
+- **delete_book** - Delete a book with all its chapters and highlights. A hard delete: syncing the book from KOReader again recreates it, but the notes, flashcards, tags and digests Crossbill kept alongside it are gone
+- **delete_highlights** - Delete highlights from a book. The deletion sticks, so later syncs of that book will not bring them back
+
+Neither one deletes anything on the assistant's say-so. Before touching the API, the server asks you to confirm through MCP elicitation, spelling out what is about to go: the book's title and how many chapters and highlights it holds, or how many highlights and from which book. Only an explicit yes goes through; declining or dismissing the prompt leaves everything in place.
+
+The prompt comes from the server, not from the assistant, so it cannot be talked around. If your MCP client does not support elicitation, the deletion is refused outright and you are pointed at the Crossbill web UI instead — a client that cannot ask you is a client that cannot delete.
+
+Every deletion tool in the server (these two plus `delete_note`, `delete_flashcard`, `delete_tag`, `delete_tag_group` and `delete_bookmark`) is annotated `destructiveHint: true`, which clients can use to treat them differently from the rest. If you allowlist the whole Crossbill server in Claude Code, keep the delete tools behind a prompt:
+
+```json
+{
+  "permissions": {
+    "ask": ["mcp__crossbill__delete_*"]
+  }
+}
+```
+
 ## Available Tools
 
 ### Books
@@ -96,6 +118,7 @@ crossbill-mcp
 - **get_book** - Get detailed book info with chapters and highlights
 - **get_recently_viewed_books** - Get recently viewed books
 - **set_reading_stage** - Set a book's manual reading stage (`to_read`, `skimming`, `reading`, `finished`, `reflected`), or clear it back to the stage Crossbill infers from reading activity
+- **delete_book** - Delete a book with all its chapters and highlights, after asking you to confirm (see [Deleting data](#deleting-data))
 
 ### Highlights
 
@@ -103,6 +126,7 @@ crossbill-mcp
 - **update_highlight_note** - Add or update a note on a highlight, or clear it by omitting the note
 - **tag_highlight** - Add a tag to a highlight
 - **untag_highlight** - Remove a tag from a highlight
+- **delete_highlights** - Delete one or more highlights from a book, after asking you to confirm (see [Deleting data](#deleting-data))
 
 ### Highlight Labels
 

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -100,7 +100,7 @@ crossbill-mcp
 ### Highlights
 
 - **get_highlights** - Get highlights from a book, optionally filtered by search
-- **update_highlight_note** - Add or update a note on a highlight
+- **update_highlight_note** - Add or update a note on a highlight, or clear it by omitting the note
 - **tag_highlight** - Add a tag to a highlight
 - **untag_highlight** - Remove a tag from a highlight
 
@@ -126,7 +126,7 @@ The three suggestion tools below require an AI provider configured on the Crossb
 
 ### Reading
 
-- **get_reading_sessions** - Get reading sessions for a book
+- **get_reading_sessions** - Get reading sessions for a book, with `limit` and `offset` for paging
 - **get_chapter_content** - Get full text content of a chapter from the EPUB
 - **get_reading_session_summary** - Get an AI summary of what was read in one session, cached after the first call. Requires an AI provider configured on the Crossbill server
 
@@ -145,6 +145,7 @@ A digest is an AI-written study aid for one chapter: a summary, a list of keypoi
 
 ### Bookmarks
 
+- **list_bookmarks** - Get every bookmark in a book
 - **create_bookmark** - Bookmark a highlight
 - **delete_bookmark** - Delete a bookmark
 

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -12,6 +12,7 @@ Model Context Protocol (MCP) server that exposes the Crossbill reading companion
 - Manage bookmarks
 - View reading sessions
 - Semantic search over highlights, notes, and chapter digests
+- Create, read, update, and delete markdown notes
 
 ## Installation
 
@@ -130,3 +131,13 @@ Requires an embedding provider configured on the Crossbill server; without one, 
 
 - **semantic_search** - Rank highlights, notes, and chapter digests by semantic similarity to a natural-language query, optionally scoped to one book. Results are grouped by content type, with `limit` applied per group.
 - **find_related** - Find content similar to an existing item, named by `content_type` (`note`, `highlight`, or `digest`) and `content_id`. Same grouped response shape as `semantic_search`.
+
+### Notes
+
+Notes are markdown documents that belong to a book and can be linked to that book's chapters and highlights, and to tags. A note may carry an optional `kind`: `character`, `term`, `concept`, `gist`, `reflection`, or `other`.
+
+- **create_note** - Create a note in a book from a title and markdown body, optionally with a kind and links to chapters, highlights, and tags
+- **get_note** - Get one note with its linked chapters, highlights, tags, and flashcards
+- **get_book_notes** - List a book's notes, optionally filtered by `kind`, `chapter_id`, `highlight_id`, or `tag_id` (filters combine)
+- **update_note** - Replace a note's fields and links in full. Anything omitted is cleared, so fetch the note with `get_note` first and resend everything you want to keep
+- **delete_note** - Delete a note and its links

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -7,10 +7,11 @@ Model Context Protocol (MCP) server that exposes the Crossbill reading companion
 - Browse and search your book library
 - Read chapter content from EPUB files
 - Search and annotate highlights
-- Tag highlights
+- Tag highlights, and manage a book's tags and tag groups
 - Create, update, and delete flashcards
 - Manage bookmarks
-- View reading sessions
+- View reading sessions and their AI summaries
+- Track a book's reading stage and its four-question reflection
 - Semantic search over highlights, notes, and chapter digests
 - Create, read, update, and delete markdown notes
 - Generate chapter digests and AI flashcard suggestions
@@ -94,6 +95,7 @@ crossbill-mcp
 - **list_books** - List books with optional search and pagination
 - **get_book** - Get detailed book info with chapters and highlights
 - **get_recently_viewed_books** - Get recently viewed books
+- **set_reading_stage** - Set a book's manual reading stage (`to_read`, `skimming`, `reading`, `finished`, `reflected`), or clear it back to the stage Crossbill infers from reading activity
 
 ### Highlights
 
@@ -126,6 +128,7 @@ The three suggestion tools below require an AI provider configured on the Crossb
 
 - **get_reading_sessions** - Get reading sessions for a book
 - **get_chapter_content** - Get full text content of a chapter from the EPUB
+- **get_reading_session_summary** - Get an AI summary of what was read in one session, cached after the first call. Requires an AI provider configured on the Crossbill server
 
 ### Chapter Digests
 
@@ -161,3 +164,21 @@ Notes are markdown documents that belong to a book and can be linked to that boo
 - **get_book_notes** - List a book's notes, optionally filtered by `kind`, `chapter_id`, `highlight_id`, or `tag_id` (filters combine)
 - **update_note** - Replace a note's fields and links in full. Anything omitted is cleared, so fetch the note with `get_note` first and resend everything you want to keep
 - **delete_note** - Delete a note and its links
+
+### Tags
+
+Tags belong to one book and can be attached to that book's highlights and notes. A tag group is an optional folder gathering related tags; a tag outside every group has a null `tag_group_id`.
+
+- **get_book_tags** - Get every tag of a book, with the group each one belongs to
+- **create_tag** - Create a tag in a book (to tag a highlight, use `tag_highlight`, which creates the tag by name when needed)
+- **update_tag** - Rename a tag and/or move it into a tag group
+- **delete_tag** - Delete a tag, which also removes it from every highlight carrying it
+- **create_or_rename_tag_group** - Create a tag group, or rename an existing one by passing its `tag_group_id`
+- **delete_tag_group** - Delete a tag group, leaving the tags in it ungrouped
+
+### Reflection
+
+A book's reflection is its answers to four fixed questions: what is it about, what does it say, do I agree, so what. An answer is not text but a reference to the note holding that answer's markdown, so answering means writing a note first and passing its ID. The reflection also links the book's term and concept notes.
+
+- **get_book_reflection** - Get a book's reflection; every book has one, unanswered questions are null
+- **update_book_reflection** - Replace a reflection in full. Anything omitted is cleared, so fetch it with `get_book_reflection` first and resend everything you want to keep

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -11,6 +11,7 @@ Model Context Protocol (MCP) server that exposes the Crossbill reading companion
 - Create, update, and delete flashcards
 - Manage bookmarks
 - View reading sessions
+- Semantic search over highlights, notes, and chapter digests
 
 ## Installation
 
@@ -122,3 +123,10 @@ crossbill-mcp
 
 - **create_bookmark** - Bookmark a highlight
 - **delete_bookmark** - Delete a bookmark
+
+### Semantic Search
+
+Requires an embedding provider configured on the Crossbill server; without one, both tools report that semantic search is not enabled.
+
+- **semantic_search** - Rank highlights, notes, and chapter digests by semantic similarity to a natural-language query, optionally scoped to one book. Results are grouped by content type, with `limit` applied per group.
+- **find_related** - Find content similar to an existing item, named by `content_type` (`note`, `highlight`, or `digest`) and `content_id`. Same grouped response shape as `semantic_search`.

--- a/mcp-server/pyproject.toml
+++ b/mcp-server/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "MCP server for Crossbill reading companion"
 requires-python = ">=3.11"
 dependencies = [
-    "mcp>=1.0.0",
+    "mcp>=1.0.0,<2",
     "httpx>=0.27.0",
     "pydantic>=2.0.0",
 ]

--- a/mcp-server/src/crossbill_mcp/ai_gate.py
+++ b/mcp-server/src/crossbill_mcp/ai_gate.py
@@ -1,0 +1,27 @@
+"""Shared handling for endpoints gated behind an AI provider."""
+
+import json
+from collections.abc import Awaitable
+from typing import Any
+
+import httpx
+
+AI_DISABLED_MESSAGE = (
+    "AI features are not enabled on this Crossbill server "
+    "(no AI provider configured)."
+)
+
+
+async def ai_gated_json(call: Awaitable[Any]) -> str:
+    """Await an AI-gated client call and return its result as JSON.
+
+    Answers with AI_DISABLED_MESSAGE when the server reports HTTP 410, which
+    is how it says no AI provider is configured.
+    """
+    try:
+        result = await call
+    except httpx.HTTPStatusError as exc:
+        if exc.response.status_code == 410:
+            return AI_DISABLED_MESSAGE
+        raise
+    return json.dumps(result, indent=2, default=str)

--- a/mcp-server/src/crossbill_mcp/client.py
+++ b/mcp-server/src/crossbill_mcp/client.py
@@ -110,6 +110,16 @@ class CrossbillClient:
         )
         return response.json()
 
+    async def set_reading_stage(
+        self, book_id: int, reading_stage: str | None = None
+    ) -> None:
+        """Set a book's manual reading stage, or clear it when given None."""
+        await self._request(
+            "PUT",
+            f"/api/v1/books/{book_id}/reading-stage",
+            json={"reading_stage": reading_stage},
+        )
+
     # --- Highlight endpoints ---
 
     async def search_highlights(self, book_id: int, search_text: str) -> dict:
@@ -328,6 +338,15 @@ class CrossbillClient:
         )
         return response.json()
 
+    async def get_reading_session_summary(self, reading_session_id: int) -> dict:
+        """Get a reading session's AI summary, generating it when not cached."""
+        response = await self._request(
+            "GET",
+            f"/api/v1/{reading_session_id}/ai_summary",
+            timeout=300.0,
+        )
+        return response.json()
+
     # --- Chapter content endpoint ---
 
     async def get_chapter_content(self, chapter_id: int) -> dict:
@@ -496,4 +515,82 @@ class CrossbillClient:
     async def delete_note(self, note_id: int) -> dict:
         """Delete a note."""
         response = await self._request("DELETE", f"/api/v1/notes/{note_id}")
+        return response.json()
+
+    # --- Tag endpoints ---
+
+    async def get_book_tags(self, book_id: int) -> dict:
+        """Get all tags of a book."""
+        response = await self._request("GET", f"/api/v1/books/{book_id}/tags")
+        return response.json()
+
+    async def create_tag(self, book_id: int, name: str) -> dict:
+        """Create a tag in a book."""
+        response = await self._request(
+            "POST", f"/api/v1/books/{book_id}/tag", json={"name": name}
+        )
+        return response.json()
+
+    async def update_tag(
+        self,
+        book_id: int,
+        tag_id: int,
+        name: str | None = None,
+        tag_group_id: int | None = None,
+    ) -> dict:
+        """Update a tag's name and/or the tag group it belongs to."""
+        response = await self._request(
+            "POST",
+            f"/api/v1/books/{book_id}/tag/{tag_id}",
+            json={"name": name, "tag_group_id": tag_group_id},
+        )
+        return response.json()
+
+    async def delete_tag(self, book_id: int, tag_id: int) -> None:
+        """Delete a tag from a book and from every highlight carrying it."""
+        await self._request("DELETE", f"/api/v1/books/{book_id}/tag/{tag_id}")
+
+    async def create_or_rename_tag_group(
+        self, book_id: int, name: str, tag_group_id: int | None = None
+    ) -> dict:
+        """Create a tag group, or rename an existing one when its ID is given."""
+        response = await self._request(
+            "POST",
+            "/api/v1/tag-groups",
+            json={"id": tag_group_id, "book_id": book_id, "name": name},
+        )
+        return response.json()
+
+    async def delete_tag_group(self, tag_group_id: int) -> None:
+        """Delete a tag group."""
+        await self._request("DELETE", f"/api/v1/tag-groups/{tag_group_id}")
+
+    # --- Book reflection endpoints ---
+
+    async def get_book_reflection(self, book_id: int) -> dict:
+        """Get a book's reflection: the note IDs answering its four questions."""
+        response = await self._request("GET", f"/api/v1/books/{book_id}/reflection")
+        return response.json()
+
+    async def update_book_reflection(
+        self,
+        book_id: int,
+        what_is_it_about_note_id: int | None = None,
+        what_does_it_say_note_id: int | None = None,
+        do_i_agree_note_id: int | None = None,
+        so_what_note_id: int | None = None,
+        note_ids: list[int] | None = None,
+    ) -> dict:
+        """Replace a book's reflection in full."""
+        response = await self._request(
+            "PUT",
+            f"/api/v1/books/{book_id}/reflection",
+            json={
+                "what_is_it_about_note_id": what_is_it_about_note_id,
+                "what_does_it_say_note_id": what_does_it_say_note_id,
+                "do_i_agree_note_id": do_i_agree_note_id,
+                "so_what_note_id": so_what_note_id,
+                "note_ids": note_ids or [],
+            },
+        )
         return response.json()

--- a/mcp-server/src/crossbill_mcp/client.py
+++ b/mcp-server/src/crossbill_mcp/client.py
@@ -325,3 +325,85 @@ class CrossbillClient:
             },
         )
         return response.json()
+
+    # --- Note endpoints ---
+
+    async def create_note(
+        self,
+        book_id: int,
+        title: str,
+        body: str = "",
+        kind: str | None = None,
+        chapter_ids: list[int] | None = None,
+        highlight_ids: list[int] | None = None,
+        tag_ids: list[int] | None = None,
+    ) -> dict:
+        """Create a note in a book, optionally linked to chapters/highlights/tags."""
+        json_body: dict[str, Any] = {
+            "title": title,
+            "body": body,
+            "kind": kind,
+            "book_id": book_id,
+            "chapter_ids": chapter_ids or [],
+            "highlight_ids": highlight_ids or [],
+            "tag_ids": tag_ids or [],
+        }
+        response = await self._request("POST", "/api/v1/notes", json=json_body)
+        return response.json()
+
+    async def get_note(self, note_id: int) -> dict:
+        """Get a note with its linked chapters, highlights, tags and flashcards."""
+        response = await self._request("GET", f"/api/v1/notes/{note_id}")
+        return response.json()
+
+    async def get_book_notes(
+        self,
+        book_id: int,
+        kind: str | None = None,
+        chapter_id: int | None = None,
+        highlight_id: int | None = None,
+        tag_id: int | None = None,
+    ) -> dict:
+        """List a book's notes, optionally filtered by kind or linked entity."""
+        params: dict[str, str | int] = {}
+        if kind is not None:
+            params["kind"] = kind
+        if chapter_id is not None:
+            params["chapter_id"] = chapter_id
+        if highlight_id is not None:
+            params["highlight_id"] = highlight_id
+        if tag_id is not None:
+            params["tag_id"] = tag_id
+        response = await self._request(
+            "GET", f"/api/v1/books/{book_id}/notes", params=params
+        )
+        return response.json()
+
+    async def update_note(
+        self,
+        note_id: int,
+        title: str,
+        body: str = "",
+        kind: str | None = None,
+        chapter_ids: list[int] | None = None,
+        highlight_ids: list[int] | None = None,
+        tag_ids: list[int] | None = None,
+    ) -> dict:
+        """Replace a note's fields and links in full."""
+        json_body: dict[str, Any] = {
+            "title": title,
+            "body": body,
+            "kind": kind,
+            "chapter_ids": chapter_ids or [],
+            "highlight_ids": highlight_ids or [],
+            "tag_ids": tag_ids or [],
+        }
+        response = await self._request(
+            "PUT", f"/api/v1/notes/{note_id}", json=json_body
+        )
+        return response.json()
+
+    async def delete_note(self, note_id: int) -> dict:
+        """Delete a note."""
+        response = await self._request("DELETE", f"/api/v1/notes/{note_id}")
+        return response.json()

--- a/mcp-server/src/crossbill_mcp/client.py
+++ b/mcp-server/src/crossbill_mcp/client.py
@@ -120,6 +120,10 @@ class CrossbillClient:
             json={"reading_stage": reading_stage},
         )
 
+    async def delete_book(self, book_id: int) -> None:
+        """Hard-delete a book with all of its chapters and highlights."""
+        await self._request("DELETE", f"/api/v1/books/{book_id}")
+
     # --- Highlight endpoints ---
 
     async def search_highlights(self, book_id: int, search_text: str) -> dict:
@@ -128,6 +132,15 @@ class CrossbillClient:
             "GET",
             f"/api/v1/books/{book_id}/highlights",
             params={"searchText": search_text},
+        )
+        return response.json()
+
+    async def delete_highlights(self, book_id: int, highlight_ids: list[int]) -> dict:
+        """Soft-delete highlights so later syncs do not bring them back."""
+        response = await self._request(
+            "DELETE",
+            f"/api/v1/books/{book_id}/highlight",
+            json={"highlight_ids": highlight_ids},
         )
         return response.json()
 

--- a/mcp-server/src/crossbill_mcp/client.py
+++ b/mcp-server/src/crossbill_mcp/client.py
@@ -298,3 +298,30 @@ class CrossbillClient:
         """Get the full text content of a chapter."""
         response = await self._request("GET", f"/api/v1/chapters/{chapter_id}/content")
         return response.json()
+
+    # --- Semantic search endpoints ---
+
+    async def semantic_search(
+        self, query: str, book_id: int | None = None, limit: int = 10
+    ) -> dict:
+        """Search embedded content by semantic similarity, grouped by content type."""
+        params: dict[str, str | int] = {"q": query, "limit": limit}
+        if book_id is not None:
+            params["book_id"] = book_id
+        response = await self._request("GET", "/api/v1/semantic/search", params=params)
+        return response.json()
+
+    async def related_content(
+        self, content_type: str, content_id: int, limit: int = 10
+    ) -> dict:
+        """Find content semantically similar to one already-indexed item."""
+        response = await self._request(
+            "GET",
+            "/api/v1/semantic/related",
+            params={
+                "content_type": content_type,
+                "content_id": content_id,
+                "limit": limit,
+            },
+        )
+        return response.json()

--- a/mcp-server/src/crossbill_mcp/client.py
+++ b/mcp-server/src/crossbill_mcp/client.py
@@ -184,6 +184,21 @@ class CrossbillClient:
             )
         return response.json()
 
+    async def create_note_flashcard(
+        self,
+        note_id: int,
+        question: str,
+        answer: str,
+        book_id: int | None = None,
+    ) -> dict:
+        """Create a flashcard linked to a note."""
+        response = await self._request(
+            "POST",
+            f"/api/v1/notes/{note_id}/flashcards",
+            json={"question": question, "answer": answer, "book_id": book_id},
+        )
+        return response.json()
+
     async def update_flashcard(
         self,
         flashcard_id: int,
@@ -204,6 +219,27 @@ class CrossbillClient:
     async def delete_flashcard(self, flashcard_id: int) -> dict:
         """Delete a flashcard."""
         response = await self._request("DELETE", f"/api/v1/flashcards/{flashcard_id}")
+        return response.json()
+
+    async def get_chapter_flashcard_suggestions(self, chapter_id: int) -> dict:
+        """Get AI flashcard suggestions from a chapter's digest."""
+        response = await self._request(
+            "GET", f"/api/v1/chapters/{chapter_id}/flashcard_suggestions"
+        )
+        return response.json()
+
+    async def get_highlight_flashcard_suggestions(self, highlight_id: int) -> dict:
+        """Get AI flashcard suggestions for a highlight."""
+        response = await self._request(
+            "GET", f"/api/v1/highlights/{highlight_id}/flashcard_suggestions"
+        )
+        return response.json()
+
+    async def get_note_flashcard_suggestions(self, note_id: int) -> dict:
+        """Get AI flashcard suggestions for a note."""
+        response = await self._request(
+            "GET", f"/api/v1/notes/{note_id}/flashcard_suggestions"
+        )
         return response.json()
 
     # --- Bookmark endpoints ---
@@ -297,6 +333,60 @@ class CrossbillClient:
     async def get_chapter_content(self, chapter_id: int) -> dict:
         """Get the full text content of a chapter."""
         response = await self._request("GET", f"/api/v1/chapters/{chapter_id}/content")
+        return response.json()
+
+    # --- Digest endpoints ---
+
+    async def get_chapter_digest(self, chapter_id: int) -> dict | None:
+        """Get a chapter's existing digest, or None when it has none."""
+        response = await self._request("GET", f"/api/v1/chapters/{chapter_id}/digest")
+        return response.json()
+
+    async def generate_chapter_digest(self, chapter_id: int) -> dict:
+        """Generate a chapter's digest synchronously with one AI call."""
+        response = await self._request(
+            "POST",
+            f"/api/v1/chapters/{chapter_id}/digest/generate",
+            timeout=300.0,
+        )
+        return response.json()
+
+    async def update_digest_answers(
+        self, chapter_id: int, answers: list[dict[str, Any]]
+    ) -> dict:
+        """Record user answers to a digest's comprehension questions."""
+        response = await self._request(
+            "PUT",
+            f"/api/v1/chapters/{chapter_id}/digest/answers",
+            json={"answers": answers},
+        )
+        return response.json()
+
+    async def get_book_digests(self, book_id: int) -> dict:
+        """Get the digest of every chapter in a book that has one."""
+        response = await self._request("GET", f"/api/v1/books/{book_id}/digest")
+        return response.json()
+
+    # --- Job batch endpoints ---
+
+    async def enqueue_book_digests(self, book_id: int) -> dict:
+        """Enqueue digest generation for all chapters of a book."""
+        response = await self._request("POST", f"/api/v1/jobs/books/{book_id}/digest")
+        return response.json()
+
+    async def get_active_book_digest_batch(self, book_id: int) -> dict | None:
+        """Get the active digest batch for a book, or None when there is none."""
+        response = await self._request("GET", f"/api/v1/jobs/books/{book_id}/digest")
+        return response.json()
+
+    async def get_job_batch(self, batch_id: int) -> dict:
+        """Get a job batch's status and progress counts."""
+        response = await self._request("GET", f"/api/v1/jobs/batches/{batch_id}")
+        return response.json()
+
+    async def cancel_job_batch(self, batch_id: int) -> dict:
+        """Cancel a job batch and abort its pending jobs."""
+        response = await self._request("DELETE", f"/api/v1/jobs/batches/{batch_id}")
         return response.json()
 
     # --- Semantic search endpoints ---

--- a/mcp-server/src/crossbill_mcp/confirm.py
+++ b/mcp-server/src/crossbill_mcp/confirm.py
@@ -1,0 +1,48 @@
+"""Server-enforced user confirmation for destructive MCP tools."""
+
+from mcp.server.fastmcp import Context
+from mcp.server.session import ServerSession
+from mcp.types import ClientCapabilities, ElicitationCapability
+from pydantic import BaseModel, Field
+
+NO_ELICITATION_MESSAGE = (
+    "Deletion not performed: this client does not support confirmation "
+    "prompts (MCP elicitation). Delete this from the Crossbill web UI "
+    "instead."
+)
+
+CANCELLED_MESSAGE = "Deletion cancelled by user."
+
+REQUIRES_USER_INTERACTION = {"anthropic/requiresUserInteraction": True}
+
+
+class DeletionConfirmation(BaseModel):
+    """The single yes/no field the user answers before a deletion runs."""
+
+    confirm: bool = Field(
+        default=False,
+        title="Delete permanently",
+        description="Tick to confirm this deletion. Leave unticked to cancel.",
+    )
+
+
+async def block_unconfirmed_deletion(
+    ctx: Context[ServerSession, None], message: str
+) -> str | None:
+    """Ask the user to confirm a deletion before it happens.
+
+    Returns None when the user explicitly confirmed and the caller may go
+    ahead. Otherwise returns the message the tool should hand back instead of
+    deleting anything: clients that never declared the elicitation capability
+    cannot be asked at all, so their deletions are refused outright.
+    """
+    supports_elicitation = ctx.session.check_client_capability(
+        ClientCapabilities(elicitation=ElicitationCapability())
+    )
+    if not supports_elicitation:
+        return NO_ELICITATION_MESSAGE
+
+    result = await ctx.elicit(message=message, schema=DeletionConfirmation)
+    if result.action == "accept" and result.data.confirm:
+        return None
+    return CANCELLED_MESSAGE

--- a/mcp-server/src/crossbill_mcp/server.py
+++ b/mcp-server/src/crossbill_mcp/server.py
@@ -13,6 +13,7 @@ from crossbill_mcp.tools.flashcards import register_flashcard_tools
 from crossbill_mcp.tools.highlight_labels import register_highlight_label_tools
 from crossbill_mcp.tools.highlights import register_highlight_tools
 from crossbill_mcp.tools.reading import register_reading_tools
+from crossbill_mcp.tools.semantic import register_semantic_tools
 
 logger = logging.getLogger(__name__)
 
@@ -41,6 +42,7 @@ def create_server() -> tuple[FastMCP, CrossbillClient]:
     register_flashcard_tools(server, client)
     register_reading_tools(server, client)
     register_bookmark_tools(server, client)
+    register_semantic_tools(server, client)
 
     return server, client
 

--- a/mcp-server/src/crossbill_mcp/server.py
+++ b/mcp-server/src/crossbill_mcp/server.py
@@ -9,6 +9,7 @@ from mcp.server.fastmcp import FastMCP
 from crossbill_mcp.client import CrossbillClient
 from crossbill_mcp.tools.bookmarks import register_bookmark_tools
 from crossbill_mcp.tools.books import register_book_tools
+from crossbill_mcp.tools.digests import register_digest_tools
 from crossbill_mcp.tools.flashcards import register_flashcard_tools
 from crossbill_mcp.tools.highlight_labels import register_highlight_label_tools
 from crossbill_mcp.tools.highlights import register_highlight_tools
@@ -45,6 +46,7 @@ def create_server() -> tuple[FastMCP, CrossbillClient]:
     register_bookmark_tools(server, client)
     register_semantic_tools(server, client)
     register_notes_tools(server, client)
+    register_digest_tools(server, client)
 
     return server, client
 

--- a/mcp-server/src/crossbill_mcp/server.py
+++ b/mcp-server/src/crossbill_mcp/server.py
@@ -12,6 +12,7 @@ from crossbill_mcp.tools.books import register_book_tools
 from crossbill_mcp.tools.flashcards import register_flashcard_tools
 from crossbill_mcp.tools.highlight_labels import register_highlight_label_tools
 from crossbill_mcp.tools.highlights import register_highlight_tools
+from crossbill_mcp.tools.notes import register_notes_tools
 from crossbill_mcp.tools.reading import register_reading_tools
 from crossbill_mcp.tools.semantic import register_semantic_tools
 
@@ -43,6 +44,7 @@ def create_server() -> tuple[FastMCP, CrossbillClient]:
     register_reading_tools(server, client)
     register_bookmark_tools(server, client)
     register_semantic_tools(server, client)
+    register_notes_tools(server, client)
 
     return server, client
 

--- a/mcp-server/src/crossbill_mcp/server.py
+++ b/mcp-server/src/crossbill_mcp/server.py
@@ -15,7 +15,9 @@ from crossbill_mcp.tools.highlight_labels import register_highlight_label_tools
 from crossbill_mcp.tools.highlights import register_highlight_tools
 from crossbill_mcp.tools.notes import register_notes_tools
 from crossbill_mcp.tools.reading import register_reading_tools
+from crossbill_mcp.tools.reflection import register_reflection_tools
 from crossbill_mcp.tools.semantic import register_semantic_tools
+from crossbill_mcp.tools.tags import register_tag_tools
 
 logger = logging.getLogger(__name__)
 
@@ -47,6 +49,8 @@ def create_server() -> tuple[FastMCP, CrossbillClient]:
     register_semantic_tools(server, client)
     register_notes_tools(server, client)
     register_digest_tools(server, client)
+    register_tag_tools(server, client)
+    register_reflection_tools(server, client)
 
     return server, client
 

--- a/mcp-server/src/crossbill_mcp/tools/bookmarks.py
+++ b/mcp-server/src/crossbill_mcp/tools/bookmarks.py
@@ -11,6 +11,16 @@ def register_bookmark_tools(server: FastMCP, client: CrossbillClient) -> None:
     """Register bookmark-related tools with the MCP server."""
 
     @server.tool()
+    async def list_bookmarks(book_id: int) -> str:
+        """Get every bookmark in a book, with the highlight each one marks.
+
+        Args:
+            book_id: The ID of the book
+        """
+        result = await client.get_bookmarks(book_id)
+        return json.dumps(result, indent=2, default=str)
+
+    @server.tool()
     async def create_bookmark(book_id: int, highlight_id: int) -> str:
         """Create a bookmark for a highlight.
 

--- a/mcp-server/src/crossbill_mcp/tools/bookmarks.py
+++ b/mcp-server/src/crossbill_mcp/tools/bookmarks.py
@@ -3,6 +3,7 @@
 import json
 
 from mcp.server.fastmcp import FastMCP
+from mcp.types import ToolAnnotations
 
 from crossbill_mcp.client import CrossbillClient
 
@@ -10,7 +11,7 @@ from crossbill_mcp.client import CrossbillClient
 def register_bookmark_tools(server: FastMCP, client: CrossbillClient) -> None:
     """Register bookmark-related tools with the MCP server."""
 
-    @server.tool()
+    @server.tool(annotations=ToolAnnotations(readOnlyHint=True))
     async def list_bookmarks(book_id: int) -> str:
         """Get every bookmark in a book, with the highlight each one marks.
 
@@ -31,7 +32,7 @@ def register_bookmark_tools(server: FastMCP, client: CrossbillClient) -> None:
         result = await client.create_bookmark(book_id, highlight_id)
         return json.dumps(result, indent=2, default=str)
 
-    @server.tool()
+    @server.tool(annotations=ToolAnnotations(destructiveHint=True, readOnlyHint=False))
     async def delete_bookmark(book_id: int, bookmark_id: int) -> str:
         """Delete a bookmark.
 

--- a/mcp-server/src/crossbill_mcp/tools/books.py
+++ b/mcp-server/src/crossbill_mcp/tools/books.py
@@ -2,10 +2,15 @@
 
 import json
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp import Context, FastMCP
+from mcp.server.session import ServerSession
 from mcp.types import ToolAnnotations
 
 from crossbill_mcp.client import CrossbillClient
+from crossbill_mcp.confirm import (
+    REQUIRES_USER_INTERACTION,
+    block_unconfirmed_deletion,
+)
 
 
 def register_book_tools(server: FastMCP, client: CrossbillClient) -> None:
@@ -64,3 +69,37 @@ def register_book_tools(server: FastMCP, client: CrossbillClient) -> None:
         if reading_stage is None:
             return f"Cleared the manual reading stage of book {book_id}."
         return f"Set the reading stage of book {book_id} to {reading_stage}."
+
+    @server.tool(
+        annotations=ToolAnnotations(destructiveHint=True, readOnlyHint=False),
+        meta=REQUIRES_USER_INTERACTION,
+    )
+    async def delete_book(book_id: int, ctx: Context[ServerSession, None]) -> str:
+        """Delete a book with all of its chapters and highlights.
+
+        The user is asked to confirm before anything is deleted, and nothing is
+        deleted if they decline. Clients that cannot show a confirmation prompt
+        are refused outright.
+
+        This is a hard delete and cannot be undone. Syncing the book from
+        KOReader again recreates it, but everything Crossbill added on top -
+        notes, flashcards, tags, digests - is gone for good.
+
+        Args:
+            book_id: The ID of the book to delete
+        """
+        book = await client.get_book(book_id)
+        title = book.get("title") or f"book {book_id}"
+        chapters = book.get("chapters") or []
+        highlights = sum(len(chapter.get("highlights") or []) for chapter in chapters)
+        refusal = await block_unconfirmed_deletion(
+            ctx,
+            f'Delete the book "{title}", with its {len(chapters)} chapters and '
+            f"{highlights} highlights? This permanently deletes the book, its "
+            f"chapters and highlights, and cannot be undone.",
+        )
+        if refusal is not None:
+            return refusal
+
+        await client.delete_book(book_id)
+        return f'Deleted the book "{title}" with its chapters and highlights.'

--- a/mcp-server/src/crossbill_mcp/tools/books.py
+++ b/mcp-server/src/crossbill_mcp/tools/books.py
@@ -45,3 +45,21 @@ def register_book_tools(server: FastMCP, client: CrossbillClient) -> None:
         """
         result = await client.get_recently_viewed_books(limit=limit)
         return json.dumps(result, indent=2, default=str)
+
+    @server.tool()
+    async def set_reading_stage(book_id: int, reading_stage: str | None = None) -> str:
+        """Set how far along the user is with a book, as a manual stage.
+
+        The stage is one of "to_read", "skimming", "reading", "finished" or
+        "reflected". Omitting the stage clears the manual setting, so the book
+        goes back to the stage Crossbill infers from reading activity.
+
+        Args:
+            book_id: The ID of the book
+            reading_stage: "to_read", "skimming", "reading", "finished" or
+                "reflected"; omit to clear the stage back to automatic
+        """
+        await client.set_reading_stage(book_id, reading_stage=reading_stage)
+        if reading_stage is None:
+            return f"Cleared the manual reading stage of book {book_id}."
+        return f"Set the reading stage of book {book_id} to {reading_stage}."

--- a/mcp-server/src/crossbill_mcp/tools/books.py
+++ b/mcp-server/src/crossbill_mcp/tools/books.py
@@ -3,6 +3,7 @@
 import json
 
 from mcp.server.fastmcp import FastMCP
+from mcp.types import ToolAnnotations
 
 from crossbill_mcp.client import CrossbillClient
 
@@ -10,7 +11,7 @@ from crossbill_mcp.client import CrossbillClient
 def register_book_tools(server: FastMCP, client: CrossbillClient) -> None:
     """Register book-related tools with the MCP server."""
 
-    @server.tool()
+    @server.tool(annotations=ToolAnnotations(readOnlyHint=True))
     async def list_books(
         search: str | None = None,
         limit: int = 100,
@@ -26,7 +27,7 @@ def register_book_tools(server: FastMCP, client: CrossbillClient) -> None:
         result = await client.list_books(search=search, limit=limit, offset=offset)
         return json.dumps(result, indent=2, default=str)
 
-    @server.tool()
+    @server.tool(annotations=ToolAnnotations(readOnlyHint=True))
     async def get_book(book_id: int) -> str:
         """Get detailed information about a book including chapters and highlights.
 
@@ -36,7 +37,7 @@ def register_book_tools(server: FastMCP, client: CrossbillClient) -> None:
         result = await client.get_book(book_id)
         return json.dumps(result, indent=2, default=str)
 
-    @server.tool()
+    @server.tool(annotations=ToolAnnotations(readOnlyHint=True))
     async def get_recently_viewed_books(limit: int = 10) -> str:
         """Get recently viewed books.
 

--- a/mcp-server/src/crossbill_mcp/tools/digests.py
+++ b/mcp-server/src/crossbill_mcp/tools/digests.py
@@ -3,6 +3,7 @@
 import json
 
 from mcp.server.fastmcp import FastMCP
+from mcp.types import ToolAnnotations
 
 from crossbill_mcp.ai_gate import ai_gated_json
 from crossbill_mcp.client import CrossbillClient
@@ -21,7 +22,7 @@ NO_ACTIVE_BATCH_MESSAGE = (
 def register_digest_tools(server: FastMCP, client: CrossbillClient) -> None:
     """Register chapter digest tools with the MCP server."""
 
-    @server.tool()
+    @server.tool(annotations=ToolAnnotations(readOnlyHint=True))
     async def get_chapter_digest(chapter_id: int) -> str:
         """Get a chapter's digest: an AI-written study aid for that chapter.
 
@@ -69,7 +70,7 @@ def register_digest_tools(server: FastMCP, client: CrossbillClient) -> None:
         result = await client.update_digest_answers(chapter_id, answers)
         return json.dumps(result, indent=2, default=str)
 
-    @server.tool()
+    @server.tool(annotations=ToolAnnotations(readOnlyHint=True))
     async def get_book_digests(book_id: int) -> str:
         """Get every chapter digest a book has.
 
@@ -94,7 +95,7 @@ def register_digest_tools(server: FastMCP, client: CrossbillClient) -> None:
         """
         return await ai_gated_json(client.enqueue_book_digests(book_id))
 
-    @server.tool()
+    @server.tool(annotations=ToolAnnotations(readOnlyHint=True))
     async def get_digest_generation_status(book_id: int) -> str:
         """Get the active digest generation batch for a book, if any.
 
@@ -110,7 +111,7 @@ def register_digest_tools(server: FastMCP, client: CrossbillClient) -> None:
             return NO_ACTIVE_BATCH_MESSAGE
         return json.dumps(result, indent=2, default=str)
 
-    @server.tool()
+    @server.tool(annotations=ToolAnnotations(readOnlyHint=True))
     async def get_job_batch(batch_id: int) -> str:
         """Get any job batch by ID, with its status and progress counts.
 
@@ -120,7 +121,7 @@ def register_digest_tools(server: FastMCP, client: CrossbillClient) -> None:
         result = await client.get_job_batch(batch_id)
         return json.dumps(result, indent=2, default=str)
 
-    @server.tool()
+    @server.tool(annotations=ToolAnnotations(destructiveHint=True, readOnlyHint=False))
     async def cancel_job_batch(batch_id: int) -> str:
         """Cancel a job batch, aborting the jobs in it that have not run yet.
 

--- a/mcp-server/src/crossbill_mcp/tools/digests.py
+++ b/mcp-server/src/crossbill_mcp/tools/digests.py
@@ -1,0 +1,133 @@
+"""Chapter digest MCP tools."""
+
+import json
+
+from mcp.server.fastmcp import FastMCP
+
+from crossbill_mcp.ai_gate import ai_gated_json
+from crossbill_mcp.client import CrossbillClient
+
+NO_DIGEST_MESSAGE = (
+    "No digest exists for this chapter yet. Use generate_chapter_digest to "
+    "create one."
+)
+
+NO_ACTIVE_BATCH_MESSAGE = (
+    "No active digest batch for this book. Use generate_book_digests to start "
+    "one."
+)
+
+
+def register_digest_tools(server: FastMCP, client: CrossbillClient) -> None:
+    """Register chapter digest tools with the MCP server."""
+
+    @server.tool()
+    async def get_chapter_digest(chapter_id: int) -> str:
+        """Get a chapter's digest: an AI-written study aid for that chapter.
+
+        A digest holds a summary of the chapter, a list of keypoints, and
+        comprehension questions with their answers and whatever the user has
+        answered so far. Chapters only have one once it has been generated.
+
+        Args:
+            chapter_id: The ID of the chapter
+        """
+        result = await client.get_chapter_digest(chapter_id)
+        if result is None:
+            return NO_DIGEST_MESSAGE
+        return json.dumps(result, indent=2, default=str)
+
+    @server.tool()
+    async def generate_chapter_digest(chapter_id: int) -> str:
+        """Generate the digest for one chapter and return it.
+
+        This runs synchronously - it makes an AI call over the chapter text and
+        can take tens of seconds. Overwrites any digest the chapter already
+        has. To cover a whole book, use generate_book_digests instead, which
+        runs in the background.
+
+        Args:
+            chapter_id: The ID of the chapter
+        """
+        return await ai_gated_json(client.generate_chapter_digest(chapter_id))
+
+    @server.tool()
+    async def answer_digest_question(
+        chapter_id: int, question_index: int, user_answer: str
+    ) -> str:
+        """Record the user's answer to one comprehension question in a digest.
+
+        Returns the updated digest, so the recorded answer can be compared with
+        the digest's own answer for that question.
+
+        Args:
+            chapter_id: The ID of the chapter whose digest is being answered
+            question_index: Zero-based index into the digest's questions list
+            user_answer: The user's answer to that question
+        """
+        answers = [{"question_index": question_index, "user_answer": user_answer}]
+        result = await client.update_digest_answers(chapter_id, answers)
+        return json.dumps(result, indent=2, default=str)
+
+    @server.tool()
+    async def get_book_digests(book_id: int) -> str:
+        """Get every chapter digest a book has.
+
+        Chapters without a generated digest are simply absent from the list.
+
+        Args:
+            book_id: The ID of the book
+        """
+        result = await client.get_book_digests(book_id)
+        return json.dumps(result, indent=2, default=str)
+
+    @server.tool()
+    async def generate_book_digests(book_id: int) -> str:
+        """Enqueue digest generation for every chapter of a book.
+
+        The work runs in the background, one job per chapter. Returns the job
+        batch that was created; poll it with get_digest_generation_status to
+        see how far along it is.
+
+        Args:
+            book_id: The ID of the book
+        """
+        return await ai_gated_json(client.enqueue_book_digests(book_id))
+
+    @server.tool()
+    async def get_digest_generation_status(book_id: int) -> str:
+        """Get the active digest generation batch for a book, if any.
+
+        Returns the batch with its status and its total and completed job
+        counts. Once the batch finishes it is no longer active, so use
+        get_book_digests to read the results.
+
+        Args:
+            book_id: The ID of the book
+        """
+        result = await client.get_active_book_digest_batch(book_id)
+        if result is None:
+            return NO_ACTIVE_BATCH_MESSAGE
+        return json.dumps(result, indent=2, default=str)
+
+    @server.tool()
+    async def get_job_batch(batch_id: int) -> str:
+        """Get any job batch by ID, with its status and progress counts.
+
+        Args:
+            batch_id: The ID of the job batch
+        """
+        result = await client.get_job_batch(batch_id)
+        return json.dumps(result, indent=2, default=str)
+
+    @server.tool()
+    async def cancel_job_batch(batch_id: int) -> str:
+        """Cancel a job batch, aborting the jobs in it that have not run yet.
+
+        Jobs already finished keep their results. Returns the cancelled batch.
+
+        Args:
+            batch_id: The ID of the job batch
+        """
+        result = await client.cancel_job_batch(batch_id)
+        return json.dumps(result, indent=2, default=str)

--- a/mcp-server/src/crossbill_mcp/tools/flashcards.py
+++ b/mcp-server/src/crossbill_mcp/tools/flashcards.py
@@ -4,6 +4,7 @@ import json
 
 from mcp.server.fastmcp import FastMCP
 
+from crossbill_mcp.ai_gate import ai_gated_json
 from crossbill_mcp.client import CrossbillClient
 
 
@@ -26,18 +27,33 @@ def register_flashcard_tools(server: FastMCP, client: CrossbillClient) -> None:
         question: str,
         answer: str,
         highlight_id: int | None = None,
+        note_id: int | None = None,
         chapter_id: int | None = None,
     ) -> str:
-        """Create a new flashcard for a book, optionally linked to a highlight or chapter.
+        """Create a new flashcard for a book, optionally anchored to its source.
+
+        A flashcard always belongs to a book, and can additionally be anchored
+        to the highlight, note or chapter it came from. Give at most one of
+        highlight_id, note_id and chapter_id; a card with none of them is filed
+        under the book alone. When anchored to a note, the book must be one the
+        note is linked to.
 
         Args:
             book_id: The ID of the book
             question: The flashcard question
             answer: The flashcard answer
             highlight_id: Optional highlight ID to link the flashcard to
+            note_id: Optional note ID to link the flashcard to
             chapter_id: Optional chapter ID to link the flashcard to
         """
-        result = await client.create_flashcard(book_id, question, answer, highlight_id, chapter_id)
+        if note_id is not None:
+            result = await client.create_note_flashcard(
+                note_id, question, answer, book_id
+            )
+        else:
+            result = await client.create_flashcard(
+                book_id, question, answer, highlight_id, chapter_id
+            )
         return json.dumps(result, indent=2, default=str)
 
     @server.tool()
@@ -65,3 +81,45 @@ def register_flashcard_tools(server: FastMCP, client: CrossbillClient) -> None:
         """
         result = await client.delete_flashcard(flashcard_id)
         return json.dumps(result, indent=2, default=str)
+
+    @server.tool()
+    async def suggest_flashcards_for_chapter(chapter_id: int) -> str:
+        """Suggest flashcards drawn from a chapter's digest.
+
+        Returns AI-generated question/answer pairs only - nothing is saved.
+        Pass the ones worth keeping to create_flashcard. Requires the chapter
+        to already have a digest, so run generate_chapter_digest first if it
+        has none.
+
+        Args:
+            chapter_id: The ID of the chapter
+        """
+        return await ai_gated_json(
+            client.get_chapter_flashcard_suggestions(chapter_id)
+        )
+
+    @server.tool()
+    async def suggest_flashcards_for_highlight(highlight_id: int) -> str:
+        """Suggest flashcards drawn from a highlight's text.
+
+        Returns AI-generated question/answer pairs only - nothing is saved.
+        Pass the ones worth keeping to create_flashcard.
+
+        Args:
+            highlight_id: The ID of the highlight
+        """
+        return await ai_gated_json(
+            client.get_highlight_flashcard_suggestions(highlight_id)
+        )
+
+    @server.tool()
+    async def suggest_flashcards_for_note(note_id: int) -> str:
+        """Suggest flashcards drawn from a note and its linked highlights.
+
+        Returns AI-generated question/answer pairs only - nothing is saved.
+        Pass the ones worth keeping to create_flashcard.
+
+        Args:
+            note_id: The ID of the note
+        """
+        return await ai_gated_json(client.get_note_flashcard_suggestions(note_id))

--- a/mcp-server/src/crossbill_mcp/tools/flashcards.py
+++ b/mcp-server/src/crossbill_mcp/tools/flashcards.py
@@ -3,6 +3,7 @@
 import json
 
 from mcp.server.fastmcp import FastMCP
+from mcp.types import ToolAnnotations
 
 from crossbill_mcp.ai_gate import ai_gated_json
 from crossbill_mcp.client import CrossbillClient
@@ -11,7 +12,7 @@ from crossbill_mcp.client import CrossbillClient
 def register_flashcard_tools(server: FastMCP, client: CrossbillClient) -> None:
     """Register flashcard-related tools with the MCP server."""
 
-    @server.tool()
+    @server.tool(annotations=ToolAnnotations(readOnlyHint=True))
     async def get_flashcards(book_id: int) -> str:
         """Get all flashcards for a book with their associated highlights.
 
@@ -72,7 +73,7 @@ def register_flashcard_tools(server: FastMCP, client: CrossbillClient) -> None:
         result = await client.update_flashcard(flashcard_id, question, answer)
         return json.dumps(result, indent=2, default=str)
 
-    @server.tool()
+    @server.tool(annotations=ToolAnnotations(destructiveHint=True, readOnlyHint=False))
     async def delete_flashcard(flashcard_id: int) -> str:
         """Delete a flashcard.
 
@@ -82,7 +83,7 @@ def register_flashcard_tools(server: FastMCP, client: CrossbillClient) -> None:
         result = await client.delete_flashcard(flashcard_id)
         return json.dumps(result, indent=2, default=str)
 
-    @server.tool()
+    @server.tool(annotations=ToolAnnotations(readOnlyHint=True))
     async def suggest_flashcards_for_chapter(chapter_id: int) -> str:
         """Suggest flashcards drawn from a chapter's digest.
 
@@ -98,7 +99,7 @@ def register_flashcard_tools(server: FastMCP, client: CrossbillClient) -> None:
             client.get_chapter_flashcard_suggestions(chapter_id)
         )
 
-    @server.tool()
+    @server.tool(annotations=ToolAnnotations(readOnlyHint=True))
     async def suggest_flashcards_for_highlight(highlight_id: int) -> str:
         """Suggest flashcards drawn from a highlight's text.
 
@@ -112,7 +113,7 @@ def register_flashcard_tools(server: FastMCP, client: CrossbillClient) -> None:
             client.get_highlight_flashcard_suggestions(highlight_id)
         )
 
-    @server.tool()
+    @server.tool(annotations=ToolAnnotations(readOnlyHint=True))
     async def suggest_flashcards_for_note(note_id: int) -> str:
         """Suggest flashcards drawn from a note and its linked highlights.
 

--- a/mcp-server/src/crossbill_mcp/tools/highlight_labels.py
+++ b/mcp-server/src/crossbill_mcp/tools/highlight_labels.py
@@ -3,6 +3,7 @@
 import json
 
 from mcp.server.fastmcp import FastMCP
+from mcp.types import ToolAnnotations
 
 from crossbill_mcp.client import CrossbillClient
 
@@ -10,7 +11,7 @@ from crossbill_mcp.client import CrossbillClient
 def register_highlight_label_tools(server: FastMCP, client: CrossbillClient) -> None:
     """Register highlight-label tools with the MCP server."""
 
-    @server.tool()
+    @server.tool(annotations=ToolAnnotations(readOnlyHint=True))
     async def get_book_highlight_labels(book_id: int) -> str:
         """Get all highlight labels for a book with their resolved labels and highlight counts.
 
@@ -20,7 +21,7 @@ def register_highlight_label_tools(server: FastMCP, client: CrossbillClient) -> 
         result = await client.get_book_highlight_labels(book_id)
         return json.dumps(result, indent=2, default=str)
 
-    @server.tool()
+    @server.tool(annotations=ToolAnnotations(readOnlyHint=True))
     async def get_global_highlight_labels() -> str:
         """Get all global default highlight labels."""
         result = await client.get_global_highlight_labels()

--- a/mcp-server/src/crossbill_mcp/tools/highlights.py
+++ b/mcp-server/src/crossbill_mcp/tools/highlights.py
@@ -2,10 +2,15 @@
 
 import json
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp import Context, FastMCP
+from mcp.server.session import ServerSession
 from mcp.types import ToolAnnotations
 
 from crossbill_mcp.client import CrossbillClient
+from crossbill_mcp.confirm import (
+    REQUIRES_USER_INTERACTION,
+    block_unconfirmed_deletion,
+)
 
 
 def register_highlight_tools(server: FastMCP, client: CrossbillClient) -> None:
@@ -64,4 +69,41 @@ def register_highlight_tools(server: FastMCP, client: CrossbillClient) -> None:
             tag_id: The ID of the tag to remove
         """
         result = await client.untag_highlight(book_id, highlight_id, tag_id)
+        return json.dumps(result, indent=2, default=str)
+
+    @server.tool(
+        annotations=ToolAnnotations(destructiveHint=True, readOnlyHint=False),
+        meta=REQUIRES_USER_INTERACTION,
+    )
+    async def delete_highlights(
+        book_id: int, highlight_ids: list[int], ctx: Context[ServerSession, None]
+    ) -> str:
+        """Delete highlights from a book.
+
+        The user is asked to confirm before anything is deleted, and nothing is
+        deleted if they decline. Clients that cannot show a confirmation prompt
+        are refused outright.
+
+        The deletion sticks: a deleted highlight stays deleted, and future
+        KOReader syncs of the book will not bring it back.
+
+        Args:
+            book_id: The ID of the book the highlights belong to
+            highlight_ids: IDs of the highlights to delete (at least one)
+        """
+        if not highlight_ids:
+            return "No highlight IDs given, so there is nothing to delete."
+
+        book = await client.get_book(book_id)
+        title = book.get("title") or f"book {book_id}"
+        refusal = await block_unconfirmed_deletion(
+            ctx,
+            f'Delete {len(highlight_ids)} highlight(s) from "{title}"? Deleted '
+            f"highlights stay deleted - future KOReader syncs of this book will "
+            f"not bring them back.",
+        )
+        if refusal is not None:
+            return refusal
+
+        result = await client.delete_highlights(book_id, highlight_ids)
         return json.dumps(result, indent=2, default=str)

--- a/mcp-server/src/crossbill_mcp/tools/highlights.py
+++ b/mcp-server/src/crossbill_mcp/tools/highlights.py
@@ -3,6 +3,7 @@
 import json
 
 from mcp.server.fastmcp import FastMCP
+from mcp.types import ToolAnnotations
 
 from crossbill_mcp.client import CrossbillClient
 
@@ -10,7 +11,7 @@ from crossbill_mcp.client import CrossbillClient
 def register_highlight_tools(server: FastMCP, client: CrossbillClient) -> None:
     """Register highlight-related tools with the MCP server."""
 
-    @server.tool()
+    @server.tool(annotations=ToolAnnotations(readOnlyHint=True))
     async def get_highlights(book_id: int, search: str | None = None) -> str:
         """Get highlights from a book, optionally filtered by search text.
 

--- a/mcp-server/src/crossbill_mcp/tools/highlights.py
+++ b/mcp-server/src/crossbill_mcp/tools/highlights.py
@@ -28,12 +28,13 @@ def register_highlight_tools(server: FastMCP, client: CrossbillClient) -> None:
         return json.dumps(result, indent=2, default=str)
 
     @server.tool()
-    async def update_highlight_note(highlight_id: int, note: str) -> str:
+    async def update_highlight_note(highlight_id: int, note: str | None = None) -> str:
         """Add or update a note/annotation on a highlight.
 
         Args:
             highlight_id: The ID of the highlight
-            note: The note text (pass empty string to clear)
+            note: The note text; omit it, or pass an empty string, to clear the
+                highlight's note
         """
         result = await client.update_highlight_note(
             highlight_id, note if note else None

--- a/mcp-server/src/crossbill_mcp/tools/notes.py
+++ b/mcp-server/src/crossbill_mcp/tools/notes.py
@@ -3,6 +3,7 @@
 import json
 
 from mcp.server.fastmcp import FastMCP
+from mcp.types import ToolAnnotations
 
 from crossbill_mcp.client import CrossbillClient
 
@@ -47,7 +48,7 @@ def register_notes_tools(server: FastMCP, client: CrossbillClient) -> None:
         )
         return json.dumps(result, indent=2, default=str)
 
-    @server.tool()
+    @server.tool(annotations=ToolAnnotations(readOnlyHint=True))
     async def get_note(note_id: int) -> str:
         """Get a single note with its linked chapters, highlights and tags.
 
@@ -60,7 +61,7 @@ def register_notes_tools(server: FastMCP, client: CrossbillClient) -> None:
         result = await client.get_note(note_id)
         return json.dumps(result, indent=2, default=str)
 
-    @server.tool()
+    @server.tool(annotations=ToolAnnotations(readOnlyHint=True))
     async def get_book_notes(
         book_id: int,
         kind: str | None = None,
@@ -128,7 +129,7 @@ def register_notes_tools(server: FastMCP, client: CrossbillClient) -> None:
         )
         return json.dumps(result, indent=2, default=str)
 
-    @server.tool()
+    @server.tool(annotations=ToolAnnotations(destructiveHint=True, readOnlyHint=False))
     async def delete_note(note_id: int) -> str:
         """Delete a note and its links to chapters, highlights and tags.
 

--- a/mcp-server/src/crossbill_mcp/tools/notes.py
+++ b/mcp-server/src/crossbill_mcp/tools/notes.py
@@ -1,0 +1,139 @@
+"""Note-related MCP tools."""
+
+import json
+
+from mcp.server.fastmcp import FastMCP
+
+from crossbill_mcp.client import CrossbillClient
+
+
+def register_notes_tools(server: FastMCP, client: CrossbillClient) -> None:
+    """Register note-related tools with the MCP server."""
+
+    @server.tool()
+    async def create_note(
+        book_id: int,
+        title: str,
+        body: str = "",
+        kind: str | None = None,
+        chapter_ids: list[int] | None = None,
+        highlight_ids: list[int] | None = None,
+        tag_ids: list[int] | None = None,
+    ) -> str:
+        """Create a markdown note in a book, optionally linked to other content.
+
+        Notes belong to a book and can additionally be linked to any number of
+        that book's chapters and highlights, and to any of the user's tags.
+        Returns the created note, including its new ID.
+
+        Args:
+            book_id: The ID of the book the note belongs to
+            title: Note title (required, must not be blank)
+            body: Note body in markdown (default empty)
+            kind: Optional note kind: "character", "term", "concept", "gist",
+                "reflection" or "other"
+            chapter_ids: IDs of chapters to link the note to
+            highlight_ids: IDs of highlights to link the note to
+            tag_ids: IDs of tags to attach to the note
+        """
+        result = await client.create_note(
+            book_id,
+            title,
+            body=body,
+            kind=kind,
+            chapter_ids=chapter_ids or [],
+            highlight_ids=highlight_ids or [],
+            tag_ids=tag_ids or [],
+        )
+        return json.dumps(result, indent=2, default=str)
+
+    @server.tool()
+    async def get_note(note_id: int) -> str:
+        """Get a single note with its linked chapters, highlights and tags.
+
+        Returns the note's fields plus summaries of everything linked to it,
+        including any flashcards generated from it.
+
+        Args:
+            note_id: The ID of the note
+        """
+        result = await client.get_note(note_id)
+        return json.dumps(result, indent=2, default=str)
+
+    @server.tool()
+    async def get_book_notes(
+        book_id: int,
+        kind: str | None = None,
+        chapter_id: int | None = None,
+        highlight_id: int | None = None,
+        tag_id: int | None = None,
+    ) -> str:
+        """List a book's notes, optionally narrowed by kind or by what they link to.
+
+        Every filter given is applied, so passing several narrows the list
+        further. Returns the matching notes with their links.
+
+        Args:
+            book_id: The ID of the book
+            kind: Keep only notes of this kind: "character", "term", "concept",
+                "gist", "reflection" or "other"
+            chapter_id: Keep only notes linked to this chapter
+            highlight_id: Keep only notes linked to this highlight
+            tag_id: Keep only notes carrying this tag
+        """
+        result = await client.get_book_notes(
+            book_id,
+            kind=kind,
+            chapter_id=chapter_id,
+            highlight_id=highlight_id,
+            tag_id=tag_id,
+        )
+        return json.dumps(result, indent=2, default=str)
+
+    @server.tool()
+    async def update_note(
+        note_id: int,
+        title: str,
+        body: str = "",
+        kind: str | None = None,
+        chapter_ids: list[int] | None = None,
+        highlight_ids: list[int] | None = None,
+        tag_ids: list[int] | None = None,
+    ) -> str:
+        """Replace a note's fields and links in full.
+
+        This is a full replace, not a patch: every field and every link list is
+        overwritten with what you send. Omitting body, kind or a link list
+        blanks that field and clears those links. Call get_note first and resend
+        everything you want to keep, with your changes applied on top.
+
+        Args:
+            note_id: The ID of the note to replace
+            title: New note title (required, must not be blank)
+            body: New note body in markdown (default empty, clearing the body)
+            kind: New note kind: "character", "term", "concept", "gist",
+                "reflection" or "other" (default None, clearing the kind)
+            chapter_ids: Full new set of linked chapter IDs
+            highlight_ids: Full new set of linked highlight IDs
+            tag_ids: Full new set of tag IDs
+        """
+        result = await client.update_note(
+            note_id,
+            title,
+            body=body,
+            kind=kind,
+            chapter_ids=chapter_ids or [],
+            highlight_ids=highlight_ids or [],
+            tag_ids=tag_ids or [],
+        )
+        return json.dumps(result, indent=2, default=str)
+
+    @server.tool()
+    async def delete_note(note_id: int) -> str:
+        """Delete a note and its links to chapters, highlights and tags.
+
+        Args:
+            note_id: The ID of the note to delete
+        """
+        result = await client.delete_note(note_id)
+        return json.dumps(result, indent=2, default=str)

--- a/mcp-server/src/crossbill_mcp/tools/reading.py
+++ b/mcp-server/src/crossbill_mcp/tools/reading.py
@@ -3,6 +3,7 @@
 import json
 
 from mcp.server.fastmcp import FastMCP
+from mcp.types import ToolAnnotations
 
 from crossbill_mcp.ai_gate import ai_gated_json
 from crossbill_mcp.client import CrossbillClient
@@ -11,7 +12,7 @@ from crossbill_mcp.client import CrossbillClient
 def register_reading_tools(server: FastMCP, client: CrossbillClient) -> None:
     """Register reading session and chapter content tools."""
 
-    @server.tool()
+    @server.tool(annotations=ToolAnnotations(readOnlyHint=True))
     async def get_reading_sessions(
         book_id: int, limit: int = 30, offset: int = 0
     ) -> str:
@@ -25,7 +26,7 @@ def register_reading_tools(server: FastMCP, client: CrossbillClient) -> None:
         result = await client.get_reading_sessions(book_id, limit=limit, offset=offset)
         return json.dumps(result, indent=2, default=str)
 
-    @server.tool()
+    @server.tool(annotations=ToolAnnotations(readOnlyHint=True))
     async def get_chapter_content(chapter_id: int) -> str:
         """Get the full text content of a chapter from the EPUB file.
 
@@ -37,7 +38,7 @@ def register_reading_tools(server: FastMCP, client: CrossbillClient) -> None:
         result = await client.get_chapter_content(chapter_id)
         return json.dumps(result, indent=2, default=str)
 
-    @server.tool()
+    @server.tool(annotations=ToolAnnotations(readOnlyHint=True))
     async def get_reading_session_summary(reading_session_id: int) -> str:
         """Get an AI summary of what the user read in one reading session.
 

--- a/mcp-server/src/crossbill_mcp/tools/reading.py
+++ b/mcp-server/src/crossbill_mcp/tools/reading.py
@@ -4,6 +4,7 @@ import json
 
 from mcp.server.fastmcp import FastMCP
 
+from crossbill_mcp.ai_gate import ai_gated_json
 from crossbill_mcp.client import CrossbillClient
 
 
@@ -32,3 +33,20 @@ def register_reading_tools(server: FastMCP, client: CrossbillClient) -> None:
         """
         result = await client.get_chapter_content(chapter_id)
         return json.dumps(result, indent=2, default=str)
+
+    @server.tool()
+    async def get_reading_session_summary(reading_session_id: int) -> str:
+        """Get an AI summary of what the user read in one reading session.
+
+        The summary is written from the text covered between the session's
+        start and end positions, and cached, so the AI call only happens the
+        first time. Sessions without position data have nothing to summarise.
+        Requires an AI provider configured on the Crossbill server.
+
+        Args:
+            reading_session_id: The ID of the reading session, from
+                get_reading_sessions
+        """
+        return await ai_gated_json(
+            client.get_reading_session_summary(reading_session_id)
+        )

--- a/mcp-server/src/crossbill_mcp/tools/reading.py
+++ b/mcp-server/src/crossbill_mcp/tools/reading.py
@@ -12,14 +12,17 @@ def register_reading_tools(server: FastMCP, client: CrossbillClient) -> None:
     """Register reading session and chapter content tools."""
 
     @server.tool()
-    async def get_reading_sessions(book_id: int, limit: int = 30) -> str:
+    async def get_reading_sessions(
+        book_id: int, limit: int = 30, offset: int = 0
+    ) -> str:
         """Get reading sessions for a book.
 
         Args:
             book_id: The ID of the book
             limit: Maximum number of sessions to return (default 30)
+            offset: Pagination offset (default 0)
         """
-        result = await client.get_reading_sessions(book_id, limit=limit)
+        result = await client.get_reading_sessions(book_id, limit=limit, offset=offset)
         return json.dumps(result, indent=2, default=str)
 
     @server.tool()

--- a/mcp-server/src/crossbill_mcp/tools/reflection.py
+++ b/mcp-server/src/crossbill_mcp/tools/reflection.py
@@ -1,0 +1,70 @@
+"""Book reflection MCP tools."""
+
+import json
+
+from mcp.server.fastmcp import FastMCP
+
+from crossbill_mcp.client import CrossbillClient
+
+
+def register_reflection_tools(server: FastMCP, client: CrossbillClient) -> None:
+    """Register book reflection tools with the MCP server."""
+
+    @server.tool()
+    async def get_book_reflection(book_id: int) -> str:
+        """Get a book's reflection: its answers to the four reading questions.
+
+        The four questions are fixed: what is the book about, what does it say,
+        do I agree, and so what. Each answer is not text but a reference to the
+        note holding that answer's markdown, or null while the question is
+        unanswered - read the answers with get_note. The reflection also keeps
+        note_ids, the term and concept notes linked to it. Every book has a
+        reflection; an untouched one simply has nulls and no linked notes.
+
+        Args:
+            book_id: The ID of the book
+        """
+        result = await client.get_book_reflection(book_id)
+        return json.dumps(result, indent=2, default=str)
+
+    @server.tool()
+    async def update_book_reflection(
+        book_id: int,
+        what_is_it_about_note_id: int | None = None,
+        what_does_it_say_note_id: int | None = None,
+        do_i_agree_note_id: int | None = None,
+        so_what_note_id: int | None = None,
+        note_ids: list[int] | None = None,
+    ) -> str:
+        """Replace a book's reflection in full.
+
+        Answers live in ordinary notes, so answering a question is two steps:
+        write the answer with create_note (or update_note), then pass that
+        note's ID here as the question's answer.
+
+        This is a full replace, not a patch: every field is overwritten with
+        what you send, so omitting an answer clears it and omitting note_ids
+        clears every linked note. Call get_book_reflection first and resend
+        everything you want to keep, with your changes applied on top.
+
+        Args:
+            book_id: The ID of the book
+            what_is_it_about_note_id: ID of the note answering "what is it
+                about" (default None, clearing that answer)
+            what_does_it_say_note_id: ID of the note answering "what does it
+                say" (default None, clearing that answer)
+            do_i_agree_note_id: ID of the note answering "do I agree" (default
+                None, clearing that answer)
+            so_what_note_id: ID of the note answering "so what" (default None,
+                clearing that answer)
+            note_ids: Full new set of linked term and concept note IDs
+        """
+        result = await client.update_book_reflection(
+            book_id,
+            what_is_it_about_note_id=what_is_it_about_note_id,
+            what_does_it_say_note_id=what_does_it_say_note_id,
+            do_i_agree_note_id=do_i_agree_note_id,
+            so_what_note_id=so_what_note_id,
+            note_ids=note_ids or [],
+        )
+        return json.dumps(result, indent=2, default=str)

--- a/mcp-server/src/crossbill_mcp/tools/reflection.py
+++ b/mcp-server/src/crossbill_mcp/tools/reflection.py
@@ -3,6 +3,7 @@
 import json
 
 from mcp.server.fastmcp import FastMCP
+from mcp.types import ToolAnnotations
 
 from crossbill_mcp.client import CrossbillClient
 
@@ -10,7 +11,7 @@ from crossbill_mcp.client import CrossbillClient
 def register_reflection_tools(server: FastMCP, client: CrossbillClient) -> None:
     """Register book reflection tools with the MCP server."""
 
-    @server.tool()
+    @server.tool(annotations=ToolAnnotations(readOnlyHint=True))
     async def get_book_reflection(book_id: int) -> str:
         """Get a book's reflection: its answers to the four reading questions.
 

--- a/mcp-server/src/crossbill_mcp/tools/semantic.py
+++ b/mcp-server/src/crossbill_mcp/tools/semantic.py
@@ -1,0 +1,66 @@
+"""Semantic search MCP tools."""
+
+import json
+
+import httpx
+from mcp.server.fastmcp import FastMCP
+
+from crossbill_mcp.client import CrossbillClient
+
+SEMANTIC_DISABLED_MESSAGE = (
+    "Semantic search is not enabled on this Crossbill server "
+    "(no embedding provider configured)."
+)
+
+
+def register_semantic_tools(server: FastMCP, client: CrossbillClient) -> None:
+    """Register semantic search tools with the MCP server."""
+
+    @server.tool()
+    async def semantic_search(
+        query: str, book_id: int | None = None, limit: int = 10
+    ) -> str:
+        """Search highlights, notes and chapter digests by meaning, not keywords.
+
+        Ranks the user's embedded content by semantic similarity to the query, so
+        it finds passages that express an idea even when they share no words with
+        it. Results come back grouped by content type (highlights, notes, digests);
+        every group is present even when empty, and each item carries a similarity
+        score on one shared scale plus the identifiers needed to open the source
+        content.
+
+        Args:
+            query: What to search for, in natural language (1-1000 characters)
+            book_id: Optional book ID to restrict the search to a single book
+            limit: Maximum items per content type, not overall (1-100, default 10)
+        """
+        try:
+            result = await client.semantic_search(query, book_id=book_id, limit=limit)
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code == 403:
+                return SEMANTIC_DISABLED_MESSAGE
+            raise
+        return json.dumps(result, indent=2, default=str)
+
+    @server.tool()
+    async def find_related(content_type: str, content_id: int, limit: int = 10) -> str:
+        """Find content semantically similar to an existing note, highlight or digest.
+
+        Use this to follow a thread from one item the user already has: it ranks
+        their other embedded content by similarity to that anchor. Same response
+        shape as semantic_search - grouped by content type, with the limit applied
+        per group. The anchor never appears among its own results, and every group
+        is empty when the anchor has not been indexed yet.
+
+        Args:
+            content_type: Kind of the anchor item: "note", "highlight" or "digest"
+            content_id: The ID of the anchor item
+            limit: Maximum items per content type, not overall (1-100, default 10)
+        """
+        try:
+            result = await client.related_content(content_type, content_id, limit=limit)
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code == 403:
+                return SEMANTIC_DISABLED_MESSAGE
+            raise
+        return json.dumps(result, indent=2, default=str)

--- a/mcp-server/src/crossbill_mcp/tools/semantic.py
+++ b/mcp-server/src/crossbill_mcp/tools/semantic.py
@@ -4,6 +4,7 @@ import json
 
 import httpx
 from mcp.server.fastmcp import FastMCP
+from mcp.types import ToolAnnotations
 
 from crossbill_mcp.client import CrossbillClient
 
@@ -16,7 +17,7 @@ SEMANTIC_DISABLED_MESSAGE = (
 def register_semantic_tools(server: FastMCP, client: CrossbillClient) -> None:
     """Register semantic search tools with the MCP server."""
 
-    @server.tool()
+    @server.tool(annotations=ToolAnnotations(readOnlyHint=True))
     async def semantic_search(
         query: str, book_id: int | None = None, limit: int = 10
     ) -> str:
@@ -42,7 +43,7 @@ def register_semantic_tools(server: FastMCP, client: CrossbillClient) -> None:
             raise
         return json.dumps(result, indent=2, default=str)
 
-    @server.tool()
+    @server.tool(annotations=ToolAnnotations(readOnlyHint=True))
     async def find_related(content_type: str, content_id: int, limit: int = 10) -> str:
         """Find content semantically similar to an existing note, highlight or digest.
 

--- a/mcp-server/src/crossbill_mcp/tools/tags.py
+++ b/mcp-server/src/crossbill_mcp/tools/tags.py
@@ -3,6 +3,7 @@
 import json
 
 from mcp.server.fastmcp import FastMCP
+from mcp.types import ToolAnnotations
 
 from crossbill_mcp.client import CrossbillClient
 
@@ -10,7 +11,7 @@ from crossbill_mcp.client import CrossbillClient
 def register_tag_tools(server: FastMCP, client: CrossbillClient) -> None:
     """Register tag and tag group tools with the MCP server."""
 
-    @server.tool()
+    @server.tool(annotations=ToolAnnotations(readOnlyHint=True))
     async def get_book_tags(book_id: int) -> str:
         """Get every tag of a book, with the tag group each one belongs to.
 
@@ -60,7 +61,7 @@ def register_tag_tools(server: FastMCP, client: CrossbillClient) -> None:
         )
         return json.dumps(result, indent=2, default=str)
 
-    @server.tool()
+    @server.tool(annotations=ToolAnnotations(destructiveHint=True, readOnlyHint=False))
     async def delete_tag(book_id: int, tag_id: int) -> str:
         """Delete a tag from a book.
 
@@ -95,7 +96,7 @@ def register_tag_tools(server: FastMCP, client: CrossbillClient) -> None:
         )
         return json.dumps(result, indent=2, default=str)
 
-    @server.tool()
+    @server.tool(annotations=ToolAnnotations(destructiveHint=True, readOnlyHint=False))
     async def delete_tag_group(tag_group_id: int) -> str:
         """Delete a tag group, leaving the tags in it ungrouped.
 

--- a/mcp-server/src/crossbill_mcp/tools/tags.py
+++ b/mcp-server/src/crossbill_mcp/tools/tags.py
@@ -1,0 +1,106 @@
+"""Tag and tag group MCP tools."""
+
+import json
+
+from mcp.server.fastmcp import FastMCP
+
+from crossbill_mcp.client import CrossbillClient
+
+
+def register_tag_tools(server: FastMCP, client: CrossbillClient) -> None:
+    """Register tag and tag group tools with the MCP server."""
+
+    @server.tool()
+    async def get_book_tags(book_id: int) -> str:
+        """Get every tag of a book, with the tag group each one belongs to.
+
+        Tags belong to a single book and can be attached to that book's
+        highlights and notes. A tag group is an optional folder that gathers
+        related tags; a tag outside every group has a null tag_group_id.
+
+        Args:
+            book_id: The ID of the book
+        """
+        result = await client.get_book_tags(book_id)
+        return json.dumps(result, indent=2, default=str)
+
+    @server.tool()
+    async def create_tag(book_id: int, name: str) -> str:
+        """Create a tag in a book and return it, including its new ID.
+
+        The new tag starts out in no tag group; use update_tag to put it in
+        one. To tag a highlight, use tag_highlight instead - it creates the tag
+        by name when the book has none by that name yet.
+
+        Args:
+            book_id: The ID of the book the tag belongs to
+            name: Tag name (1-100 characters, must be unique within the book)
+        """
+        result = await client.create_tag(book_id, name)
+        return json.dumps(result, indent=2, default=str)
+
+    @server.tool()
+    async def update_tag(
+        book_id: int,
+        tag_id: int,
+        name: str | None = None,
+        tag_group_id: int | None = None,
+    ) -> str:
+        """Rename a tag and/or move it into a tag group.
+
+        Args:
+            book_id: The ID of the book the tag belongs to
+            tag_id: The ID of the tag to update
+            name: New tag name (1-100 characters); omit to keep the current one
+            tag_group_id: ID of the tag group to move the tag into; omit to
+                take the tag out of whatever group it is in
+        """
+        result = await client.update_tag(
+            book_id, tag_id, name=name, tag_group_id=tag_group_id
+        )
+        return json.dumps(result, indent=2, default=str)
+
+    @server.tool()
+    async def delete_tag(book_id: int, tag_id: int) -> str:
+        """Delete a tag from a book.
+
+        This also removes the tag from every highlight it was attached to, so
+        the highlights themselves survive but lose that tag.
+
+        Args:
+            book_id: The ID of the book the tag belongs to
+            tag_id: The ID of the tag to delete
+        """
+        await client.delete_tag(book_id, tag_id)
+        return f"Deleted tag {tag_id} from book {book_id}."
+
+    @server.tool()
+    async def create_or_rename_tag_group(
+        book_id: int, name: str, tag_group_id: int | None = None
+    ) -> str:
+        """Create a tag group in a book, or rename an existing one.
+
+        A tag group is a named folder for a book's tags. Passing a
+        tag_group_id renames that group instead of creating a new one. Returns
+        the group either way; put tags into it with update_tag.
+
+        Args:
+            book_id: The ID of the book the tag group belongs to
+            name: Tag group name (1-100 characters)
+            tag_group_id: ID of an existing group to rename; omit to create a
+                new group
+        """
+        result = await client.create_or_rename_tag_group(
+            book_id, name, tag_group_id=tag_group_id
+        )
+        return json.dumps(result, indent=2, default=str)
+
+    @server.tool()
+    async def delete_tag_group(tag_group_id: int) -> str:
+        """Delete a tag group, leaving the tags in it ungrouped.
+
+        Args:
+            tag_group_id: The ID of the tag group to delete
+        """
+        await client.delete_tag_group(tag_group_id)
+        return f"Deleted tag group {tag_group_id}."


### PR DESCRIPTION
## Summary

The MCP server had not been touched since February and was missing every backend feature shipped since: semantic search, notes, chapter digests, AI flashcard suggestions, tagging, reflections and more. This brings it from 19 tools to 48, covering the full current API surface that makes sense to expose to an AI assistant.

- **Semantic search** — `semantic_search` and `find_related`, with a friendly message when the server has no embedding provider (403)
- **Notes CRUD** — `create_note`, `get_note`, `get_book_notes` (filterable), `update_note` (with a prominent full-replace warning in the docstring), `delete_note`
- **Chapter digests** — read/generate/answer per chapter, book-wide generation via job batches with status polling and cancel
- **AI flashcard suggestions** — for chapters, highlights and notes; `create_flashcard` gained a `note_id` anchor
- **Tags & tag groups** — book-tag CRUD and group management
- **Book reflections, reading stage, session AI summaries**
- **Fixes to existing tools** — `update_highlight_note` can now clear a note, `list_bookmarks` added, `get_reading_sessions` exposes `offset`

Supporting changes:

- AI-gated endpoints (HTTP 410 when no AI provider) answer with a clear message via a shared `ai_gate.py` helper; synchronous AI generations override the 30s client timeout with 300s
- `mcp` dependency pinned `<2` — mcp 2.0 removed `mcp.server.fastmcp`, which this server is built on
- The post-edit Python format hook is now scoped to `backend/` so it no longer reformats `mcp-server`'s 88-column files with the backend's 100-column ruff config

Destructive operations: `delete_book` and `delete_highlights` are exposed with server-enforced confirmation — the tool asks the user via MCP elicitation before deleting and refuses outright on clients without elicitation support; both carry `destructiveHint` and `anthropic/requiresUserInteraction` annotations, and the README recommends an `ask` permission rule as extra hardening. All tools now carry read-only/destructive annotations. Deliberately not exposed: chat/quiz session proxying (the MCP consumer is an LLM already).

## Test plan

- `pyright` clean on `mcp-server/src` (with `mcp<2` pinned)
- Smoke test: server instantiates and registers all 48 tools
- Format hook verified to no-op on `mcp-server` files and still run ruff+pyright on `backend` files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
