### PR TITLE
Server: is_new upload flag — deliberate re-highlights revive removed or deleted highlights (#599)

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -583,7 +583,7 @@
           "highlights"
         ],
         "summary": "Upload Highlights",
-        "description": "Upload highlights from KOReader.\n\nCreates or updates book record and adds highlights with automatic deduplication.\nDuplicates are identified by the combination of book, text, and datetime.\n\n``removed_ids`` carries the highlights the reader deleted on the device:\nthey are withheld from every device's pull and stay whole on the web.\n\nArgs:\n    request: Highlight upload request containing book metadata and highlights\n\nReturns:\n    HighlightUploadResponse with upload statistics\n\nRaises:\n    HTTPException: If upload fails due to server error",
+        "description": "Upload highlights from KOReader.\n\nCreates or updates book record and adds highlights with automatic deduplication.\nDuplicates are identified by the combination of book, text, and datetime.\n\n``removed_ids`` carries the highlights the reader deleted on the device:\nthey are withheld from every device's pull and stay whole on the web.\n\nA highlight flagged ``is_new`` was created on the device after its last\npull, so a duplicate of a removed or deleted highlight is a deliberate\nre-highlight and brings that highlight back.\n\nArgs:\n    request: Highlight upload request containing book metadata and highlights\n\nReturns:\n    HighlightUploadResponse with upload statistics\n\nRaises:\n    HTTPException: If upload fails due to server error",
         "operationId": "upload_highlights",
         "requestBody": {
           "content": {
@@ -5974,6 +5974,12 @@
             ],
             "title": "Datetime Updated",
             "description": "KOReader datetime of the last edit on the device; absent until the highlight is first edited. The newest edit wins when devices disagree."
+          },
+          "is_new": {
+            "type": "boolean",
+            "title": "Is New",
+            "description": "True when the device created this highlight after its last pull, so the server can tell a deliberate re-highlight from a stale echo. A flagged push of a text removed from devices or deleted on the web brings that highlight back; an unflagged one is skipped, as it always was.",
+            "default": false
           }
         },
         "type": "object",

--- a/backend/src/application/reading/commands/highlights/highlight_upload_use_case.py
+++ b/backend/src/application/reading/commands/highlights/highlight_upload_use_case.py
@@ -55,6 +55,9 @@ class HighlightUploadData:
     datetime: str | None = None
     datetime_updated: str | None = None
     koreader_note: str | None = None
+    # Set by the device for a highlight it created after its last pull; tells a
+    # deliberate re-highlight from a stale echo of one already removed or deleted.
+    is_new: bool = False
 
 
 @dataclass(frozen=True)
@@ -119,9 +122,10 @@ class HighlightUploadUseCase:
         3. Batch fetches chapters by chapter_number
         4. Creates domain entities using factory methods
         5. Deduplicates using domain service
-        6. Applies the e-reader's newer note and style edits to skipped duplicates
-        7. Fills in the xpoints and position of duplicates stored without them
-        8. Bulk saves unique highlights
+        6. Revives the highlights a duplicate flagged is_new re-creates
+        7. Applies the e-reader's newer note and style edits to skipped duplicates
+        8. Fills in the xpoints and position of duplicates stored without them
+        9. Bulk saves unique highlights
 
         Args:
             client_book_id: Book identifier from client
@@ -176,6 +180,7 @@ class HighlightUploadUseCase:
 
         # Step 4: Create domain entities using factory methods
         new_highlights: list[Highlight] = []
+        pushed_as_new: set[ContentHash] = set()
 
         for data in highlight_data_list:
             # Resolve chapter ID
@@ -230,6 +235,8 @@ class HighlightUploadUseCase:
                 origin_device_id=device_id,
             )
             new_highlights.append(highlight)
+            if data.is_new:
+                pushed_as_new.add(highlight.content_hash)
 
         # Step 5: Deduplication using domain service
         existing_hashes = await self.highlight_repository.get_existing_hashes(
@@ -240,14 +247,20 @@ class HighlightUploadUseCase:
             new_highlights, existing_hashes
         )
 
-        # Steps 6-7: reconcile the live rows the duplicates matched, loaded once
+        # Step 6: bring back what a deliberate re-highlight re-creates, before the
+        # reconciliation below loads the rows -- a revived row is open to edits again
+        revived_count = await self._revive_rehighlighted(
+            duplicates, pushed_as_new, user_id_vo, book_id
+        )
+
+        # Steps 7-8: reconcile the live rows the duplicates matched, loaded once
         stored_duplicates = await self.highlight_repository.find_reconcilable_by_content_hashes(
             user_id_vo, book_id, [duplicate.content_hash for duplicate in duplicates]
         )
         await self._sync_device_edits_of_duplicates(duplicates, stored_duplicates, book_id)
         await self._fill_missing_positions_of_duplicates(duplicates, stored_duplicates, book_id)
 
-        # Step 8: Bulk save unique highlights
+        # Step 9: Bulk save unique highlights
         if unique:
             saved = await self.highlight_repository.bulk_save(unique)
             await self._embedding_enqueuer.enqueue_many(
@@ -264,6 +277,7 @@ class HighlightUploadUseCase:
             highlights_created=len(unique),
             highlights_skipped=len(duplicates),
             highlights_removed=removed_count,
+            highlights_revived=revived_count,
         )
 
         return HighlightUploadResult(
@@ -313,6 +327,78 @@ class HighlightUploadUseCase:
         )
 
         return len(removed)
+
+    async def _revive_rehighlighted(
+        self,
+        duplicates: list[Highlight],
+        pushed_as_new: set[ContentHash],
+        user_id: UserId,
+        book_id: BookId,
+    ) -> int:
+        """
+        Bring back the highlights a deliberate re-highlight re-creates.
+
+        A push that duplicates a highlight removed from devices or deleted on
+        the web is normally dropped, which is what stops a push-only device
+        from resurrecting the reader's deletions. The device tells the two
+        apart itself: a highlight absent from its last-pulled snapshot is new
+        on this device, and the reader marked the passage again on purpose, so
+        the stored highlight -- with its flashcards, bookmarks and tags --
+        comes back rather than a second row appearing beside it. An unflagged
+        duplicate is still dropped, so a stale device and a plugin too old to
+        send the flag behave exactly as before.
+
+        The revived row is live again before the reconciliation that follows,
+        so the push's note and style edits land on it through the ordinary
+        path. A row the web delete cascaded is only partly recoverable: its
+        flashcards and bookmarks were really deleted then and stay gone, and
+        its embedding, deleted with them, is enqueued again here.
+
+        Args:
+            duplicates: Highlights skipped by deduplication
+            pushed_as_new: Content hashes the device flagged as new on it
+            user_id: User the upload belongs to
+            book_id: Book the upload belongs to
+
+        Returns:
+            Number of stored highlights this call brought back
+        """
+        hashes = list(
+            dict.fromkeys(
+                duplicate.content_hash
+                for duplicate in duplicates
+                if duplicate.content_hash in pushed_as_new
+            )
+        )
+        if not hashes:
+            return 0
+
+        returned = await self.highlight_repository.restore_to_devices_by_content_hashes(
+            hashes, user_id, book_id
+        )
+        undeleted = await self.highlight_repository.restore_deleted_by_content_hashes(
+            hashes, user_id, book_id
+        )
+
+        if undeleted:
+            await self._embedding_enqueuer.enqueue_many(
+                ContentType.HIGHLIGHT,
+                [highlight_id.value for highlight_id in undeleted],
+                user_id.value,
+                reference_id=str(book_id.value),
+            )
+
+        revived = {highlight_id.value for highlight_id in returned + undeleted}
+
+        if revived:
+            logger.info(
+                "highlights_revived_by_rehighlight",
+                book_id=book_id.value,
+                returned_to_devices=len(returned),
+                undeleted=len(undeleted),
+            )
+
+        return len(revived)
 
     async def _sync_device_edits_of_duplicates(
         self,

--- a/backend/src/application/reading/protocols/highlight_repository.py
+++ b/backend/src/application/reading/protocols/highlight_repository.py
@@ -91,6 +91,27 @@ class HighlightRepositoryProtocol(Protocol):
         """
         ...
 
+    async def restore_to_devices_by_content_hashes(
+        self, hashes: list[ContentHash], user_id: UserId, book_id: BookId
+    ) -> list[HighlightId]:
+        """Let the highlights matching these hashes reach e-readers again.
+
+        Only rows actually withheld are touched, and only those IDs come back;
+        a hash matching a live or absent highlight changes nothing.
+        """
+        ...
+
+    async def restore_deleted_by_content_hashes(
+        self, hashes: list[ContentHash], user_id: UserId, book_id: BookId
+    ) -> list[HighlightId]:
+        """Undo the soft delete of the highlights matching these hashes.
+
+        Only rows actually soft-deleted are touched, and only those IDs come
+        back. What the delete cascaded away -- flashcards, bookmarks,
+        embeddings -- is gone for good; this brings back the highlight alone.
+        """
+        ...
+
     async def soft_delete_by_ids(
         self,
         highlight_ids: list[HighlightId],

--- a/backend/src/infrastructure/reading/repositories/highlight_repository.py
+++ b/backend/src/infrastructure/reading/repositories/highlight_repository.py
@@ -11,6 +11,7 @@ from datetime import UTC, datetime
 from sqlalchemy import delete, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload, selectinload
+from sqlalchemy.orm.attributes import InstrumentedAttribute
 
 from src.application.reading.protocols.highlight_repository import DeviceEdit
 from src.domain.common.value_objects import (
@@ -389,6 +390,89 @@ class HighlightRepository:
                 f"book_id={book_id.value}, user_id={user_id.value}"
             )
         return [HighlightId(hid) for hid in marked_ids]
+
+    async def restore_to_devices_by_content_hashes(
+        self, hashes: list[ContentHash], user_id: UserId, book_id: BookId
+    ) -> list[HighlightId]:
+        """
+        Let the highlights matching these hashes reach e-readers again.
+
+        Args:
+            hashes: Content hashes of the highlights to let through
+            user_id: User ID for authorization check
+            book_id: Book ID for validation
+
+        Returns:
+            The IDs of the highlights this call let through -- those that were
+            actually withheld. A hash matching a live highlight, another user's
+            or none at all changes nothing.
+        """
+        return await self._clear_flag_by_content_hashes(
+            HighlightORM.removed_from_devices_at, hashes, user_id, book_id
+        )
+
+    async def restore_deleted_by_content_hashes(
+        self, hashes: list[ContentHash], user_id: UserId, book_id: BookId
+    ) -> list[HighlightId]:
+        """
+        Undo the soft delete of the highlights matching these hashes.
+
+        What the web delete cascaded away -- flashcards, bookmarks, embeddings
+        -- was really deleted then and stays gone; this brings back the
+        highlight row alone.
+
+        Args:
+            hashes: Content hashes of the highlights to undelete
+            user_id: User ID for authorization check
+            book_id: Book ID for validation
+
+        Returns:
+            The IDs of the highlights this call undeleted -- those that were
+            actually soft-deleted.
+        """
+        return await self._clear_flag_by_content_hashes(
+            HighlightORM.deleted_at, hashes, user_id, book_id
+        )
+
+    async def _clear_flag_by_content_hashes(
+        self,
+        flag: InstrumentedAttribute[datetime | None],
+        hashes: list[ContentHash],
+        user_id: UserId,
+        book_id: BookId,
+    ) -> list[HighlightId]:
+        """
+        Clear one withholding timestamp on the rows that still carry it.
+
+        A single UPDATE ... RETURNING carries the eligibility check, mirroring
+        mark_removed_from_devices: two devices reviving the same highlight at
+        once cannot both report it, and a row revived moments earlier in this
+        same request cannot be missed through a stale identity map.
+        """
+        if not hashes:
+            return []
+
+        stmt = (
+            update(HighlightORM)
+            .where(
+                HighlightORM.user_id == user_id.value,
+                HighlightORM.book_id == book_id.value,
+                HighlightORM.content_hash.in_([h.value for h in hashes]),
+                flag.is_not(None),
+            )
+            .values({flag: None})
+            .returning(HighlightORM.id)
+            .execution_options(synchronize_session=False)
+        )
+        cleared_ids = list((await self.db.execute(stmt)).scalars().all())
+        await self.db.commit()
+
+        if cleared_ids:
+            logger.info(
+                f"Cleared {flag.key} on {len(cleared_ids)} highlights for "
+                f"book_id={book_id.value}, user_id={user_id.value}"
+            )
+        return [HighlightId(hid) for hid in cleared_ids]
 
     async def soft_delete_by_ids(
         self,

--- a/backend/src/infrastructure/reading/routers/highlights.py
+++ b/backend/src/infrastructure/reading/routers/highlights.py
@@ -72,6 +72,10 @@ async def upload_highlights(
     ``removed_ids`` carries the highlights the reader deleted on the device:
     they are withheld from every device's pull and stay whole on the web.
 
+    A highlight flagged ``is_new`` was created on the device after its last
+    pull, so a duplicate of a removed or deleted highlight is a deliberate
+    re-highlight and brings that highlight back.
+
     Args:
         request: Highlight upload request containing book metadata and highlights
 
@@ -94,6 +98,7 @@ async def upload_highlights(
             datetime=h.datetime,
             datetime_updated=h.datetime_updated,
             koreader_note=h.note,
+            is_new=h.is_new,
         )
         for h in request.highlights
     ]

--- a/backend/src/infrastructure/reading/schemas/highlight_schemas.py
+++ b/backend/src/infrastructure/reading/schemas/highlight_schemas.py
@@ -50,6 +50,15 @@ class HighlightCreate(HighlightBase):
             "highlight is first edited. The newest edit wins when devices disagree."
         ),
     )
+    is_new: bool = Field(
+        False,
+        description=(
+            "True when the device created this highlight after its last pull, so the "
+            "server can tell a deliberate re-highlight from a stale echo. A flagged "
+            "push of a text removed from devices or deleted on the web brings that "
+            "highlight back; an unflagged one is skipped, as it always was."
+        ),
+    )
 
 
 class HighlightLabel(BaseModel):

--- a/backend/tests/test_highlights.py
+++ b/backend/tests/test_highlights.py
@@ -1025,11 +1025,56 @@ async def sync(
     return response.json()
 
 
+async def pulled_ids(client: AsyncClient) -> dict[str, int]:
+    """What the e-reader gets back on its next pull, each text mapped to its ID."""
+    response = await client.get(f"/api/v1/ereader/books/{CLIENT_BOOK_ID}/highlights")
+    assert response.status_code == status.HTTP_200_OK
+    return {item["text"]: item["id"] for item in response.json()["items"]}
+
+
 async def pulled_texts(client: AsyncClient) -> list[str]:
     """The texts the e-reader gets back on its next pull."""
     response = await client.get(f"/api/v1/ereader/books/{CLIENT_BOOK_ID}/highlights")
     assert response.status_code == status.HTTP_200_OK
     return [item["text"] for item in response.json()["items"]]
+
+
+def pushed_as_new(text: str, **overrides: str) -> dict[str, Any]:
+    """The device's push of a highlight it created after its last pull."""
+    original = next(h for h in PUSHED_HIGHLIGHTS if h["text"] == text)
+    return {**original, "is_new": True, **overrides}
+
+
+async def another_readers_copy(
+    db_session: AsyncSession,
+    email: str,
+    text: str,
+    datetime_str: str,
+    removed_from_devices_at: datetime | None = None,
+) -> models.Highlight:
+    """The same passage in another reader's copy of the same client_book_id.
+
+    Two readers syncing the same book share its client_book_id, so every write
+    the upload does has to be scoped by user as well as by book.
+    """
+    other_user = models.User(email=email)
+    db_session.add(other_user)
+    await db_session.commit()
+    await db_session.refresh(other_user)
+    other_book = await create_test_book(
+        db_session=db_session,
+        user_id=other_user.id,
+        title="Their Copy",
+        client_book_id=CLIENT_BOOK_ID,
+    )
+    return await create_test_highlight(
+        db_session=db_session,
+        book=other_book,
+        user_id=other_user.id,
+        text=text,
+        datetime_str=datetime_str,
+        removed_from_devices_at=removed_from_devices_at,
+    )
 
 
 @pytest.fixture
@@ -1047,8 +1092,7 @@ async def synced_book(
 
     assert (await sync(client))["highlights_created"] == 2
 
-    response = await client.get(f"/api/v1/ereader/books/{CLIENT_BOOK_ID}/highlights")
-    return book, {item["text"]: item["id"] for item in response.json()["items"]}
+    return book, await pulled_ids(client)
 
 
 class TestHighlightUploadRemovals:
@@ -1137,23 +1181,9 @@ class TestHighlightUploadRemovals:
         db_session: AsyncSession,
         synced_book: tuple[models.Book, dict[str, int]],
     ) -> None:
-        """Two readers can share a client_book_id; a removal must not cross users."""
-        other_user = models.User(email="other-removals@test.com")
-        db_session.add(other_user)
-        await db_session.commit()
-        await db_session.refresh(other_user)
-        other_book = await create_test_book(
-            db_session=db_session,
-            user_id=other_user.id,
-            title="Their Copy",
-            client_book_id=CLIENT_BOOK_ID,
-        )
-        theirs = await create_test_highlight(
-            db_session=db_session,
-            book=other_book,
-            user_id=other_user.id,
-            text="Theirs",
-            datetime_str="2024-01-15 14:00:00",
+        """A removal must not cross users."""
+        theirs = await another_readers_copy(
+            db_session, "other-removals@test.com", "Theirs", "2024-01-15 14:00:00"
         )
 
         result = await sync(client, removed_ids=[theirs.id])
@@ -1227,3 +1257,179 @@ class TestHighlightUploadRemovals:
 
         assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
         assert await pulled_texts(client) == ["Kept on the device", "Deleted on the device"]
+
+
+class TestHighlightUploadRehighlights:
+    """A passage marked again on the device brings its highlight back."""
+
+    async def _remove_from_devices(self, client: AsyncClient, highlight_id: int) -> None:
+        assert (await sync(client, removed_ids=[highlight_id]))["highlights_removed"] == 1
+        assert await pulled_texts(client) == ["Kept on the device"]
+
+    async def _delete_on_the_web(self, client: AsyncClient, book_id: int, ids: list[int]) -> None:
+        deletion = await client.request(
+            "DELETE", f"/api/v1/books/{book_id}/highlight", json={"highlight_ids": ids}
+        )
+        assert deletion.status_code == status.HTTP_200_OK
+        assert deletion.json()["deleted_count"] == len(ids)
+
+    async def test_a_flagged_rehighlight_returns_a_removed_highlight_to_devices(
+        self, client: AsyncClient, synced_book: tuple[models.Book, dict[str, int]]
+    ) -> None:
+        _, ids = synced_book
+        await self._remove_from_devices(client, ids["Deleted on the device"])
+
+        result = await sync(
+            client,
+            highlights=[PUSHED_HIGHLIGHTS[0], pushed_as_new("Deleted on the device")],
+        )
+
+        assert result["highlights_created"] == 0
+        assert result["highlights_skipped"] == 2
+        # The same row is back, not a second one beside it.
+        assert await pulled_ids(client) == ids
+
+    async def test_a_flagged_rehighlight_restores_a_web_deleted_highlight(
+        self, client: AsyncClient, synced_book: tuple[models.Book, dict[str, int]]
+    ) -> None:
+        """What the web delete cascaded away stays gone; the highlight itself returns."""
+        book, ids = synced_book
+        deleted_id = ids["Deleted on the device"]
+        flashcard = await client.post(
+            f"/api/v1/highlights/{deleted_id}/flashcards",
+            json={"question": "Does it come back?", "answer": "The highlight does"},
+        )
+        assert flashcard.status_code == status.HTTP_201_CREATED
+        await self._delete_on_the_web(client, book.id, [deleted_id])
+
+        result = await sync(client, highlights=[pushed_as_new("Deleted on the device")])
+
+        assert result["highlights_created"] == 0
+        assert await pulled_ids(client) == ids
+
+        details = await client.get(f"/api/v1/books/{book.id}")
+        on_the_web = {h["id"]: h for c in details.json()["chapters"] for h in c["highlights"]}
+        assert deleted_id in on_the_web
+        assert on_the_web[deleted_id]["flashcards"] == []
+
+    async def test_a_flagged_rehighlight_takes_the_note_written_with_it(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        synced_book: tuple[models.Book, dict[str, int]],
+    ) -> None:
+        """Reviving happens before reconciliation, so the push's edits land on the row."""
+        _, ids = synced_book
+        await self._remove_from_devices(client, ids["Deleted on the device"])
+
+        await sync(
+            client,
+            highlights=[
+                pushed_as_new(
+                    "Deleted on the device",
+                    note="Marked it again",
+                    datetime_updated="2026-01-01 00:00:00",
+                )
+            ],
+        )
+
+        stored = (
+            await db_session.execute(
+                select(models.Highlight).filter_by(id=ids["Deleted on the device"])
+            )
+        ).scalar_one()
+        await db_session.refresh(stored)
+        assert stored.koreader_note == "Marked it again"
+        assert stored.removed_from_devices_at is None
+
+    async def test_an_unflagged_push_leaves_a_removed_highlight_removed(
+        self, client: AsyncClient, synced_book: tuple[models.Book, dict[str, int]]
+    ) -> None:
+        """A device that never learned the flag keeps today's behaviour."""
+        _, ids = synced_book
+        await self._remove_from_devices(client, ids["Deleted on the device"])
+
+        result = await sync(client)
+
+        assert result["highlights_created"] == 0
+        assert await pulled_texts(client) == ["Kept on the device"]
+
+    async def test_an_unflagged_push_leaves_a_web_deleted_highlight_deleted(
+        self, client: AsyncClient, synced_book: tuple[models.Book, dict[str, int]]
+    ) -> None:
+        book, ids = synced_book
+        await self._delete_on_the_web(client, book.id, [ids["Deleted on the device"]])
+
+        result = await sync(client)
+
+        assert result["highlights_created"] == 0
+        assert await pulled_texts(client) == ["Kept on the device"]
+        details = await client.get(f"/api/v1/books/{book.id}")
+        on_the_web = [h["text"] for c in details.json()["chapters"] for h in c["highlights"]]
+        assert on_the_web == ["Kept on the device"]
+
+    async def test_a_flagged_push_of_a_live_highlight_only_merges_its_edits(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        synced_book: tuple[models.Book, dict[str, int]],
+    ) -> None:
+        """A device that lost its snapshot flags everything; nothing may double up."""
+        _, ids = synced_book
+
+        result = await sync(
+            client,
+            highlights=[
+                pushed_as_new(
+                    "Kept on the device", note="Still here", datetime_updated="2026-01-01 00:00:00"
+                ),
+                pushed_as_new("Deleted on the device"),
+            ],
+        )
+
+        assert result["highlights_created"] == 0
+        assert result["highlights_skipped"] == 2
+        assert await pulled_ids(client) == ids
+
+        stored = (
+            await db_session.execute(
+                select(models.Highlight).filter_by(id=ids["Kept on the device"])
+            )
+        ).scalar_one()
+        await db_session.refresh(stored)
+        assert stored.koreader_note == "Still here"
+
+    async def test_a_flagged_rehighlight_outlives_a_removal_in_the_same_request(
+        self, client: AsyncClient, synced_book: tuple[models.Book, dict[str, int]]
+    ) -> None:
+        """Removals run first, so re-marking the passage wins -- deterministically."""
+        _, ids = synced_book
+
+        result = await sync(
+            client,
+            removed_ids=[ids["Deleted on the device"]],
+            highlights=[PUSHED_HIGHLIGHTS[0], pushed_as_new("Deleted on the device")],
+        )
+
+        assert result["highlights_removed"] == 1
+        assert await pulled_ids(client) == ids
+
+    async def test_another_users_removed_highlight_is_not_revived(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        synced_book: tuple[models.Book, dict[str, int]],
+    ) -> None:
+        """Two readers can remove the same passage; a revival must not cross users."""
+        theirs = await another_readers_copy(
+            db_session,
+            "other-rehighlights@test.com",
+            "Deleted on the device",
+            "2024-01-15 14:01:00",
+            removed_from_devices_at=datetime(2024, 3, 1, tzinfo=UTC),
+        )
+
+        await sync(client, highlights=[pushed_as_new("Deleted on the device")])
+
+        await db_session.refresh(theirs)
+        assert theirs.removed_from_devices_at is not None

--- a/backend/tests/test_semantic_live_enqueue.py
+++ b/backend/tests/test_semantic_live_enqueue.py
@@ -33,6 +33,9 @@ from tests.semantic_helpers import (
 #: without posting 33 highlights.
 SLICE_SIZE = "src.application.semantic.batching.EMBEDDING_SLICE_SIZE"
 
+#: The passage the revival tests delete or withhold and then mark again.
+REHIGHLIGHTED_TEXT = "first idea"
+
 
 def embedding_calls(job_queue: AsyncMock) -> list[dict[str, Any]]:
     """The kwargs of every embedding enqueue, ignoring any other task."""
@@ -50,6 +53,36 @@ async def create_note(client: AsyncClient, book: Book) -> dict[str, Any]:
     )
     assert response.status_code == status.HTTP_201_CREATED, response.text
     return response.json()["note"]
+
+
+async def upload_one_highlight(
+    client: AsyncClient, db_session: AsyncSession, job_queue: AsyncMock
+) -> models.Highlight:
+    """Upload REHIGHLIGHTED_TEXT and hand back its row, with the queue reset after."""
+    await upload_highlights(client, "book-1", REHIGHLIGHTED_TEXT)
+    stored = (await db_session.execute(select(models.Highlight))).scalars().one()
+    job_queue.enqueue.reset_mock()
+    return stored
+
+
+async def rehighlight(client: AsyncClient, removed_ids: list[int] | None = None) -> dict[str, Any]:
+    """Push REHIGHLIGHTED_TEXT as a highlight the device made after its last pull."""
+    response = await client.post(
+        "/api/v1/highlights/upload",
+        json={
+            "client_book_id": "book-1",
+            "removed_ids": removed_ids or [],
+            "highlights": [
+                {
+                    "text": REHIGHLIGHTED_TEXT,
+                    "datetime": "2024-01-15 14:30:00",
+                    "is_new": True,
+                }
+            ],
+        },
+    )
+    assert response.status_code == status.HTTP_200_OK, response.text
+    return response.json()
 
 
 class TestNoteWrites:
@@ -205,6 +238,50 @@ class TestHighlightUpload:
         assert result["highlights_created"] == 2
         texts = (await db_session.execute(select(models.Highlight.text))).scalars().all()
         assert sorted(texts) == ["first idea", "second idea"]
+
+    async def test_a_restored_highlight_is_enqueued_again(
+        self,
+        client: AsyncClient,
+        job_queue: AsyncMock,
+        db_session: AsyncSession,
+        create_book_via_api: CreateBookFunc,
+    ) -> None:
+        """The web delete took the embedding with it, so reviving the row must bring it back."""
+        book = await create_book_via_api(
+            {"client_book_id": "book-1", "title": "Crime and Punishment"}
+        )
+
+        with embeddings_enabled():
+            stored = await upload_one_highlight(client, db_session, job_queue)
+            deletion = await client.request(
+                "DELETE",
+                f"/api/v1/books/{book.book_id}/highlight",
+                json={"highlight_ids": [stored.id]},
+            )
+            assert deletion.json()["deleted_count"] == 1
+            job_queue.enqueue.reset_mock()
+
+            revived = await rehighlight(client)
+
+        assert revived["highlights_created"] == 0
+        assert [call["content_ids"] for call in embedding_calls(job_queue)] == [[stored.id]]
+
+    async def test_a_highlight_only_returned_to_devices_is_not_enqueued_again(
+        self,
+        client: AsyncClient,
+        job_queue: AsyncMock,
+        db_session: AsyncSession,
+        create_book_via_api: CreateBookFunc,
+    ) -> None:
+        """Removing a highlight from devices never touched its embedding."""
+        await create_book_via_api({"client_book_id": "book-1", "title": "Crime and Punishment"})
+
+        with embeddings_enabled():
+            stored = await upload_one_highlight(client, db_session, job_queue)
+            returned = await rehighlight(client, removed_ids=[stored.id])
+
+        assert returned["highlights_removed"] == 1
+        assert embedding_calls(job_queue) == []
 
     async def test_an_upload_that_creates_nothing_enqueues_nothing(
         self, client: AsyncClient, job_queue: AsyncMock, create_book_via_api: CreateBookFunc

--- a/frontend/src/api/generated/highlights/highlights.ts
+++ b/frontend/src/api/generated/highlights/highlights.ts
@@ -56,6 +56,10 @@ const withQueryKey = <T extends object, K>(query: T, queryKey: K): T & { queryKe
  * ``removed_ids`` carries the highlights the reader deleted on the device:
  * they are withheld from every device's pull and stay whole on the web.
  *
+ * A highlight flagged ``is_new`` was created on the device after its last
+ * pull, so a duplicate of a removed or deleted highlight is a deliberate
+ * re-highlight and brings that highlight back.
+ *
  * Args:
  *     request: Highlight upload request containing book metadata and highlights
  *

--- a/frontend/src/api/generated/model/highlightCreate.ts
+++ b/frontend/src/api/generated/model/highlightCreate.ts
@@ -38,4 +38,6 @@ export interface HighlightCreate {
   note?: string | null;
   /** KOReader datetime of the last edit on the device; absent until the highlight is first edited. The newest edit wins when devices disagree. */
   datetime_updated?: string | null;
+  /** True when the device created this highlight after its last pull, so the server can tell a deliberate re-highlight from a stale echo. A flagged push of a text removed from devices or deleted on the web brings that highlight back; an unflagged one is skipped, as it always was. */
+  is_new?: boolean;
 }


### PR DESCRIPTION
Fixes #599

Part 4 of the highlight deletion sync. The upload dedup check counts soft-deleted and withheld rows, which is what stops a push-only device from resurrecting the reader's deletions — and also what made a passage deleted on the web impossible to highlight again. The device now tells the two apart itself: a highlight absent from its last-pulled snapshot is new on this device, so a duplicate flagged `is_new` is a deliberate re-highlight, not a stale echo. No clock comparison involved.

## What changed

| Layer | Addition |
|---|---|
| `HighlightCreate` | optional `is_new: bool = false` |
| `HighlightUploadUseCase` | `_revive_rehighlighted()`, called as step 6 |
| `HighlightRepository` | `restore_to_devices_by_content_hashes()`, `restore_deleted_by_content_hashes()` |
| `openapi.json` + generated TS client | regenerated with `make api-client` |

Resolution of a duplicate now reads:

| Stored row it matches | Flagged `is_new` | Unflagged |
|---|---|---|
| live and visible | edit-merge, unchanged | edit-merge, unchanged |
| removed from devices (#596) | `removed_from_devices_at` cleared, edits applied | skipped, as today |
| soft-deleted on the web | undeleted, edits applied — flashcards stay gone | skipped, as today |

**Ordering.** The revival runs after deduplication and *before* the reconciliation load, so a revived row is live again by the time `find_reconcilable_by_content_hashes` reads it and the push's note and style edits land on it through the ordinary last-writer-wins merge. Removals (`removed_ids`, #598) still run first, so a removal and a flagged re-push of the same text in one request leave the highlight live — deterministic either way.

## Two decisions worth a look

**Set-based writes rather than `restore()` on a loaded entity.** The ticket describes calling the entity's `restore()`; I used two `UPDATE … RETURNING` statements instead, mirroring `mark_removed_from_devices` from #598. The eligibility predicate runs in SQL, so two devices reviving the same highlight at once cannot both report it, and the rows are not loaded twice — the reconciliation step reloads them anyway. `Highlight.restore()` therefore remains unused.

**Embeddings, slightly beyond the ticket's scope.** A web delete deletes the highlight's embeddings (`HighlightDeleteUseCase._delete_embeddings_for`), so restoring the row alone would leave it permanently missing from semantic search. Undeleted rows are enqueued for embedding again; a highlight merely returned to devices never lost its embedding, so it is not.

## Acceptance criteria

| Criterion | Covered by |
|---|---|
| `is_new` push revives a removed highlight | `test_a_flagged_rehighlight_returns_a_removed_highlight_to_devices` |
| `is_new` push restores a web-deleted one | `test_a_flagged_rehighlight_restores_a_web_deleted_highlight` |
| Unflagged pushes change nothing | `test_an_unflagged_push_leaves_a_removed_highlight_removed`, `test_an_unflagged_push_leaves_a_web_deleted_highlight_deleted` |
| Dedup and the note merge unaffected | `test_a_flagged_push_of_a_live_highlight_only_merges_its_edits`, `test_a_flagged_rehighlight_takes_the_note_written_with_it` |
| Removal vs. re-highlight ordering | `test_a_flagged_rehighlight_outlives_a_removal_in_the_same_request` |
| A revival cannot cross users | `test_another_users_removed_highlight_is_not_revived` |
| Embedding restored with the highlight | `test_a_restored_highlight_is_enqueued_again`, `test_a_highlight_only_returned_to_devices_is_not_enqueued_again` |

`uv run pytest` 854 passed · `uv run pyright` 0 errors · `lint-imports` 5 contracts kept · `jscpd` 113 clones / 2.4%, unchanged from `main`.

Each new test was checked against a deliberately broken implementation: short-circuiting the revival fails the four positive cases, ignoring the flag fails both legacy-behavior cases, dropping the enqueue fails the embedding case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NTb2ne3aTy11Z7mSvYGzmR