### PR TITLE
Add `make backup-production` for a local zip backup of production

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -220,3 +220,6 @@ worktrees/
 
 # Superpowers specs and plans: local working notes, not part of the repo's docs
 /docs/superpowers/
+
+# Local production backups (`make backup-production`)
+/backups/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help test mutation-test duplication-check dev-app dev-worker migrate migrate-new lint format api-client release-nightly deploy empty-s3-bucket reset-db clone-production-db
+.PHONY: help test mutation-test duplication-check dev-app dev-worker migrate migrate-new lint format api-client release-nightly deploy empty-s3-bucket reset-db clone-production-db backup-production
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-18s\033[0m %s\n", $$1, $$2}'
@@ -76,6 +76,14 @@ empty-s3-bucket: ## Remove all objects from the local S3 bucket
 # `make clone-production-db ARGS="--yes --no-files"` (see --help).
 clone-production-db: ## Replace the local dev database and book files with a clone of production (destructive)
 	set -a; [ -f .env.deploy ] && . ./.env.deploy; set +a; ./scripts/clone-production-db.sh $(ARGS)
+
+# Read-only: dumps the production database and downloads the book files into one
+# zip under backups/. Uses the same .env.deploy and the same Railway discovery as
+# `clone-production-db`. EPUBs are excluded by default because they dominate the
+# size and can be re-uploaded; pass flags with ARGS, e.g.
+# `make backup-production ARGS="--with-epubs -o /mnt/backups"` (see --help).
+backup-production: ## Back up the production database and book files into a local zip archive
+	set -a; [ -f .env.deploy ] && . ./.env.deploy; set +a; ./scripts/backup-production.sh $(ARGS)
 
 reset-db: ## Reset the database (removes volume and re-runs migrations)
 	docker compose -f docker-compose.dev.yml down -v postgres

--- a/scripts/backup-production.sh
+++ b/scripts/backup-production.sh
@@ -1,0 +1,181 @@
+#!/bin/bash
+# Back up Railway production into a single zip archive on this machine. Read
+# only: nothing in production is written to, and no local database is touched.
+#
+# The archive holds a custom-format pg_dump and the book files, so it restores
+# with `pg_restore` plus an `aws s3 sync` of the extracted book-files directory.
+#
+# EPUBs are left out by default — they are the bulk of the bytes and can be
+# re-uploaded from their sources, while book covers are generated and small.
+# Pass --with-epubs for a complete copy.
+#
+# Production discovery, its requirements (RAILWAY_API_TOKEN,
+# RAILWAY_ENVIRONMENT_ID) and the overrides that bypass it live in
+# scripts/lib/railway-production.sh. `make backup-production` sources those from
+# the git-ignored root .env.deploy, the same file `make deploy` uses, so no extra
+# setup is needed. Needs pg_dump, psql, jq, curl, zip, and aws.
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: backup-production.sh [options]
+
+  -o, --output PATH  Where to write the archive. A directory (or a path that
+                     does not end in .zip) keeps the generated filename.
+                     Default: backups/crossbill-production-<UTC timestamp>.zip
+      --with-epubs   Include the EPUB files as well as the book covers.
+      --no-files     Back up the database only, leaving out book files entirely.
+      --with-jobs    Include the SAQ job-queue rows (schema only by default).
+  -f, --force        Overwrite an existing archive at that path.
+  -h, --help         Show this help.
+EOF
+}
+
+OUTPUT=""
+WITH_EPUBS=false
+BACKUP_FILES=true
+WITH_JOBS=false
+FORCE=false
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -o | --output)
+      [ $# -ge 2 ] || {
+        echo "--output needs a path." >&2
+        exit 2
+      }
+      OUTPUT="$2"
+      shift
+      ;;
+    --with-epubs) WITH_EPUBS=true ;;
+    --no-files) BACKUP_FILES=false ;;
+    --with-jobs) WITH_JOBS=true ;;
+    -f | --force) FORCE=true ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+# shellcheck source=lib/railway-production.sh
+. "$(cd "$(dirname "$0")" && pwd)/lib/railway-production.sh"
+
+require_tools jq curl zip pg_dump psql
+[ "$BACKUP_FILES" = true ] && require_tools aws
+
+# --- Where the archive goes --------------------------------------------------
+
+TIMESTAMP="$(date -u +%Y%m%d-%H%M%S)"
+ARCHIVE_NAME="crossbill-production-${TIMESTAMP}.zip"
+
+case "$OUTPUT" in
+  '') ARCHIVE="${REPO_ROOT}/backups/${ARCHIVE_NAME}" ;;
+  *.zip) ARCHIVE="$OUTPUT" ;;
+  *) ARCHIVE="${OUTPUT%/}/${ARCHIVE_NAME}" ;;
+esac
+
+if [ -e "$ARCHIVE" ] && [ "$FORCE" = false ]; then
+  echo "${ARCHIVE} already exists. Pass --force to overwrite it." >&2
+  exit 1
+fi
+
+mkdir -p "$(dirname "$ARCHIVE")"
+# zip writes relative to the staging directory, so resolve the path first.
+ARCHIVE="$(cd "$(dirname "$ARCHIVE")" && pwd)/$(basename "$ARCHIVE")"
+
+# --- Resolve the production side ---------------------------------------------
+
+resolve_production_database_url
+[ "$BACKUP_FILES" = true ] && resolve_production_s3 --no-files
+
+require_pg_dump_at_least_server "$PRODUCTION_DATABASE_URL"
+
+echo
+echo "  database  $(redact "$PRODUCTION_DATABASE_URL")"
+if [ "$BACKUP_FILES" = true ]; then
+  echo "  files     ${PRODUCTION_S3_ENDPOINT_URL}/${PRODUCTION_S3_BUCKET_NAME}"
+fi
+echo "         -> ${ARCHIVE}"
+echo
+
+STAGING_DIR="$(mktemp -d -t crossbill-backup-XXXXXX)"
+trap 'rm -rf "$STAGING_DIR"' EXIT
+
+# --- Database ----------------------------------------------------------------
+
+DUMP_ARGS=(--format=custom --no-owner --no-privileges)
+if [ "$WITH_JOBS" = false ]; then
+  # The queue is transient state, and restoring a backlog would have a worker
+  # re-run jobs that already finished, some of which cost money.
+  DUMP_ARGS+=(--exclude-table-data 'public.saq_jobs' --exclude-table-data 'public.saq_stats')
+fi
+
+echo "Dumping production..."
+pg_dump "${DUMP_ARGS[@]}" --file "${STAGING_DIR}/database.dump" "$PRODUCTION_DATABASE_URL"
+echo "Dumped $(du -h "${STAGING_DIR}/database.dump" | cut -f1)."
+
+# --- Book files --------------------------------------------------------------
+
+FILE_COUNT=0
+if [ "$BACKUP_FILES" = true ]; then
+  SYNC_ARGS=(--only-show-errors)
+  if [ "$WITH_EPUBS" = false ]; then
+    # Excluding the prefix rather than syncing book-covers/ alone, so any key
+    # prefix added later still lands in the backup.
+    SYNC_ARGS+=(--exclude 'epubs/*')
+  fi
+
+  echo "Downloading book files..."
+  mkdir -p "${STAGING_DIR}/book-files"
+  aws_prod s3 sync "s3://${PRODUCTION_S3_BUCKET_NAME}" "${STAGING_DIR}/book-files" "${SYNC_ARGS[@]}"
+  FILE_COUNT="$(find "${STAGING_DIR}/book-files" -type f | wc -l | tr -d ' ')"
+  echo "Downloaded ${FILE_COUNT} files."
+fi
+
+# --- Manifest ----------------------------------------------------------------
+
+SERVER_VERSION="$(psql "$PRODUCTION_DATABASE_URL" -tAc 'SHOW server_version')"
+ALEMBIC_REVISION="$(psql "$PRODUCTION_DATABASE_URL" -tAc 'SELECT version_num FROM alembic_version' 2>/dev/null || echo unknown)"
+
+cat >"${STAGING_DIR}/MANIFEST.txt" <<EOF
+Crossbill production backup
+created         ${TIMESTAMP} UTC
+source          $(redact "$PRODUCTION_DATABASE_URL")
+postgres        ${SERVER_VERSION}
+alembic head    ${ALEMBIC_REVISION}
+job queue rows  $([ "$WITH_JOBS" = true ] && echo included || echo "excluded (schema only)")
+book files      $(
+  if [ "$BACKUP_FILES" = false ]; then
+    echo "excluded"
+  elif [ "$WITH_EPUBS" = true ]; then
+    echo "${FILE_COUNT} files, EPUBs included"
+  else
+    echo "${FILE_COUNT} files, EPUBs excluded"
+  fi
+)
+
+Restore the database into an empty database:
+  pg_restore --dbname "\$DATABASE_URL" --no-owner --no-privileges --single-transaction database.dump
+
+Restore the book files into object storage:
+  aws --endpoint-url "\$S3_ENDPOINT_URL" s3 sync book-files "s3://\$S3_BUCKET_NAME"
+EOF
+
+# --- Archive -----------------------------------------------------------------
+
+echo "Writing the archive..."
+rm -f "$ARCHIVE"
+(cd "$STAGING_DIR" && zip -q -r "$ARCHIVE" .)
+
+echo
+echo "Wrote ${ARCHIVE} ($(du -h "$ARCHIVE" | cut -f1))."
+if [ "$BACKUP_FILES" = true ] && [ "$WITH_EPUBS" = false ]; then
+  echo "EPUB files were left out; pass --with-epubs to include them."
+fi

--- a/scripts/clone-production-db.sh
+++ b/scripts/clone-production-db.sh
@@ -3,28 +3,11 @@
 # production. Destructive by design: the local database is dropped and
 # recreated, and local book storage is mirrored onto production's.
 #
-# Requirements (no `railway` CLI / login needed — talks to the API directly):
-#   - RAILWAY_API_TOKEN   Account/Team token: railway.com -> Account -> Tokens.
-#                         NOTE: must be this name, NOT RAILWAY_TOKEN (the CLI
-#                         reserves RAILWAY_TOKEN for project tokens and will
-#                         reject an account token placed there).
-#   - RAILWAY_ENVIRONMENT_ID   which environment to clone from. Resource ID (not
-#                         kept in-repo). Find it with `railway status --json`.
-#   - pg_dump / pg_restore / psql, jq, curl, and aws (for book files)
-#
-# `make clone-production-db` sources these from the git-ignored root .env.deploy,
-# the same file `make deploy` uses, so no extra setup is needed.
-#
-# Both production endpoints are discovered through the Railway API rather than
-# being configured here, so no resource IDs live in the repo. The database is
-# whichever one the app actually connects to: the service holding DATABASE_URL
-# without PGDATA is the app, and the Postgres service whose private domain that
-# URL names is production. Anything keyed off variable names alone — "the service
-# exposing DATABASE_PUBLIC_URL" — silently picks a retired database once a project
-# holds two of them, which is what happened when production moved to pgvector.
-# Object storage still comes from the service exposing S3_BUCKET_NAME.
-# Pin either with RAILWAY_POSTGRES_SERVICE_ID / RAILWAY_SERVICE_ID, or bypass
-# discovery with PRODUCTION_DATABASE_URL and the PRODUCTION_S3_* variables.
+# Production discovery, its requirements (RAILWAY_API_TOKEN,
+# RAILWAY_ENVIRONMENT_ID) and the overrides that bypass it live in
+# scripts/lib/railway-production.sh. `make clone-production-db` sources those
+# from the git-ignored root .env.deploy, the same file `make deploy` uses, so no
+# extra setup is needed. Needs pg_dump / pg_restore / psql, jq, curl, and aws.
 #
 # The local database comes from LOCAL_DATABASE_URL, else DATABASE_URL in the root
 # .env, else the dev default. It must point at localhost — cloning over a remote
@@ -83,173 +66,12 @@ if [ "$CLONE_DB" = false ] && [ "$CLONE_FILES" = false ]; then
   exit 2
 fi
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
-API="https://backboard.railway.com/graphql/v2"
-
-require_tools() {
-  local tool
-  for tool in "$@"; do
-    command -v "$tool" >/dev/null || {
-      echo "Missing ${tool}." >&2
-      exit 1
-    }
-  done
-}
+# shellcheck source=lib/railway-production.sh
+. "$(cd "$(dirname "$0")" && pwd)/lib/railway-production.sh"
 
 require_tools jq curl
 [ "$CLONE_DB" = true ] && require_tools pg_dump pg_restore psql
 [ "$CLONE_FILES" = true ] && require_tools aws
-
-gql() {
-  # $1 = full JSON request body; echoes the response, fails on a GraphQL error.
-  local resp
-  resp="$(curl -sS -X POST "$API" \
-    -H "Authorization: Bearer ${RAILWAY_API_TOKEN}" \
-    -H "Content-Type: application/json" \
-    --data "$1")"
-  if echo "$resp" | jq -e '.errors' >/dev/null 2>&1; then
-    echo "Railway API error: $resp" >&2
-    exit 1
-  fi
-  printf '%s' "$resp"
-}
-
-service_variables() {
-  # $1 = service id; echoes that service instance's resolved variables as JSON.
-  gql "$(jq -n --arg p "$PROJECT_ID" --arg e "$ENVIRONMENT_ID" --arg s "$1" '{
-    query: "query($p: String!, $e: String!, $s: String!) { variables(projectId: $p, environmentId: $e, serviceId: $s) }",
-    variables: { p: $p, e: $e, s: $s }
-  }')" | jq '.data.variables'
-}
-
-# Loads every service's variables into SERVICE_NAMES / SERVICE_VARS once, so the
-# database and the storage credentials cost one discovery pass between them.
-declare -a SERVICE_NAMES=()
-declare -a SERVICE_VARS=()
-DISCOVERED=false
-
-discover_services() {
-  [ "$DISCOVERED" = true ] && return
-  : "${RAILWAY_API_TOKEN:?Set RAILWAY_API_TOKEN (railway.com -> Account -> Tokens; NOT RAILWAY_TOKEN)}"
-  ENVIRONMENT_ID="${RAILWAY_ENVIRONMENT_ID:?Set RAILWAY_ENVIRONMENT_ID (find it with: railway status --json)}"
-
-  PROJECT_ID="$(gql "$(jq -n --arg id "$ENVIRONMENT_ID" '{
-    query: "query($id: String!) { environment(id: $id) { projectId } }",
-    variables: { id: $id }
-  }')" | jq -r '.data.environment.projectId')"
-
-  local services id name
-  services="$(gql "$(jq -n --arg id "$PROJECT_ID" '{
-    query: "query($id: String!) { project(id: $id) { services { edges { node { id name } } } } }",
-    variables: { id: $id }
-  }')" | jq -r '.data.project.services.edges[].node | "\(.id) \(.name)"')"
-
-  while read -r id name; do
-    [ -n "$id" ] || continue
-    SERVICE_NAMES+=("$name")
-    SERVICE_VARS+=("$(service_variables "$id")")
-  done <<<"$services"
-
-  DISCOVERED=true
-}
-
-# Finds the one service whose variables contain $1, and sets FOUND_VARS /
-# FOUND_SERVICE. Anything other than exactly one match is ambiguous.
-find_service_by_variable() {
-  local key="$1" i matches=()
-  discover_services
-  for i in "${!SERVICE_NAMES[@]}"; do
-    echo "${SERVICE_VARS[$i]}" | jq -e --arg k "$key" '.[$k] // empty' >/dev/null 2>&1 &&
-      matches+=("$i")
-  done
-
-  case "${#matches[@]}" in
-    1)
-      FOUND_SERVICE="${SERVICE_NAMES[${matches[0]}]}"
-      FOUND_VARS="${SERVICE_VARS[${matches[0]}]}"
-      ;;
-    0)
-      echo "No service in this Railway environment exposes ${key}." >&2
-      return 1
-      ;;
-    *)
-      local names=()
-      for i in "${matches[@]}"; do names+=("${SERVICE_NAMES[$i]}"); done
-      echo "Several services expose ${key}: ${names[*]}" >&2
-      return 1
-      ;;
-  esac
-}
-
-# Sets FOUND_VARS / FOUND_SERVICE to the one service that uses a database
-# without being one: it holds DATABASE_URL but no PGDATA, which every Railway
-# Postgres image sets. That is the app, and what it points at defines production.
-find_database_consumer() {
-  local i matches=() names=()
-  discover_services
-  for i in "${!SERVICE_NAMES[@]}"; do
-    echo "${SERVICE_VARS[$i]}" | jq -e '.DATABASE_URL and (.PGDATA | not)' >/dev/null 2>&1 &&
-      matches+=("$i")
-  done
-
-  case "${#matches[@]}" in
-    1)
-      FOUND_SERVICE="${SERVICE_NAMES[${matches[0]}]}"
-      FOUND_VARS="${SERVICE_VARS[${matches[0]}]}"
-      ;;
-    0)
-      echo "No service in this Railway environment connects to a database." >&2
-      return 1
-      ;;
-    *)
-      for i in "${matches[@]}"; do names+=("${SERVICE_NAMES[$i]}"); done
-      echo "Several services connect to a database: ${names[*]}" >&2
-      echo "Pin the app with RAILWAY_SERVICE_ID, or set PRODUCTION_DATABASE_URL." >&2
-      return 1
-      ;;
-  esac
-}
-
-# Sets FOUND_VARS / FOUND_SERVICE to the service whose private domain is $1.
-find_service_by_private_domain() {
-  local domain="$1" i
-  discover_services
-  for i in "${!SERVICE_NAMES[@]}"; do
-    [ "$(echo "${SERVICE_VARS[$i]}" | jq -r '.RAILWAY_PRIVATE_DOMAIN // empty')" = "$domain" ] || continue
-    FOUND_SERVICE="${SERVICE_NAMES[$i]}"
-    FOUND_VARS="${SERVICE_VARS[$i]}"
-    return 0
-  done
-  return 1
-}
-
-# Echoes the hostname of a connection URL.
-url_host() {
-  local authority="${1#*://}"
-  authority="${authority%%/*}"
-  authority="${authority##*@}"
-  echo "${authority%%:*}"
-}
-
-# Echoes a URL for the database service whose variables are $1 that resolves from
-# outside Railway, or nothing if it only publishes a private endpoint. A service
-# without a TCP proxy still sets DATABASE_URL, pointing at .railway.internal,
-# which is unreachable here and would fail much later as a DNS error.
-public_database_url() {
-  local vars="$1" url
-  url="$(echo "$vars" | jq -r '.DATABASE_PUBLIC_URL // empty')"
-  [ -n "$url" ] || url="$(echo "$vars" | jq -r '.DATABASE_URL // empty')"
-  case "$(url_host "$url")" in
-    '' | *.railway.internal) return 0 ;;
-  esac
-  printf '%s' "$url"
-}
-
-# Strips the userinfo from a connection URL so it can be printed safely.
-redact() {
-  echo "$1" | sed -E 's#(://)[^/@]*@#\1<credentials>@#'
-}
 
 # Splits a connection URL into HOST, DB_NAME and MAINTENANCE_URL (the same
 # server with the `postgres` database), so we can drop the target database
@@ -269,76 +91,15 @@ parse_url() {
   MAINTENANCE_URL="postgresql://${authority}/postgres${query}"
 }
 
-# Reads one key out of the root .env. Sourcing the whole file is not safe — not
-# all of its values are shell-quoted.
-env_value() {
-  [ -f "${REPO_ROOT}/.env" ] || return 0
-  sed -n "s/^$1=//p" "${REPO_ROOT}/.env" | tail -n 1 | sed -E 's/^["'"'"']//; s/["'"'"']$//'
+aws_local() {
+  aws_with "$LOCAL_S3_ACCESS_KEY_ID" "$LOCAL_S3_SECRET_ACCESS_KEY" \
+    "$LOCAL_S3_REGION" "$LOCAL_S3_ENDPOINT_URL" "$@"
 }
 
 # --- Resolve the production side ---------------------------------------------
 
-if [ "$CLONE_DB" = true ]; then
-  if [ -n "${PRODUCTION_DATABASE_URL:-}" ]; then
-    echo "Using PRODUCTION_DATABASE_URL from the environment."
-  elif [ -n "${RAILWAY_POSTGRES_SERVICE_ID:-}" ]; then
-    discover_services
-    PRODUCTION_DATABASE_URL="$(public_database_url "$(service_variables "$RAILWAY_POSTGRES_SERVICE_ID")")"
-    [ -n "$PRODUCTION_DATABASE_URL" ] || {
-      echo "Service ${RAILWAY_POSTGRES_SERVICE_ID} publishes no endpoint reachable from here." >&2
-      echo "Enable its public TCP proxy in the Railway dashboard, or set PRODUCTION_DATABASE_URL." >&2
-      exit 1
-    }
-  else
-    echo "Resolving the production database from Railway..."
-    find_database_consumer || exit 1
-    APP_SERVICE="$FOUND_SERVICE"
-    APP_DB_HOST="$(url_host "$(echo "$FOUND_VARS" | jq -r '.DATABASE_URL')")"
-
-    find_service_by_private_domain "$APP_DB_HOST" || {
-      echo "The '${APP_SERVICE}' service points at ${APP_DB_HOST}, which is not a service" >&2
-      echo "in this environment. Pin RAILWAY_POSTGRES_SERVICE_ID, or set PRODUCTION_DATABASE_URL." >&2
-      exit 1
-    }
-
-    PRODUCTION_DATABASE_URL="$(public_database_url "$FOUND_VARS")"
-    [ -n "$PRODUCTION_DATABASE_URL" ] || {
-      echo "The '${FOUND_SERVICE}' database publishes no endpoint reachable from here." >&2
-      echo "Enable its public TCP proxy in the Railway dashboard, or set PRODUCTION_DATABASE_URL." >&2
-      exit 1
-    }
-    echo "Found the '${FOUND_SERVICE}' database, which '${APP_SERVICE}' connects to."
-  fi
-fi
-
-if [ "$CLONE_FILES" = true ]; then
-  if [ -n "${PRODUCTION_S3_BUCKET_NAME:-}" ]; then
-    echo "Using PRODUCTION_S3_* from the environment."
-  else
-    if [ -n "${RAILWAY_SERVICE_ID:-}" ]; then
-      discover_services
-      FOUND_VARS="$(service_variables "$RAILWAY_SERVICE_ID")"
-    else
-      echo "Resolving production object storage from Railway..."
-      find_service_by_variable S3_BUCKET_NAME || {
-        echo "Pin the app service with RAILWAY_SERVICE_ID, or set the PRODUCTION_S3_* variables." >&2
-        exit 1
-      }
-      echo "Found the '${FOUND_SERVICE}' service."
-    fi
-    PRODUCTION_S3_BUCKET_NAME="$(echo "$FOUND_VARS" | jq -r '.S3_BUCKET_NAME // empty')"
-    PRODUCTION_S3_ENDPOINT_URL="$(echo "$FOUND_VARS" | jq -r '.S3_ENDPOINT_URL // empty')"
-    PRODUCTION_S3_ACCESS_KEY_ID="$(echo "$FOUND_VARS" | jq -r '.S3_ACCESS_KEY_ID // empty')"
-    PRODUCTION_S3_SECRET_ACCESS_KEY="$(echo "$FOUND_VARS" | jq -r '.S3_SECRET_ACCESS_KEY // empty')"
-    PRODUCTION_S3_REGION="$(echo "$FOUND_VARS" | jq -r '.S3_REGION // "us-east-1"')"
-  fi
-
-  if [ -z "${PRODUCTION_S3_BUCKET_NAME:-}" ] || [ -z "${PRODUCTION_S3_ACCESS_KEY_ID:-}" ]; then
-    echo "Production has no S3 storage configured; nothing to copy." >&2
-    echo "Pass --no-files if production keeps book files on a container volume." >&2
-    exit 1
-  fi
-fi
+[ "$CLONE_DB" = true ] && resolve_production_database_url
+[ "$CLONE_FILES" = true ] && resolve_production_s3 --no-files
 
 # --- Resolve the local side --------------------------------------------------
 
@@ -368,15 +129,7 @@ if [ "$CLONE_DB" = true ]; then
     exit 1
   }
 
-  # pg_dump refuses to read a server newer than itself, and the error it gives is
-  # easy to misread as a connection problem.
-  REMOTE_MAJOR="$(psql "$PRODUCTION_DATABASE_URL" -tAc 'SHOW server_version_num' | cut -c1-2)"
-  DUMP_MAJOR="$(pg_dump --version | sed -E 's/.* ([0-9]+).*/\1/')"
-  if [ "$DUMP_MAJOR" -lt "$REMOTE_MAJOR" ]; then
-    echo "pg_dump is version ${DUMP_MAJOR} but production runs PostgreSQL ${REMOTE_MAJOR}." >&2
-    echo "Install PostgreSQL ${REMOTE_MAJOR} client tools or newer." >&2
-    exit 1
-  fi
+  require_pg_dump_at_least_server "$PRODUCTION_DATABASE_URL"
 fi
 
 if [ "$CLONE_FILES" = true ]; then
@@ -400,26 +153,6 @@ if [ "$CLONE_FILES" = true ]; then
     FILES_TARGET_LABEL="$FILES_TARGET (S3 not configured in .env)"
   fi
 fi
-
-# Runs the aws CLI with one endpoint's credentials, isolated from any ambient
-# AWS_PROFILE / SSO session that would otherwise take precedence.
-aws_with() {
-  local key="$1" secret="$2" region="$3" endpoint="$4"
-  shift 4
-  env -u AWS_PROFILE -u AWS_SESSION_TOKEN -u AWS_DEFAULT_PROFILE \
-    AWS_ACCESS_KEY_ID="$key" AWS_SECRET_ACCESS_KEY="$secret" AWS_DEFAULT_REGION="$region" \
-    aws --endpoint-url "$endpoint" "$@"
-}
-
-aws_prod() {
-  aws_with "$PRODUCTION_S3_ACCESS_KEY_ID" "$PRODUCTION_S3_SECRET_ACCESS_KEY" \
-    "$PRODUCTION_S3_REGION" "$PRODUCTION_S3_ENDPOINT_URL" "$@"
-}
-
-aws_local() {
-  aws_with "$LOCAL_S3_ACCESS_KEY_ID" "$LOCAL_S3_SECRET_ACCESS_KEY" \
-    "$LOCAL_S3_REGION" "$LOCAL_S3_ENDPOINT_URL" "$@"
-}
 
 # --- Confirm -----------------------------------------------------------------
 

--- a/scripts/lib/railway-production.sh
+++ b/scripts/lib/railway-production.sh
@@ -1,0 +1,294 @@
+#!/bin/bash
+# Shared discovery of the Railway production endpoints, sourced by
+# clone-production-db.sh and backup-production.sh. Not executable on its own.
+#
+# Requirements (no `railway` CLI / login needed — talks to the API directly):
+#   - RAILWAY_API_TOKEN   Account/Team token: railway.com -> Account -> Tokens.
+#                         NOTE: must be this name, NOT RAILWAY_TOKEN (the CLI
+#                         reserves RAILWAY_TOKEN for project tokens and will
+#                         reject an account token placed there).
+#   - RAILWAY_ENVIRONMENT_ID   which environment to read. Resource ID (not kept
+#                         in-repo). Find it with `railway status --json`.
+#
+# Both production endpoints are discovered through the Railway API rather than
+# being configured here, so no resource IDs live in the repo. The database is
+# whichever one the app actually connects to: the service holding DATABASE_URL
+# without PGDATA is the app, and the Postgres service whose private domain that
+# URL names is production. Anything keyed off variable names alone — "the service
+# exposing DATABASE_PUBLIC_URL" — silently picks a retired database once a project
+# holds two of them, which is what happened when production moved to pgvector.
+# Object storage still comes from the service exposing S3_BUCKET_NAME.
+# Pin either with RAILWAY_POSTGRES_SERVICE_ID / RAILWAY_SERVICE_ID, or bypass
+# discovery with PRODUCTION_DATABASE_URL and the PRODUCTION_S3_* variables.
+
+LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${LIB_DIR}/../.." && pwd)"
+API="https://backboard.railway.com/graphql/v2"
+
+require_tools() {
+  local tool
+  for tool in "$@"; do
+    command -v "$tool" >/dev/null || {
+      echo "Missing ${tool}." >&2
+      exit 1
+    }
+  done
+}
+
+gql() {
+  # $1 = full JSON request body; echoes the response, fails on a GraphQL error.
+  local resp
+  resp="$(curl -sS -X POST "$API" \
+    -H "Authorization: Bearer ${RAILWAY_API_TOKEN}" \
+    -H "Content-Type: application/json" \
+    --data "$1")"
+  if echo "$resp" | jq -e '.errors' >/dev/null 2>&1; then
+    echo "Railway API error: $resp" >&2
+    exit 1
+  fi
+  printf '%s' "$resp"
+}
+
+service_variables() {
+  # $1 = service id; echoes that service instance's resolved variables as JSON.
+  gql "$(jq -n --arg p "$PROJECT_ID" --arg e "$ENVIRONMENT_ID" --arg s "$1" '{
+    query: "query($p: String!, $e: String!, $s: String!) { variables(projectId: $p, environmentId: $e, serviceId: $s) }",
+    variables: { p: $p, e: $e, s: $s }
+  }')" | jq '.data.variables'
+}
+
+# Loads every service's variables into SERVICE_NAMES / SERVICE_VARS once, so the
+# database and the storage credentials cost one discovery pass between them.
+declare -a SERVICE_NAMES=()
+declare -a SERVICE_VARS=()
+DISCOVERED=false
+
+discover_services() {
+  [ "$DISCOVERED" = true ] && return
+  : "${RAILWAY_API_TOKEN:?Set RAILWAY_API_TOKEN (railway.com -> Account -> Tokens; NOT RAILWAY_TOKEN)}"
+  ENVIRONMENT_ID="${RAILWAY_ENVIRONMENT_ID:?Set RAILWAY_ENVIRONMENT_ID (find it with: railway status --json)}"
+
+  PROJECT_ID="$(gql "$(jq -n --arg id "$ENVIRONMENT_ID" '{
+    query: "query($id: String!) { environment(id: $id) { projectId } }",
+    variables: { id: $id }
+  }')" | jq -r '.data.environment.projectId')"
+
+  local services id name
+  services="$(gql "$(jq -n --arg id "$PROJECT_ID" '{
+    query: "query($id: String!) { project(id: $id) { services { edges { node { id name } } } } }",
+    variables: { id: $id }
+  }')" | jq -r '.data.project.services.edges[].node | "\(.id) \(.name)"')"
+
+  while read -r id name; do
+    [ -n "$id" ] || continue
+    SERVICE_NAMES+=("$name")
+    SERVICE_VARS+=("$(service_variables "$id")")
+  done <<<"$services"
+
+  DISCOVERED=true
+}
+
+# Finds the one service whose variables contain $1, and sets FOUND_VARS /
+# FOUND_SERVICE. Anything other than exactly one match is ambiguous.
+find_service_by_variable() {
+  local key="$1" i matches=()
+  discover_services
+  for i in "${!SERVICE_NAMES[@]}"; do
+    echo "${SERVICE_VARS[$i]}" | jq -e --arg k "$key" '.[$k] // empty' >/dev/null 2>&1 &&
+      matches+=("$i")
+  done
+
+  case "${#matches[@]}" in
+    1)
+      FOUND_SERVICE="${SERVICE_NAMES[${matches[0]}]}"
+      FOUND_VARS="${SERVICE_VARS[${matches[0]}]}"
+      ;;
+    0)
+      echo "No service in this Railway environment exposes ${key}." >&2
+      return 1
+      ;;
+    *)
+      local names=()
+      for i in "${matches[@]}"; do names+=("${SERVICE_NAMES[$i]}"); done
+      echo "Several services expose ${key}: ${names[*]}" >&2
+      return 1
+      ;;
+  esac
+}
+
+# Sets FOUND_VARS / FOUND_SERVICE to the one service that uses a database
+# without being one: it holds DATABASE_URL but no PGDATA, which every Railway
+# Postgres image sets. That is the app, and what it points at defines production.
+find_database_consumer() {
+  local i matches=() names=()
+  discover_services
+  for i in "${!SERVICE_NAMES[@]}"; do
+    echo "${SERVICE_VARS[$i]}" | jq -e '.DATABASE_URL and (.PGDATA | not)' >/dev/null 2>&1 &&
+      matches+=("$i")
+  done
+
+  case "${#matches[@]}" in
+    1)
+      FOUND_SERVICE="${SERVICE_NAMES[${matches[0]}]}"
+      FOUND_VARS="${SERVICE_VARS[${matches[0]}]}"
+      ;;
+    0)
+      echo "No service in this Railway environment connects to a database." >&2
+      return 1
+      ;;
+    *)
+      for i in "${matches[@]}"; do names+=("${SERVICE_NAMES[$i]}"); done
+      echo "Several services connect to a database: ${names[*]}" >&2
+      echo "Pin the app with RAILWAY_SERVICE_ID, or set PRODUCTION_DATABASE_URL." >&2
+      return 1
+      ;;
+  esac
+}
+
+# Sets FOUND_VARS / FOUND_SERVICE to the service whose private domain is $1.
+find_service_by_private_domain() {
+  local domain="$1" i
+  discover_services
+  for i in "${!SERVICE_NAMES[@]}"; do
+    [ "$(echo "${SERVICE_VARS[$i]}" | jq -r '.RAILWAY_PRIVATE_DOMAIN // empty')" = "$domain" ] || continue
+    FOUND_SERVICE="${SERVICE_NAMES[$i]}"
+    FOUND_VARS="${SERVICE_VARS[$i]}"
+    return 0
+  done
+  return 1
+}
+
+# Echoes the hostname of a connection URL.
+url_host() {
+  local authority="${1#*://}"
+  authority="${authority%%/*}"
+  authority="${authority##*@}"
+  echo "${authority%%:*}"
+}
+
+# Echoes a URL for the database service whose variables are $1 that resolves from
+# outside Railway, or nothing if it only publishes a private endpoint. A service
+# without a TCP proxy still sets DATABASE_URL, pointing at .railway.internal,
+# which is unreachable here and would fail much later as a DNS error.
+public_database_url() {
+  local vars="$1" url
+  url="$(echo "$vars" | jq -r '.DATABASE_PUBLIC_URL // empty')"
+  [ -n "$url" ] || url="$(echo "$vars" | jq -r '.DATABASE_URL // empty')"
+  case "$(url_host "$url")" in
+    '' | *.railway.internal) return 0 ;;
+  esac
+  printf '%s' "$url"
+}
+
+# Strips the userinfo from a connection URL so it can be printed safely.
+redact() {
+  echo "$1" | sed -E 's#(://)[^/@]*@#\1<credentials>@#'
+}
+
+# Reads one key out of the root .env. Sourcing the whole file is not safe — not
+# all of its values are shell-quoted.
+env_value() {
+  [ -f "${REPO_ROOT}/.env" ] || return 0
+  sed -n "s/^$1=//p" "${REPO_ROOT}/.env" | tail -n 1 | sed -E 's/^["'"'"']//; s/["'"'"']$//'
+}
+
+# Sets PRODUCTION_DATABASE_URL, unless it is already set in the environment.
+resolve_production_database_url() {
+  if [ -n "${PRODUCTION_DATABASE_URL:-}" ]; then
+    echo "Using PRODUCTION_DATABASE_URL from the environment."
+    return 0
+  fi
+
+  if [ -n "${RAILWAY_POSTGRES_SERVICE_ID:-}" ]; then
+    discover_services
+    PRODUCTION_DATABASE_URL="$(public_database_url "$(service_variables "$RAILWAY_POSTGRES_SERVICE_ID")")"
+    [ -n "$PRODUCTION_DATABASE_URL" ] || {
+      echo "Service ${RAILWAY_POSTGRES_SERVICE_ID} publishes no endpoint reachable from here." >&2
+      echo "Enable its public TCP proxy in the Railway dashboard, or set PRODUCTION_DATABASE_URL." >&2
+      exit 1
+    }
+    return 0
+  fi
+
+  echo "Resolving the production database from Railway..."
+  find_database_consumer || exit 1
+  local app_service app_db_host
+  app_service="$FOUND_SERVICE"
+  app_db_host="$(url_host "$(echo "$FOUND_VARS" | jq -r '.DATABASE_URL')")"
+
+  find_service_by_private_domain "$app_db_host" || {
+    echo "The '${app_service}' service points at ${app_db_host}, which is not a service" >&2
+    echo "in this environment. Pin RAILWAY_POSTGRES_SERVICE_ID, or set PRODUCTION_DATABASE_URL." >&2
+    exit 1
+  }
+
+  PRODUCTION_DATABASE_URL="$(public_database_url "$FOUND_VARS")"
+  [ -n "$PRODUCTION_DATABASE_URL" ] || {
+    echo "The '${FOUND_SERVICE}' database publishes no endpoint reachable from here." >&2
+    echo "Enable its public TCP proxy in the Railway dashboard, or set PRODUCTION_DATABASE_URL." >&2
+    exit 1
+  }
+  echo "Found the '${FOUND_SERVICE}' database, which '${app_service}' connects to."
+}
+
+# Sets the PRODUCTION_S3_* variables, unless they are already set in the
+# environment. $1 is the flag to suggest when production has no S3 storage.
+resolve_production_s3() {
+  local no_files_flag="${1:---no-files}"
+
+  if [ -n "${PRODUCTION_S3_BUCKET_NAME:-}" ]; then
+    echo "Using PRODUCTION_S3_* from the environment."
+  else
+    if [ -n "${RAILWAY_SERVICE_ID:-}" ]; then
+      discover_services
+      FOUND_VARS="$(service_variables "$RAILWAY_SERVICE_ID")"
+    else
+      echo "Resolving production object storage from Railway..."
+      find_service_by_variable S3_BUCKET_NAME || {
+        echo "Pin the app service with RAILWAY_SERVICE_ID, or set the PRODUCTION_S3_* variables." >&2
+        exit 1
+      }
+      echo "Found the '${FOUND_SERVICE}' service."
+    fi
+    PRODUCTION_S3_BUCKET_NAME="$(echo "$FOUND_VARS" | jq -r '.S3_BUCKET_NAME // empty')"
+    PRODUCTION_S3_ENDPOINT_URL="$(echo "$FOUND_VARS" | jq -r '.S3_ENDPOINT_URL // empty')"
+    PRODUCTION_S3_ACCESS_KEY_ID="$(echo "$FOUND_VARS" | jq -r '.S3_ACCESS_KEY_ID // empty')"
+    PRODUCTION_S3_SECRET_ACCESS_KEY="$(echo "$FOUND_VARS" | jq -r '.S3_SECRET_ACCESS_KEY // empty')"
+    PRODUCTION_S3_REGION="$(echo "$FOUND_VARS" | jq -r '.S3_REGION // "us-east-1"')"
+  fi
+
+  if [ -z "${PRODUCTION_S3_BUCKET_NAME:-}" ] || [ -z "${PRODUCTION_S3_ACCESS_KEY_ID:-}" ]; then
+    echo "Production has no S3 storage configured; nothing to copy." >&2
+    echo "Pass ${no_files_flag} if production keeps book files on a container volume." >&2
+    exit 1
+  fi
+}
+
+# Runs the aws CLI with one endpoint's credentials, isolated from any ambient
+# AWS_PROFILE / SSO session that would otherwise take precedence.
+aws_with() {
+  local key="$1" secret="$2" region="$3" endpoint="$4"
+  shift 4
+  env -u AWS_PROFILE -u AWS_SESSION_TOKEN -u AWS_DEFAULT_PROFILE \
+    AWS_ACCESS_KEY_ID="$key" AWS_SECRET_ACCESS_KEY="$secret" AWS_DEFAULT_REGION="$region" \
+    aws --endpoint-url "$endpoint" "$@"
+}
+
+aws_prod() {
+  aws_with "$PRODUCTION_S3_ACCESS_KEY_ID" "$PRODUCTION_S3_SECRET_ACCESS_KEY" \
+    "$PRODUCTION_S3_REGION" "$PRODUCTION_S3_ENDPOINT_URL" "$@"
+}
+
+# Fails early when the local pg_dump cannot read the server at $1: pg_dump
+# refuses a server newer than itself, and the error it gives is easy to misread
+# as a connection problem.
+require_pg_dump_at_least_server() {
+  local remote_major dump_major
+  remote_major="$(psql "$1" -tAc 'SHOW server_version_num' | cut -c1-2)"
+  dump_major="$(pg_dump --version | sed -E 's/.* ([0-9]+).*/\1/')"
+  if [ "$dump_major" -lt "$remote_major" ]; then
+    echo "pg_dump is version ${dump_major} but production runs PostgreSQL ${remote_major}." >&2
+    echo "Install PostgreSQL ${remote_major} client tools or newer." >&2
+    exit 1
+  fi
+}


### PR DESCRIPTION
Adds a read-only counterpart to `make clone-production-db`: it dumps the production database and downloads the book files into one timestamped zip under `backups/`, without touching the local database or writing anything to production.

```bash
make backup-production                                 # DB + book covers, no EPUBs
make backup-production ARGS="--with-epubs"             # everything
make backup-production ARGS="--no-files"               # database only
make backup-production ARGS="-o /mnt/backups --force"  # somewhere else
```

The archive holds `database.dump` (custom-format `pg_dump`), `book-files/`, and a `MANIFEST.txt` recording the timestamp, source, Postgres version, alembic head, what was left out, and the two commands that restore it.

**EPUBs are excluded by default.** They dominate the size — 81M against 17M on the current data, 35 EPUBs against 34 covers — and can be re-uploaded from their sources, while the covers are generated and small. `--with-epubs` takes the lot. The exclusion drops the `epubs/*` prefix rather than syncing `book-covers/` alone, so a prefix added later still lands in the backup.

The SAQ queue rows are dumped as schema only, for the same reason the clone skips them: restoring a backlog has a worker re-run jobs that already finished.

### The first commit is a pure refactor

Production discovery (which Postgres service the app actually connects to, which service holds the bucket) is ~180 lines that both scripts now need. `fd84776a` moves it verbatim into `scripts/lib/railway-production.sh` so the two cannot drift; `clone-production-db.sh` sources it and keeps its own local-side logic. No behaviour change.

### Verification

- Real run against Railway: discovered the `pgvector` database through the shared library, dumped 13M, pulled 34 files, wrote a 17M archive.
- Restored that archive's dump into a scratch database — `pg_restore` clean, alembic head `067`, 36 books, 969 highlights, 0 queued jobs.
- `--with-epubs`, `--no-files`, `-o`, overwrite refusal and `--force` each exercised.
- The refactored clone script reaches its confirmation prompt correctly with both `--no-files` and `--files-only`.
- Not run: a full destructive clone, since it drops the local database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012CEfsEF2XcS7t9PAhfDbGn