### PR TITLE
Add a "removed from devices" state to highlights and hide it from the e-reader pull

### DIFF
--- a/backend/alembic/versions/068_highlight_removed_from_devices.py
+++ b/backend/alembic/versions/068_highlight_removed_from_devices.py
@@ -1,0 +1,40 @@
+"""Withhold a highlight from e-readers without deleting it
+
+A highlight deleted on a device must not come back on the next pull, but the
+user's flashcards, bookmarks and notes hang off it, so the server keeps it
+(#596). This timestamp marks that second state: the highlight stays whole on
+the web and only the ereader pull skips it. Null means it still syncs, which
+is every row written before this migration.
+
+Revision ID: 068
+Revises: 067
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "068"
+down_revision: str | Sequence[str] | None = "067"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "highlights",
+        sa.Column("removed_from_devices_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_index(
+        op.f("ix_highlights_removed_from_devices_at"),
+        "highlights",
+        ["removed_from_devices_at"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_highlights_removed_from_devices_at"), table_name="highlights")
+    op.drop_column("highlights", "removed_from_devices_at")

--- a/backend/src/domain/reading/entities/highlight.py
+++ b/backend/src/domain/reading/entities/highlight.py
@@ -36,6 +36,7 @@ class Highlight(AggregateRoot[HighlightId]):
     - Cannot have empty text
     - Content hash is computed from text (for deduplication)
     - Soft deletion is supported (deleted_at timestamp)
+    - Removal from devices is separate: the highlight stays on the web
     - Tags can be added/removed
     """
 
@@ -65,6 +66,9 @@ class Highlight(AggregateRoot[HighlightId]):
     created_at: dt_module.datetime = field(default_factory=lambda: dt_module.datetime.now(UTC))
     updated_at: dt_module.datetime = field(default_factory=lambda: dt_module.datetime.now(UTC))
     deleted_at: dt_module.datetime | None = None
+    # Set when the user deleted the highlight on an e-reader: it stays on the web,
+    # with its flashcards and bookmarks, but is withheld from every device's pull.
+    removed_from_devices_at: dt_module.datetime | None = None
 
     # Relationships
     _tag_ids: list[int] = field(default_factory=list, repr=False)
@@ -81,6 +85,10 @@ class Highlight(AggregateRoot[HighlightId]):
     def is_deleted(self) -> bool:
         """Check if this highlight has been soft-deleted."""
         return self.deleted_at is not None
+
+    def is_removed_from_devices(self) -> bool:
+        """Check if this highlight has been withheld from the e-reader pull."""
+        return self.removed_from_devices_at is not None
 
     def has_position_info(self) -> bool:
         """Check if this highlight has position information (xpoints or page)."""
@@ -111,6 +119,30 @@ class Highlight(AggregateRoot[HighlightId]):
             raise DomainError(f"Highlight {self.id} is not deleted")
 
         self.deleted_at = None
+
+    def remove_from_devices(self) -> None:
+        """
+        Withhold this highlight from every e-reader, keeping it on the web.
+
+        Raises:
+            DomainError: If highlight is already removed from devices
+        """
+        if self.is_removed_from_devices():
+            raise DomainError(f"Highlight {self.id} is already removed from devices")
+
+        self.removed_from_devices_at = dt_module.datetime.now(UTC)
+
+    def restore_to_devices(self) -> None:
+        """
+        Let this highlight reach e-readers again.
+
+        Raises:
+            DomainError: If highlight is not removed from devices
+        """
+        if not self.is_removed_from_devices():
+            raise DomainError(f"Highlight {self.id} is not removed from devices")
+
+        self.removed_from_devices_at = None
 
     def associate_with_chapter(self, chapter_id: ChapterId) -> None:
         """Associate this highlight with a chapter."""
@@ -217,6 +249,7 @@ class Highlight(AggregateRoot[HighlightId]):
         position: Position | None = None,
         highlight_style_id: HighlightStyleId | None = None,
         deleted_at: dt_module.datetime | None = None,
+        removed_from_devices_at: dt_module.datetime | None = None,
         koreader_updated_at: str | None = None,
         koreader_note: str | None = None,
         origin_device_id: str | None = None,
@@ -243,5 +276,6 @@ class Highlight(AggregateRoot[HighlightId]):
             created_at=created_at,
             updated_at=updated_at,
             deleted_at=deleted_at,
+            removed_from_devices_at=removed_from_devices_at,
             _tag_ids=[],
         )

--- a/backend/src/infrastructure/reading/mappers/highlight_mapper.py
+++ b/backend/src/infrastructure/reading/mappers/highlight_mapper.py
@@ -59,6 +59,7 @@ class HighlightMapper:
             if orm_model.highlight_style_id
             else None,
             deleted_at=orm_model.deleted_at,
+            removed_from_devices_at=orm_model.removed_from_devices_at,
             koreader_updated_at=orm_model.koreader_updated_at,
             koreader_note=orm_model.koreader_note,
             origin_device_id=orm_model.origin_device_id,
@@ -109,6 +110,7 @@ class HighlightMapper:
             domain_entity.highlight_style_id.value if domain_entity.highlight_style_id else None
         )
         orm_model.deleted_at = domain_entity.deleted_at
+        orm_model.removed_from_devices_at = domain_entity.removed_from_devices_at
         orm_model.koreader_updated_at = domain_entity.koreader_updated_at
         orm_model.koreader_note = domain_entity.koreader_note
         orm_model.origin_device_id = domain_entity.origin_device_id

--- a/backend/src/infrastructure/reading/orm/highlight_model.py
+++ b/backend/src/infrastructure/reading/orm/highlight_model.py
@@ -69,6 +69,9 @@ class Highlight(Base):
     deleted_at: Mapped[dt | None] = mapped_column(
         DateTime(timezone=True), nullable=True, index=True
     )
+    removed_from_devices_at: Mapped[dt | None] = mapped_column(
+        DateTime(timezone=True), nullable=True, index=True
+    )
     text_search_vector: Mapped[str | None] = mapped_column(
         Text().with_variant(TSVECTOR, "postgresql"), nullable=True, index=True
     )

--- a/backend/src/infrastructure/reading/queries/ereader_highlights_query.py
+++ b/backend/src/infrastructure/reading/queries/ereader_highlights_query.py
@@ -27,7 +27,11 @@ class EreaderHighlightsQuery:
     async def list_for_book(
         self, book_id: BookId, user_id: UserId
     ) -> tuple[EreaderHighlightView, ...]:
-        """Return the book's live highlights, oldest position first.
+        """Return the book's device-visible highlights, oldest position first.
+
+        Two states withhold a highlight here. Soft deletion takes it off the web
+        as well; removal from devices keeps it on the web, with its flashcards
+        and bookmarks, and only stops it reaching e-readers.
 
         The statement is built here rather than at module scope: adapters are
         imported early enough that resolving relationships at import time would
@@ -60,6 +64,7 @@ class EreaderHighlightsQuery:
                 HighlightORM.book_id == book_id.value,
                 HighlightORM.user_id == user_id.value,
                 HighlightORM.deleted_at.is_(None),
+                HighlightORM.removed_from_devices_at.is_(None),
             )
             .order_by(nulls_last(HighlightORM.page), HighlightORM.datetime, HighlightORM.id)
         )

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -152,6 +152,7 @@ async def create_test_highlight(
     page: int | None = None,
     chapter_id: int | None = None,
     deleted_at: dt | None = None,
+    removed_from_devices_at: dt | None = None,
     start_xpoint: str | None = None,
     end_xpoint: str | None = None,
     highlight_style_id: int | None = None,
@@ -175,6 +176,7 @@ async def create_test_highlight(
         datetime=datetime_str,
         content_hash=content_hash,
         deleted_at=deleted_at,
+        removed_from_devices_at=removed_from_devices_at,
         highlight_style_id=highlight_style_id,
     )
     db_session.add(highlight)

--- a/backend/tests/test_ereader_highlights.py
+++ b/backend/tests/test_ereader_highlights.py
@@ -1,5 +1,6 @@
 """Tests for the ereader highlight pull endpoint."""
 
+from datetime import UTC, datetime
 from typing import Any
 
 import pytest
@@ -231,3 +232,31 @@ async def test_book_without_highlights_returns_empty_list(
 
     assert response.status_code == 200
     assert response.json()["items"] == []
+
+
+async def test_highlight_removed_from_devices_is_excluded(
+    db_session: AsyncSession, client: AsyncClient, ereader_book: Book, test_user: User
+) -> None:
+    """A highlight the user deleted on a device stays away from every device."""
+    await create_test_highlight(
+        db_session=db_session,
+        book=ereader_book,
+        user_id=test_user.id,
+        text="Kept",
+        datetime_str="2024-01-15 14:00:00",
+        page=1,
+    )
+    await create_test_highlight(
+        db_session=db_session,
+        book=ereader_book,
+        user_id=test_user.id,
+        text="Deleted on the e-reader",
+        datetime_str="2024-01-15 14:01:00",
+        page=2,
+        removed_from_devices_at=datetime(2024, 3, 1, tzinfo=UTC),
+    )
+
+    response = await client.get("/api/v1/ereader/books/client-pull/highlights")
+
+    assert response.status_code == 200
+    assert [i["text"] for i in response.json()["items"]] == ["Kept"]

--- a/backend/tests/test_highlights.py
+++ b/backend/tests/test_highlights.py
@@ -925,9 +925,7 @@ class TestHighlightRemovedFromDevices:
     async def _removed_highlight(
         self, db_session: AsyncSession, test_user: models.User
     ) -> tuple[models.Book, models.Highlight]:
-        book = await create_test_book(
-            db_session=db_session, user_id=test_user.id, title="Web Book"
-        )
+        book = await create_test_book(db_session=db_session, user_id=test_user.id, title="Web Book")
         chapter = await create_test_chapter(
             db_session=db_session, book=book, name="Chapter One", chapter_number=1
         )

--- a/backend/tests/test_highlights.py
+++ b/backend/tests/test_highlights.py
@@ -1,5 +1,6 @@
 """Tests for highlights API endpoints."""
 
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -9,7 +10,12 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src import models
-from tests.conftest import CreateBookFunc
+from tests.conftest import (
+    CreateBookFunc,
+    create_test_book,
+    create_test_chapter,
+    create_test_highlight,
+)
 
 
 async def resync_edited_highlight(
@@ -911,3 +917,74 @@ class TestHighlightsUpload:
         response = await client.post("/api/v1/highlights/upload", json=payload)
 
         assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+
+
+class TestHighlightRemovedFromDevices:
+    """A highlight withheld from e-readers is untouched everywhere else."""
+
+    async def _removed_highlight(
+        self, db_session: AsyncSession, test_user: models.User
+    ) -> tuple[models.Book, models.Highlight]:
+        book = await create_test_book(
+            db_session=db_session, user_id=test_user.id, title="Web Book"
+        )
+        chapter = await create_test_chapter(
+            db_session=db_session, book=book, name="Chapter One", chapter_number=1
+        )
+        highlight = await create_test_highlight(
+            db_session=db_session,
+            book=book,
+            user_id=test_user.id,
+            text="Deleted on the e-reader, kept here",
+            datetime_str="2024-01-15 14:00:00",
+            chapter_id=chapter.id,
+            removed_from_devices_at=datetime(2024, 3, 1, tzinfo=UTC),
+        )
+        return book, highlight
+
+    async def test_removed_highlight_still_appears_in_the_web_reads(
+        self, client: AsyncClient, db_session: AsyncSession, test_user: models.User
+    ) -> None:
+        book, highlight = await self._removed_highlight(db_session, test_user)
+
+        search = await client.get(
+            f"/api/v1/books/{book.id}/highlights", params={"searchText": "e-reader"}
+        )
+        assert search.status_code == status.HTTP_200_OK
+        found = [h for c in search.json()["chapters"] for h in c["highlights"]]
+        assert [h["id"] for h in found] == [highlight.id]
+        assert found[0]["text"] == "Deleted on the e-reader, kept here"
+
+        details = await client.get(f"/api/v1/books/{book.id}")
+        assert details.status_code == status.HTTP_200_OK
+        listed = [h["id"] for c in details.json()["chapters"] for h in c["highlights"]]
+        assert listed == [highlight.id]
+
+    async def test_deleting_a_removed_highlight_still_soft_deletes_it(
+        self, client: AsyncClient, db_session: AsyncSession, test_user: models.User
+    ) -> None:
+        book, highlight = await self._removed_highlight(db_session, test_user)
+        before = await client.get(
+            f"/api/v1/books/{book.id}/highlights", params={"searchText": "e-reader"}
+        )
+        assert [h["id"] for c in before.json()["chapters"] for h in c["highlights"]] == [
+            highlight.id
+        ]
+
+        deletion = await client.request(
+            "DELETE",
+            f"/api/v1/books/{book.id}/highlight",
+            json={"highlight_ids": [highlight.id]},
+        )
+
+        assert deletion.status_code == status.HTTP_200_OK
+        assert deletion.json()["deleted_count"] == 1
+
+        after = await client.get(
+            f"/api/v1/books/{book.id}/highlights", params={"searchText": "e-reader"}
+        )
+        assert [h for c in after.json()["chapters"] for h in c["highlights"]] == []
+
+        await db_session.refresh(highlight)
+        assert highlight.deleted_at is not None
+        assert highlight.removed_from_devices_at is not None

--- a/backend/tests/unit/domain/reading/entities/test_highlight.py
+++ b/backend/tests/unit/domain/reading/entities/test_highlight.py
@@ -1,0 +1,79 @@
+"""Unit tests for the Highlight aggregate's device-removal state.
+
+Removal from devices is a second, non-destructive lifecycle alongside soft
+deletion: the highlight stays on the web and only disappears from e-readers.
+No endpoint sets it yet, so these guards are unreachable from the API tier.
+"""
+
+import pytest
+
+from src.domain.common.exceptions import DomainError
+from src.domain.common.value_objects.ids import BookId, UserId
+from src.domain.reading.entities.highlight import Highlight
+
+
+def _create() -> Highlight:
+    return Highlight.create(
+        user_id=UserId(1),
+        book_id=BookId(2),
+        text="A passage worth keeping on the web.",
+    )
+
+
+def test_new_highlight_is_not_removed_from_devices() -> None:
+    highlight = _create()
+
+    assert highlight.is_removed_from_devices() is False
+    assert highlight.removed_from_devices_at is None
+
+
+def test_remove_from_devices_stamps_the_timestamp() -> None:
+    highlight = _create()
+
+    highlight.remove_from_devices()
+
+    assert highlight.is_removed_from_devices() is True
+    assert highlight.removed_from_devices_at is not None
+
+
+def test_remove_from_devices_does_not_soft_delete() -> None:
+    highlight = _create()
+
+    highlight.remove_from_devices()
+
+    assert highlight.is_deleted() is False
+    assert highlight.deleted_at is None
+
+
+def test_removing_twice_raises() -> None:
+    highlight = _create()
+    highlight.remove_from_devices()
+
+    with pytest.raises(DomainError):
+        highlight.remove_from_devices()
+
+
+def test_restore_to_devices_clears_the_timestamp() -> None:
+    highlight = _create()
+    highlight.remove_from_devices()
+
+    highlight.restore_to_devices()
+
+    assert highlight.is_removed_from_devices() is False
+    assert highlight.removed_from_devices_at is None
+
+
+def test_restoring_a_highlight_that_is_on_devices_raises() -> None:
+    highlight = _create()
+
+    with pytest.raises(DomainError):
+        highlight.restore_to_devices()
+
+
+def test_soft_delete_leaves_the_device_state_alone() -> None:
+    highlight = _create()
+
+    highlight.soft_delete()
+
+    assert highlight.is_deleted() is True
+    assert highlight.is_removed_from_devices() is False


### PR DESCRIPTION
Fixes #596

Part 1 of highlight deletion sync. A highlight deleted on a device currently comes back on the next pull, because push is create-only and pull replaces the device's set from the server's live rows. Deleting it on the server is not an option either — the user's flashcards, bookmarks and notes hang off it.

So this adds a second, non-destructive state: `removed_from_devices_at`. The highlight stays whole on the web and only the e-reader pull skips it.

**Nothing sets the flag yet, so behaviour is unchanged.** The endpoint that sets it, the `is_new` upload semantics and the frontend badge are follow-ups.

## What changed

- **Migration `068`** — nullable `removed_from_devices_at` on `highlights`, with its own index, mirroring `deleted_at`.
- **Domain** — `remove_from_devices()` / `restore_to_devices()` / `is_removed_from_devices()` on `Highlight`, guarded by `DomainError` exactly like the `soft_delete()` / `restore()` pair.
- **ORM + mapper** — column plus both directions of `HighlightMapper`.
- **`EreaderHighlightsQuery`** — one extra `WHERE` condition. This is the only read that honours the new state; the other 15 places filtering `deleted_at IS NULL` are untouched, which is what keeps the highlight on the web.

## Acceptance criteria

| Criterion | Covered by |
|---|---|
| Absent from `GET /api/v1/ereader/books/{client_book_id}/highlights` | `test_highlight_removed_from_devices_is_excluded` |
| Still in the web highlights read | `test_removed_highlight_still_appears_in_the_web_reads` — asserts both `GET /books/{id}/highlights` and `GET /books/{id}` |
| Web delete unchanged, including for removed highlights | `test_deleting_a_removed_highlight_still_soft_deletes_it` |
| Migration + pyright + suite green | see below |

Criterion 2 names `GET /api/v1/books/{book_id}/highlights`, which is the full-text search endpoint; the plain web list is `GET /api/v1/books/{book_id}`. The test asserts the highlight survives in both.

## Verification

- `alembic upgrade head` → `068`, plus a `downgrade`/`upgrade` round trip, clean against Postgres.
- `make lint` — ruff clean, pyright 0 errors, import-linter 5 contracts kept.
- `uv run pytest` — 836 passed (was 833).
- jscpd — 114 clones before and after, 2.47% → 2.46%. No new duplication, threshold left at 2.55.

Each new test was proven able to fail: the e-reader test failed before the filter went in, and adding the same filter to `highlight_search_query.py` and `book_details_query.py` made both web-visibility tests fail before I reverted it.

## Note for review

`CONTEXT.md` has no term for this state yet, and its **E-reader** entry says to avoid "device" for the role — so `removed_from_devices` cuts against the glossary. I used the ticket's naming and left `CONTEXT.md` alone; worth a `/domain-modeling` pass later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)