### PR TITLE
Web: badge highlights that are removed from devices (#600)

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -5806,6 +5806,12 @@
             ],
             "description": "Resolved label for this highlight"
           },
+          "removed_from_devices": {
+            "type": "boolean",
+            "title": "Removed From Devices",
+            "description": "True when the reader deleted this highlight on a device. It is kept whole on the web but withheld from every device's pull.",
+            "default": false
+          },
           "tags": {
             "items": {
               "$ref": "#/components/schemas/TagInBook"
@@ -6317,6 +6323,12 @@
               }
             ],
             "description": "Resolved label for this highlight"
+          },
+          "removed_from_devices": {
+            "type": "boolean",
+            "title": "Removed From Devices",
+            "description": "True when the reader deleted this highlight on a device. It is kept whole on the web but withheld from every device's pull.",
+            "default": false
           },
           "tags": {
             "items": {

--- a/backend/src/application/common/queries/highlight_row.py
+++ b/backend/src/application/common/queries/highlight_row.py
@@ -36,6 +36,7 @@ class HighlightRow:
     page: int | None
     datetime: str
     label: HighlightLabelView | None
+    removed_from_devices: bool
     tags: tuple[TagRef, ...]
     flashcards: tuple[FlashcardRef, ...]
     created_at: dt

--- a/backend/src/application/reading/queries/reading_sessions.py
+++ b/backend/src/application/reading/queries/reading_sessions.py
@@ -27,6 +27,7 @@ class SessionHighlightView:
     page: int | None
     datetime: str
     label: HighlightLabelView | None
+    removed_from_devices: bool
     created_at: dt
     updated_at: dt
 

--- a/backend/src/infrastructure/common/queries/row_mappers.py
+++ b/backend/src/infrastructure/common/queries/row_mappers.py
@@ -52,6 +52,7 @@ def highlight_row(row: HighlightORM, labels: dict[int, ResolvedLabel]) -> Highli
         )
         if style_id is not None
         else None,
+        removed_from_devices=row.removed_from_devices_at is not None,
         tags=tuple(tag_ref(tag) for tag in row.tags),
         flashcards=tuple(flashcard_ref(card) for card in row.flashcards),
         created_at=row.created_at,

--- a/backend/src/infrastructure/reading/queries/reading_session_query.py
+++ b/backend/src/infrastructure/reading/queries/reading_session_query.py
@@ -219,6 +219,7 @@ def _highlight_view(row: HighlightORM, labels: dict[int, ResolvedLabel]) -> Sess
         )
         if style_id is not None
         else None,
+        removed_from_devices=row.removed_from_devices_at is not None,
         created_at=row.created_at,
         updated_at=row.updated_at,
     )

--- a/backend/src/infrastructure/reading/routers/reading_sessions.py
+++ b/backend/src/infrastructure/reading/routers/reading_sessions.py
@@ -68,6 +68,7 @@ def _build_session_schema(view: ReadingSessionView) -> ReadingSession:
                 )
                 if highlight.label
                 else None,
+                removed_from_devices=highlight.removed_from_devices,
                 chapter=None,
                 chapter_number=None,
                 tags=[],

--- a/backend/src/infrastructure/reading/schemas/highlight_builders.py
+++ b/backend/src/infrastructure/reading/schemas/highlight_builders.py
@@ -28,6 +28,7 @@ def build_highlight_schema(highlight: HighlightRow) -> Highlight:
         )
         if highlight.label
         else None,
+        removed_from_devices=highlight.removed_from_devices,
         flashcards=[
             Flashcard(
                 id=card.id,

--- a/backend/src/infrastructure/reading/schemas/highlight_schemas.py
+++ b/backend/src/infrastructure/reading/schemas/highlight_schemas.py
@@ -70,6 +70,13 @@ class HighlightResponseBase(HighlightBase):
     book_id: int
     chapter_id: int | None
     label: HighlightLabel | None = Field(None, description="Resolved label for this highlight")
+    removed_from_devices: bool = Field(
+        default=False,
+        description=(
+            "True when the reader deleted this highlight on a device. It is kept "
+            "whole on the web but withheld from every device's pull."
+        ),
+    )
     tags: list[TagInBook] = Field(..., description="List of tags for this highlight")
     created_at: dt
     updated_at: dt

--- a/backend/src/infrastructure/tagging/routers/tags.py
+++ b/backend/src/infrastructure/tagging/routers/tags.py
@@ -377,6 +377,7 @@ async def add_tag_to_highlight(
         )
         if highlight.highlight_style_id
         else None,
+        removed_from_devices=highlight.is_removed_from_devices(),
         tags=[
             TagInBook(
                 id=tag.id.value,
@@ -456,6 +457,7 @@ async def remove_tag_from_highlight(
         )
         if highlight.highlight_style_id
         else None,
+        removed_from_devices=highlight.is_removed_from_devices(),
         tags=[
             TagInBook(
                 id=tag.id.value,

--- a/backend/tests/test_highlights.py
+++ b/backend/tests/test_highlights.py
@@ -959,6 +959,39 @@ class TestHighlightRemovedFromDevices:
         listed = [h["id"] for c in details.json()["chapters"] for h in c["highlights"]]
         assert listed == [highlight.id]
 
+    async def test_web_reads_flag_only_the_removed_highlight(
+        self, client: AsyncClient, db_session: AsyncSession, test_user: models.User
+    ) -> None:
+        book, removed = await self._removed_highlight(db_session, test_user)
+        kept = await create_test_highlight(
+            db_session=db_session,
+            book=book,
+            user_id=test_user.id,
+            text="Still on the e-reader",
+            datetime_str="2024-01-16 14:00:00",
+            chapter_id=removed.chapter_id,
+        )
+
+        details = await client.get(f"/api/v1/books/{book.id}")
+        assert details.status_code == status.HTTP_200_OK
+        by_id = {
+            h["id"]: h["removed_from_devices"]
+            for c in details.json()["chapters"]
+            for h in c["highlights"]
+        }
+        assert by_id == {removed.id: True, kept.id: False}
+
+        search = await client.get(
+            f"/api/v1/books/{book.id}/highlights", params={"searchText": "e-reader"}
+        )
+        assert search.status_code == status.HTTP_200_OK
+        searched = {
+            h["id"]: h["removed_from_devices"]
+            for c in search.json()["chapters"]
+            for h in c["highlights"]
+        }
+        assert searched == {removed.id: True, kept.id: False}
+
     async def test_deleting_a_removed_highlight_still_soft_deletes_it(
         self, client: AsyncClient, db_session: AsyncSession, test_user: models.User
     ) -> None:

--- a/frontend/src/api/generated/model/highlight.ts
+++ b/frontend/src/api/generated/model/highlight.ts
@@ -34,6 +34,8 @@ export interface Highlight {
   chapter_id: number | null;
   /** Resolved label for this highlight */
   label?: HighlightLabel | null;
+  /** True when the reader deleted this highlight on a device. It is kept whole on the web but withheld from every device's pull. */
+  removed_from_devices?: boolean;
   /** List of tags for this highlight */
   tags: TagInBook[];
   created_at: string;

--- a/frontend/src/api/generated/model/highlightResponseBase.ts
+++ b/frontend/src/api/generated/model/highlightResponseBase.ts
@@ -35,6 +35,8 @@ export interface HighlightResponseBase {
   chapter_id: number | null;
   /** Resolved label for this highlight */
   label?: HighlightLabel | null;
+  /** True when the reader deleted this highlight on a device. It is kept whole on the web but withheld from every device's pull. */
+  removed_from_devices?: boolean;
   /** List of tags for this highlight */
   tags: TagInBook[];
   created_at: string;

--- a/frontend/src/components/cards/HighlightCard.tsx
+++ b/frontend/src/components/cards/HighlightCard.tsx
@@ -3,6 +3,7 @@ import { HoverableCardActionArea } from '@/components/cards/HoverableCardActionA
 import { MetadataRow } from '@/components/cards/MetadataRow.tsx';
 import { TagChipList } from '@/components/TagChipList.tsx';
 import { LabelIndicator } from '@/pages/BookPage/common/LabelIndicator.tsx';
+import { NotOnDeviceChip } from '@/pages/BookPage/common/NotOnDeviceChip.tsx';
 import { BookmarkFilledIcon, DateIcon, FlashcardsIcon, QuoteIcon } from '@/theme/Icons.tsx';
 import { Box, Typography } from '@mui/material';
 
@@ -38,6 +39,7 @@ const Footer = ({ highlight, bookmark }: FooterProps) => {
         }}
       >
         <LabelIndicator label={highlight.label} size="small" />
+        <NotOnDeviceChip removed={highlight.removed_from_devices} />
         <DateIcon
           sx={(theme) => ({
             fontSize: 14,

--- a/frontend/src/pages/BookPage/Highlights/HighlightsPage.test.tsx
+++ b/frontend/src/pages/BookPage/Highlights/HighlightsPage.test.tsx
@@ -1,0 +1,43 @@
+import { aBookDetails, aChapter, aHighlight } from '@tests/fixtures/book';
+import { renderApp } from '@tests/harness/renderApp';
+import { bookApi } from '@tests/msw/bookApi';
+import { worker } from '@tests/msw/worker';
+import { expect, test } from 'vitest';
+import { userEvent } from 'vitest/browser';
+
+const REMOVED_TEXT = 'Deleted on the e-reader, kept here';
+const KEPT_TEXT = 'The map is not the territory.';
+
+const aBookWithARemovedHighlight = () =>
+  bookApi({
+    book: aBookDetails({
+      chapters: [
+        aChapter({
+          highlights: [
+            aHighlight({ id: 300, text: KEPT_TEXT }),
+            aHighlight({ id: 301, text: REMOVED_TEXT, removed_from_devices: true }),
+          ],
+        }),
+      ],
+    }),
+  });
+
+test('badges only the highlight that was removed from devices', async () => {
+  worker.use(...aBookWithARemovedHighlight().handlers);
+
+  const screen = await renderApp({ path: '/book/1/highlights' });
+
+  await expect.element(screen.getByText(REMOVED_TEXT)).toBeVisible();
+  await expect.element(screen.getByText(KEPT_TEXT)).toBeVisible();
+  expect(await screen.getByText('Not on device').all()).toHaveLength(1);
+});
+
+test('the highlight dialog badges a highlight removed from devices', async () => {
+  worker.use(...aBookWithARemovedHighlight().handlers);
+
+  const screen = await renderApp({ path: '/book/1/highlights' });
+  await userEvent.click(screen.getByRole('button', { name: new RegExp(REMOVED_TEXT) }));
+
+  const dialog = screen.getByRole('dialog');
+  await expect.element(dialog.getByText('Not on device')).toBeVisible();
+});

--- a/frontend/src/pages/BookPage/common/HighlightContent.tsx
+++ b/frontend/src/pages/BookPage/common/HighlightContent.tsx
@@ -1,5 +1,6 @@
 import type { Highlight } from '@/api/generated/model';
 import { LabelIndicator } from '@/pages/BookPage/common/LabelIndicator.tsx';
+import { NotOnDeviceChip } from '@/pages/BookPage/common/NotOnDeviceChip.tsx';
 import { DateIcon, QuoteIcon } from '@/theme/Icons.tsx';
 import { Box, Typography } from '@mui/material';
 
@@ -86,6 +87,7 @@ export const HighlightContent = ({ highlight, onLabelClick }: HighlightContentPr
           {highlight.page && ` • Page ${highlight.page}`}
         </Typography>
         <LabelIndicator label={highlight.label} onClick={onLabelClick} size="medium" />
+        <NotOnDeviceChip removed={highlight.removed_from_devices} size="medium" />
       </Box>
     </Box>
   );

--- a/frontend/src/pages/BookPage/common/NotOnDeviceChip.tsx
+++ b/frontend/src/pages/BookPage/common/NotOnDeviceChip.tsx
@@ -1,0 +1,35 @@
+import { NotOnDeviceIcon } from '@/theme/Icons.tsx';
+import { Chip, Tooltip } from '@mui/material';
+
+interface NotOnDeviceChipProps {
+  removed: boolean | undefined;
+  size?: 'small' | 'medium';
+}
+
+export const NotOnDeviceChip = ({ removed, size = 'small' }: NotOnDeviceChipProps) => {
+  if (!removed) {
+    return null;
+  }
+
+  return (
+    <Tooltip title="Deleted on the e-reader. It stays here, but no longer syncs to your devices.">
+      <Chip
+        label="Not on device"
+        size="small"
+        variant="outlined"
+        icon={<NotOnDeviceIcon />}
+        sx={{
+          color: 'text.secondary',
+          borderColor: 'divider',
+          fontWeight: 500,
+          fontSize: size === 'small' ? '0.7rem' : '0.8rem',
+          height: size === 'small' ? 22 : 26,
+          '& .MuiChip-icon': {
+            color: 'text.secondary',
+            fontSize: size === 'small' ? 14 : 16,
+          },
+        }}
+      />
+    </Tooltip>
+  );
+};

--- a/frontend/src/theme/Icons.tsx
+++ b/frontend/src/theme/Icons.tsx
@@ -51,5 +51,8 @@ export {
 // User/System icons
 export { Logout as LogoutIcon, Settings as SettingsIcon } from '@mui/icons-material';
 
+// Device sync icons
+export { PhonelinkOff as NotOnDeviceIcon } from '@mui/icons-material';
+
 // Date/Time icons
 export { CalendarMonth as DateIcon } from '@mui/icons-material';


### PR DESCRIPTION
Part 5 of the highlight deletion sync feature. A highlight deleted on the e-reader stays on the web (#596); without a visual cue, a highlight that is visible here but never returns to the reader is confusing. Per the design review: badge it, no restore control in v1 — re-highlighting the passage on the device is the recovery path.

## Backend — the flag flows through the read models

| File | Change |
|---|---|
| `application/common/queries/highlight_row.py` | `removed_from_devices: bool` on the shared `HighlightRow` |
| `infrastructure/common/queries/row_mappers.py` | maps it from `removed_from_devices_at is not None` |
| `reading/schemas/highlight_schemas.py` | field on `HighlightResponseBase` |
| `reading/schemas/highlight_builders.py` | fills it for book details and in-book search |
| `reading/queries/reading_sessions.py` + adapter + router | same flag on `SessionHighlightView` |
| `tagging/routers/tags.py` (×2) | fills it from `highlight.is_removed_from_devices()` |

One deliberate step past the ticket's wording: it named only the book-highlights read model, but `HighlightCard` is reused by reading sessions, notes and the chapter dialog, so the reading-session view carries the flag too — otherwise the badge would be silently absent there. The flashcard-embedded highlight (`FlashcardHighlightView`) keeps the `False` default; that view never renders a `HighlightCard`.

## Frontend

- `pages/BookPage/common/NotOnDeviceChip.tsx` — outlined MUI `Chip` using `text.secondary` / `divider` tokens only, `PhonelinkOff` exported as `NotOnDeviceIcon`, tooltip explaining the state.
- Rendered in `HighlightCard`'s footer (list) and `HighlightContent`'s metadata row (dialog). Both additive inside existing flex rows — no layout changes.

## Acceptance criteria

- Removed highlights render with the badge; ordinary ones don't — covered by both new tests.
- No layout regressions; duplication check green (backend 2.4% vs 2.55 threshold, frontend 1.4% vs 1.7 — neither moved).

## Verification

- Backend: 845 passed. New API test `test_web_reads_flag_only_the_removed_highlight` asserts `true` for the removed and `false` for an ordinary highlight, through `GET /api/v1/books/{id}` and the search endpoint.
- Frontend: 67 passed, including a new `HighlightsPage.test.tsx` (badge appears exactly once in the list; appears in the dialog).
- Both new tests were confirmed to fail against deliberately broken code, then reverted.
- pyright clean, ruff + format clean, import-linter 5/5 kept, eslint clean.

Fixes #600

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EpipxtqKFVvxnGLm86Ts3y
