### PR TITLE
Document what a device-side deletion now does

### DIFF
--- a/site/src/content/docs/features/highlights.md
+++ b/site/src/content/docs/features/highlights.md
@@ -13,6 +13,12 @@ The [KOReader plugin](../../getting-started/koreader-plugin/) uploads highlights
 from your device. Syncing the same book again is safe: Crossbill deduplicates,
 so a highlight you already have is not added twice.
 
+A highlight you deleted on the e-reader stays here, marked **Deleted on the
+e-reader**, and stops syncing to your devices. Deleting it here removes it from
+Crossbill and from every device. Either way, marking the passage again on the
+e-reader brings the highlight back — with its tags, and with its flashcards and
+bookmarks unless you deleted it here, which takes those with it.
+
 ## Browsing a book
 
 Open a book and go to its **Highlights** tab. Highlights are grouped by chapter,

--- a/site/src/content/docs/getting-started/koreader-plugin.md
+++ b/site/src/content/docs/getting-started/koreader-plugin.md
@@ -25,9 +25,34 @@ If you read the same book on more than one e-reader, edits to a highlight's
 note or its colour are merged by when they were made. The most recent change
 wins, whichever device made it.
 
-Deleting a highlight on the e-reader does not delete it in Crossbill, and the
-next sync brings it back. Delete it in Crossbill instead — that deletion
-reaches every device.
+## Deleting a highlight
+
+Deleting a highlight on the e-reader takes it off your devices, not out of
+Crossbill. The next sync reports it, the server withholds it from every device's
+pull, and the web copy stays whole — the notes, flashcards, tags and bookmarks
+hanging off it are untouched. In the web app it carries a **Deleted on the
+e-reader** chip. To be rid of it everywhere, delete it in Crossbill instead:
+that deletion reaches every device.
+
+When a sync would withdraw every highlight the device ever pulled for a book,
+the plugin asks first. A KOReader sidecar file that went missing looks exactly
+like a book the reader emptied on purpose, so choose **Keep** and the server's
+copy stays put while the rest of the sync runs. An automatic background sync has
+nobody to ask, so it skips the removal and leaves it for a manual sync.
+
+## Highlighting a passage again
+
+Marking a passage you had deleted brings the stored highlight back rather than
+adding a second one beside it. The plugin knows the highlight never came down
+from the server, so it tells Crossbill this was deliberate, and the row returns
+with its tags — and, if it was only withheld from your devices, with its
+flashcards and bookmarks too. A highlight you deleted in Crossbill comes back
+without them: its flashcards and bookmarks went with that deletion and are not
+recoverable.
+
+This works from the book's second sync onwards. On the first sync of a book on a
+new device, the plugin cannot yet tell an old sidecar from a fresh highlight, so
+it revives nothing — sync once, and the sync after that behaves normally.
 
 ## Installing it
 

--- a/site/src/content/docs/integrations/koreader.md
+++ b/site/src/content/docs/integrations/koreader.md
@@ -18,8 +18,11 @@ with. The Crossbill plugin runs inside it, on the device.
 
 Across two e-readers, edits to a highlight's note or colour are merged by
 newest edit: the most recent change wins, whichever device made it. Deleting a
-highlight on the e-reader does not delete it in Crossbill — the next sync
-brings it back. Delete it in Crossbill instead, and it goes from every device.
+highlight on the e-reader withdraws it from every device but leaves the web copy
+whole, marked **Deleted on the e-reader**; delete it in Crossbill instead and it
+goes everywhere. See [KOReader
+plugin](../../getting-started/koreader-plugin/#deleting-a-highlight) for what
+the plugin asks before withdrawing a whole book's worth.
 
 This is the integration Crossbill depends on: it is where your content comes
 from.

--- a/site/src/content/docs/integrations/mcp-server.md
+++ b/site/src/content/docs/integrations/mcp-server.md
@@ -115,8 +115,10 @@ you can write again. Two of them throw away more:
 - **`delete_book`** removes a book with all its chapters and highlights. Syncing
   the book from KOReader again recreates it, but the notes, flashcards, tags and
   digests Crossbill kept alongside it are gone.
-- **`delete_highlights`** removes highlights from a book, and the deletion
-  sticks: later syncs of that book do not bring them back.
+- **`delete_highlights`** removes highlights from a book along with their
+  flashcards and bookmarks. Syncing the book again does not bring them back;
+  marking one of the passages again on the e-reader restores the highlight
+  itself, but the flashcards and bookmarks stay gone.
 
 Neither of those two runs on the assistant's say-so. Before calling the API, the
 server asks *you* to confirm through MCP elicitation, spelling out what is about


### PR DESCRIPTION
The KOReader pages still said a highlight deleted on the e-reader comes back on the next sync. It has not since the plugin started sending `removed_ids`: the server withholds the highlight from every device's pull, leaves the web copy whole, and the frontend marks it **Deleted on the e-reader**.

## What this changes

- **`getting-started/koreader-plugin.md`** — a "Deleting a highlight" section with the real behaviour, the chip, the confirmation the plugin raises before withdrawing a book's whole recorded set, and why an autosync skips that removal instead. A second section covers the revival the `is_new` flag enables: re-marking a passage brings the stored highlight back rather than adding one beside it, and it starts from a book's second sync on a device.
- **`integrations/koreader.md`** — the one-paragraph summary corrected, linking to the section above.
- **`features/highlights.md`** — the chip explained where highlights are browsed.
- **`integrations/mcp-server.md`** — `delete_highlights` no longer claims the deletion sticks unconditionally; a re-highlight restores the row, while the cascaded flashcards and bookmarks stay gone.

Verified against `highlight_upload_use_case.py` and `highlight_repository.py`: the web-side delete cascades to bookmarks and flashcards only, not notes, and the docs now say so. `npm run build` in `site/` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0186Gpupe8j18PuitqdG7nUN