### PR TITLE
Gate the ereader surface on a minimum plugin version (#615)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,14 @@ option").
 - Recipe for a new view: `docs/agents/read-models.md` (reference
   implementation: the book-details view, `library` module)
 
+### The plugin-only surface is version-gated
+
+`/ereader/*`, `/highlights/upload` and `/reading_sessions/upload` are called by
+the KOReader plugin alone, and reject clients older than the minimum in
+`backend/src/infrastructure/common/client_version.py` with HTTP 426. If you
+break the request or response contract of any of them for old plugins, bump the
+`koreader-plugin` minimum in that map **in the same PR** — never out of band.
+
 ## Testing
 
 Run the full test suite after any migration or refactoring; do not declare work

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,9 +53,9 @@ option").
 
 `/ereader/*`, `/highlights/upload` and `/reading_sessions/upload` are called by
 the KOReader plugin alone, and reject clients older than the minimum in
-`backend/src/infrastructure/common/client_version.py` with HTTP 426. If you
-break the request or response contract of any of them for old plugins, bump the
-`koreader-plugin` minimum in that map **in the same PR** — never out of band.
+`backend/src/infrastructure/common/client_version.py` with HTTP 426. Breaking
+the request or response contract of any of them for old plugins means bumping
+the `koreader-plugin` minimum **in the same PR** — never out of band.
 
 ## Testing
 

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -300,15 +300,38 @@
         "summary": "Create Book",
         "description": "Create or get a book by client_book_id.\n\nThis endpoint creates a new book if it doesn't exist, or returns the existing\nbook's metadata if it does. Used by KOReader to ensure a book exists before\nuploading highlights, covers, or EPUB files.\n\nArgs:\n    book_data: Book creation data (same format as highlight upload)\n    current_user: Authenticated user\n\nReturns:\n    EreaderBookMetadata with book_id, bookname, author, cover_file, has_epub",
         "operationId": "create_book",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "X-Crossbill-Client",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Crossbill-Client"
+            }
+          }
+        ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/BookCreate"
               }
             }
-          },
-          "required": true
+          }
         },
         "responses": {
           "200": {
@@ -317,6 +340,22 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/EreaderBookMetadata"
+                }
+              }
+            }
+          },
+          "426": {
+            "description": "The caller is an outdated Crossbill client, or sent no X-Crossbill-Client header at all. The body names the minimum supported version and where to get it.",
+            "content": {
+              "application/json": {
+                "example": {
+                  "detail": {
+                    "code": "client_upgrade_required",
+                    "client": "koreader-plugin",
+                    "min_supported_version": "0.13.0",
+                    "received_version": "0.12.0",
+                    "update_url": "https://github.com/Crossbill-App/koreader-plugin"
+                  }
                 }
               }
             }
@@ -331,12 +370,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ]
+        }
       }
     },
     "/api/v1/ereader/books/{client_book_id}": {
@@ -361,6 +395,22 @@
               "type": "string",
               "title": "Client Book Id"
             }
+          },
+          {
+            "name": "X-Crossbill-Client",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Crossbill-Client"
+            }
           }
         ],
         "responses": {
@@ -370,6 +420,22 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/EreaderBookMetadata"
+                }
+              }
+            }
+          },
+          "426": {
+            "description": "The caller is an outdated Crossbill client, or sent no X-Crossbill-Client header at all. The body names the minimum supported version and where to get it.",
+            "content": {
+              "application/json": {
+                "example": {
+                  "detail": {
+                    "code": "client_upgrade_required",
+                    "client": "koreader-plugin",
+                    "min_supported_version": "0.13.0",
+                    "received_version": "0.12.0",
+                    "update_url": "https://github.com/Crossbill-App/koreader-plugin"
+                  }
                 }
               }
             }
@@ -409,6 +475,22 @@
               "type": "string",
               "title": "Client Book Id"
             }
+          },
+          {
+            "name": "X-Crossbill-Client",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Crossbill-Client"
+            }
           }
         ],
         "requestBody": {
@@ -428,6 +510,22 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/SuccessResponse"
+                }
+              }
+            }
+          },
+          "426": {
+            "description": "The caller is an outdated Crossbill client, or sent no X-Crossbill-Client header at all. The body names the minimum supported version and where to get it.",
+            "content": {
+              "application/json": {
+                "example": {
+                  "detail": {
+                    "code": "client_upgrade_required",
+                    "client": "koreader-plugin",
+                    "min_supported_version": "0.13.0",
+                    "received_version": "0.12.0",
+                    "update_url": "https://github.com/Crossbill-App/koreader-plugin"
+                  }
                 }
               }
             }
@@ -467,6 +565,22 @@
               "type": "string",
               "title": "Client Book Id"
             }
+          },
+          {
+            "name": "X-Crossbill-Client",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Crossbill-Client"
+            }
           }
         ],
         "responses": {
@@ -476,6 +590,22 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/CollectionResponse_EreaderChapterDigestItem_"
+                }
+              }
+            }
+          },
+          "426": {
+            "description": "The caller is an outdated Crossbill client, or sent no X-Crossbill-Client header at all. The body names the minimum supported version and where to get it.",
+            "content": {
+              "application/json": {
+                "example": {
+                  "detail": {
+                    "code": "client_upgrade_required",
+                    "client": "koreader-plugin",
+                    "min_supported_version": "0.13.0",
+                    "received_version": "0.12.0",
+                    "update_url": "https://github.com/Crossbill-App/koreader-plugin"
+                  }
                 }
               }
             }
@@ -515,6 +645,22 @@
               "type": "string",
               "title": "Client Book Id"
             }
+          },
+          {
+            "name": "X-Crossbill-Client",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Crossbill-Client"
+            }
           }
         ],
         "responses": {
@@ -524,6 +670,22 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/CollectionResponse_EreaderHighlightItem_"
+                }
+              }
+            }
+          },
+          "426": {
+            "description": "The caller is an outdated Crossbill client, or sent no X-Crossbill-Client header at all. The body names the minimum supported version and where to get it.",
+            "content": {
+              "application/json": {
+                "example": {
+                  "detail": {
+                    "code": "client_upgrade_required",
+                    "client": "koreader-plugin",
+                    "min_supported_version": "0.13.0",
+                    "received_version": "0.12.0",
+                    "update_url": "https://github.com/Crossbill-App/koreader-plugin"
+                  }
                 }
               }
             }
@@ -585,15 +747,38 @@
         "summary": "Upload Highlights",
         "description": "Upload highlights from KOReader.\n\nCreates or updates book record and adds highlights with automatic deduplication.\nDuplicates are identified by the combination of book, text, and datetime.\n\n``removed_ids`` carries the highlights the reader deleted on the device:\nthey are withheld from every device's pull and stay whole on the web.\n\nA highlight flagged ``is_new`` was created on the device after its last\npull, so a duplicate of a removed or deleted highlight is a deliberate\nre-highlight and brings that highlight back.\n\nArgs:\n    request: Highlight upload request containing book metadata and highlights\n\nReturns:\n    HighlightUploadResponse with upload statistics\n\nRaises:\n    HTTPException: If upload fails due to server error",
         "operationId": "upload_highlights",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "X-Crossbill-Client",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Crossbill-Client"
+            }
+          }
+        ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/HighlightUploadRequest"
               }
             }
-          },
-          "required": true
+          }
         },
         "responses": {
           "200": {
@@ -602,6 +787,22 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/HighlightUploadResponse"
+                }
+              }
+            }
+          },
+          "426": {
+            "description": "The caller is an outdated Crossbill client, or sent no X-Crossbill-Client header at all. The body names the minimum supported version and where to get it.",
+            "content": {
+              "application/json": {
+                "example": {
+                  "detail": {
+                    "code": "client_upgrade_required",
+                    "client": "koreader-plugin",
+                    "min_supported_version": "0.13.0",
+                    "received_version": "0.12.0",
+                    "update_url": "https://github.com/Crossbill-App/koreader-plugin"
+                  }
                 }
               }
             }
@@ -616,12 +817,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ]
+        }
       }
     },
     "/api/v1/books/{book_id}/highlights": {
@@ -1192,15 +1388,38 @@
         "summary": "Upload Reading Sessions",
         "description": "Upload reading sessions from KOReader for a single book.\n\nAll sessions in a request must be for the same book.\n\nArgs:\n    request: Upload request containing book metadata and reading sessions\n\nReturns:\n    ReadingSessionUploadResponse with upload statistics",
         "operationId": "upload_reading_sessions",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "X-Crossbill-Client",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Crossbill-Client"
+            }
+          }
+        ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/ReadingSessionUploadRequest"
               }
             }
-          },
-          "required": true
+          }
         },
         "responses": {
           "200": {
@@ -1209,6 +1428,22 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ReadingSessionUploadResponse"
+                }
+              }
+            }
+          },
+          "426": {
+            "description": "The caller is an outdated Crossbill client, or sent no X-Crossbill-Client header at all. The body names the minimum supported version and where to get it.",
+            "content": {
+              "application/json": {
+                "example": {
+                  "detail": {
+                    "code": "client_upgrade_required",
+                    "client": "koreader-plugin",
+                    "min_supported_version": "0.13.0",
+                    "received_version": "0.12.0",
+                    "update_url": "https://github.com/Crossbill-App/koreader-plugin"
+                  }
                 }
               }
             }
@@ -1223,12 +1458,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ]
+        }
       }
     },
     "/api/v1/books/{book_id}/reading_sessions": {

--- a/backend/src/infrastructure/common/client_version.py
+++ b/backend/src/infrastructure/common/client_version.py
@@ -1,0 +1,146 @@
+"""Client-version gate for the endpoints only our own clients call.
+
+The KOReader plugin identifies itself with ``X-Crossbill-Client:
+koreader-plugin/<x.y.z>`` on every request. The endpoints that exist solely for
+that plugin refuse anything older than the deployed server needs, answering 426
+Upgrade Required, so a stale plugin fails at the door with an actionable body
+instead of half-working further in.
+
+A missing header is treated as too old on purpose: every plugin released before
+this gate sends nothing at all, so absence *is* the signal that the caller
+predates the version we require. Callers naming a client we know nothing about
+pass through -- this gate polices the versions of our own clients, not who may
+call the API; authentication does that.
+"""
+
+import re
+from collections.abc import Awaitable, Callable, Mapping
+from dataclasses import dataclass
+from typing import Annotated, Any, Final, NoReturn
+
+from fastapi import Header, HTTPException, status
+
+CLIENT_VERSION_HEADER: Final = "X-Crossbill-Client"
+
+KOREADER_PLUGIN: Final = "koreader-plugin"
+
+UPGRADE_REQUIRED_CODE: Final = "client_upgrade_required"
+
+
+@dataclass(frozen=True)
+class ClientVersionRequirement:
+    """What one first-party client has to be for this server to serve it."""
+
+    min_version: tuple[int, int, int]
+    update_url: str
+
+
+# The minimum is a property of the deployed code, not a policy dial: it says
+# what *this* server needs a client to be able to do. Bump it in the same PR as
+# any change that breaks the request or response contract of the gated surface
+# for older clients, never out of band -- a bump on its own locks out clients
+# the running code could still serve, and a breaking change without one leaves
+# clients that the new code cannot serve to fail somewhere deeper and vaguer.
+CLIENT_VERSION_REQUIREMENTS: Final[Mapping[str, ClientVersionRequirement]] = {
+    KOREADER_PLUGIN: ClientVersionRequirement(
+        min_version=(0, 13, 0),
+        update_url="https://github.com/Crossbill-App/koreader-plugin",
+    ),
+}
+
+# Strict ``name/major.minor.patch``. No pre-release or build suffixes: our
+# clients ship plain three-part versions, and anything else is a client we
+# cannot reason about rather than one to guess at.
+_VERSION_PATTERN: Final = re.compile(r"[0-9]+\.[0-9]+\.[0-9]+")
+
+
+def format_version(version: tuple[int, int, int]) -> str:
+    """Render a version tuple the way clients write it."""
+    return ".".join(str(part) for part in version)
+
+
+def _parse_version(raw: str) -> tuple[int, int, int] | None:
+    """Parse ``major.minor.patch`` into a tuple, or ``None`` if it is not that."""
+    if _VERSION_PATTERN.fullmatch(raw) is None:
+        return None
+    major, minor, patch = (int(part) for part in raw.split("."))
+    return (major, minor, patch)
+
+
+def _upgrade_required(
+    client: str,
+    requirement: ClientVersionRequirement,
+    received_version: str | None,
+) -> NoReturn:
+    raise HTTPException(
+        status_code=status.HTTP_426_UPGRADE_REQUIRED,
+        detail={
+            "code": UPGRADE_REQUIRED_CODE,
+            "client": client,
+            "min_supported_version": format_version(requirement.min_version),
+            "received_version": received_version,
+            "update_url": requirement.update_url,
+        },
+    )
+
+
+def require_client_version(expected_client: str) -> Callable[[str | None], Awaitable[None]]:
+    """Build the dependency guarding a surface that only ``expected_client`` calls.
+
+    The expected client is named per surface because a request without the
+    header names no client at all, and the 426 body still has to say which
+    client to upgrade and where to get it.
+    """
+    expected_requirement = CLIENT_VERSION_REQUIREMENTS[expected_client]
+
+    async def dependency(
+        client_header: Annotated[str | None, Header(alias=CLIENT_VERSION_HEADER)] = None,
+    ) -> None:
+        if client_header is None:
+            _upgrade_required(expected_client, expected_requirement, received_version=None)
+
+        name, _, raw_version = client_header.strip().partition("/")
+        requirement = CLIENT_VERSION_REQUIREMENTS.get(name)
+        if requirement is None:
+            return
+
+        version = _parse_version(raw_version)
+        if version is None:
+            # Fail closed: a client of ours whose version we cannot read is not
+            # a client we can claim meets the minimum.
+            _upgrade_required(name, requirement, received_version=None)
+
+        if version < requirement.min_version:
+            _upgrade_required(name, requirement, received_version=raw_version)
+
+    return dependency
+
+
+require_koreader_plugin: Final = require_client_version(KOREADER_PLUGIN)
+
+# Shared OpenAPI metadata for the gated endpoints. 426 is unique to this gate
+# across the API, so the status code alone identifies the failure.
+UPGRADE_REQUIRED_RESPONSES: Final[dict[int | str, dict[str, Any]]] = {
+    status.HTTP_426_UPGRADE_REQUIRED: {
+        "description": (
+            "The caller is an outdated Crossbill client, or sent no "
+            f"{CLIENT_VERSION_HEADER} header at all. The body names the minimum "
+            "supported version and where to get it."
+        ),
+        "content": {
+            "application/json": {
+                "example": {
+                    "detail": {
+                        "code": UPGRADE_REQUIRED_CODE,
+                        "client": KOREADER_PLUGIN,
+                        "min_supported_version": format_version(
+                            CLIENT_VERSION_REQUIREMENTS[KOREADER_PLUGIN].min_version
+                        ),
+                        "received_version": "0.12.0",
+                        "update_url": CLIENT_VERSION_REQUIREMENTS[KOREADER_PLUGIN].update_url,
+                    }
+                }
+            }
+        },
+    }
+}

--- a/backend/src/infrastructure/common/client_version.py
+++ b/backend/src/infrastructure/common/client_version.py
@@ -51,7 +51,13 @@ CLIENT_VERSION_REQUIREMENTS: Final[Mapping[str, ClientVersionRequirement]] = {
 # Strict ``name/major.minor.patch``. No pre-release or build suffixes: our
 # clients ship plain three-part versions, and anything else is a client we
 # cannot reason about rather than one to guess at.
-_VERSION_PATTERN: Final = re.compile(r"[0-9]+\.[0-9]+\.[0-9]+")
+#
+# Each segment is bounded because ``int()`` refuses to parse a string of more
+# than 4300 digits: an unbounded pattern would hand such a segment to ``int``
+# and turn a hostile header into a 500 on a pre-auth code path. Nine digits is
+# far past any version we will ship, so the bound only ever rejects nonsense --
+# which the gate already treats as unreadable, hence 426.
+_VERSION_PATTERN: Final = re.compile(r"[0-9]{1,9}\.[0-9]{1,9}\.[0-9]{1,9}")
 
 
 def format_version(version: tuple[int, int, int]) -> str:
@@ -96,10 +102,14 @@ def require_client_version(expected_client: str) -> Callable[[str | None], Await
     async def dependency(
         client_header: Annotated[str | None, Header(alias=CLIENT_VERSION_HEADER)] = None,
     ) -> None:
-        if client_header is None:
+        # A header that is present but says nothing names no client either, so
+        # it takes the same branch as no header at all -- otherwise an empty
+        # value would read as an unknown client and sail straight through.
+        announced = "" if client_header is None else client_header.strip()
+        if not announced:
             _upgrade_required(expected_client, expected_requirement, received_version=None)
 
-        name, _, raw_version = client_header.strip().partition("/")
+        name, _, raw_version = announced.partition("/")
         requirement = CLIENT_VERSION_REQUIREMENTS.get(name)
         if requirement is None:
             return

--- a/backend/src/infrastructure/common/client_version.py
+++ b/backend/src/infrastructure/common/client_version.py
@@ -1,16 +1,10 @@
 """Client-version gate for the endpoints only our own clients call.
 
-The KOReader plugin identifies itself with ``X-Crossbill-Client:
-koreader-plugin/<x.y.z>`` on every request. The endpoints that exist solely for
-that plugin refuse anything older than the deployed server needs, answering 426
-Upgrade Required, so a stale plugin fails at the door with an actionable body
-instead of half-working further in.
-
-A missing header is treated as too old on purpose: every plugin released before
-this gate sends nothing at all, so absence *is* the signal that the caller
-predates the version we require. Callers naming a client we know nothing about
-pass through -- this gate polices the versions of our own clients, not who may
-call the API; authentication does that.
+Clients identify themselves with ``X-Crossbill-Client: <name>/<x.y.z>``, and a
+client older than the deployed server needs gets 426 Upgrade Required with a
+body naming the minimum. A missing header counts as too old, because plugins
+predating the gate send none. A client we have no requirement for passes
+through: this gates our own clients' versions, not who may call the API.
 """
 
 import re
@@ -35,12 +29,9 @@ class ClientVersionRequirement:
     update_url: str
 
 
-# The minimum is a property of the deployed code, not a policy dial: it says
-# what *this* server needs a client to be able to do. Bump it in the same PR as
-# any change that breaks the request or response contract of the gated surface
-# for older clients, never out of band -- a bump on its own locks out clients
-# the running code could still serve, and a breaking change without one leaves
-# clients that the new code cannot serve to fail somewhere deeper and vaguer.
+# The minimum says what *this* server needs a client to be able to do, so bump
+# it in the same PR as any change that breaks the gated contract for older
+# clients -- never on its own, and never without one.
 CLIENT_VERSION_REQUIREMENTS: Final[Mapping[str, ClientVersionRequirement]] = {
     KOREADER_PLUGIN: ClientVersionRequirement(
         min_version=(0, 13, 0),
@@ -48,15 +39,9 @@ CLIENT_VERSION_REQUIREMENTS: Final[Mapping[str, ClientVersionRequirement]] = {
     ),
 }
 
-# Strict ``name/major.minor.patch``. No pre-release or build suffixes: our
-# clients ship plain three-part versions, and anything else is a client we
-# cannot reason about rather than one to guess at.
-#
-# Each segment is bounded because ``int()`` refuses to parse a string of more
-# than 4300 digits: an unbounded pattern would hand such a segment to ``int``
-# and turn a hostile header into a 500 on a pre-auth code path. Nine digits is
-# far past any version we will ship, so the bound only ever rejects nonsense --
-# which the gate already treats as unreadable, hence 426.
+# Strictly three plain numeric parts, no pre-release or build suffixes. Segment
+# length is bounded so ``int()`` can never raise on regex-validated input --
+# this runs before authentication.
 _VERSION_PATTERN: Final = re.compile(r"[0-9]{1,9}\.[0-9]{1,9}\.[0-9]{1,9}")
 
 
@@ -93,18 +78,15 @@ def _upgrade_required(
 def require_client_version(expected_client: str) -> Callable[[str | None], Awaitable[None]]:
     """Build the dependency guarding a surface that only ``expected_client`` calls.
 
-    The expected client is named per surface because a request without the
-    header names no client at all, and the 426 body still has to say which
-    client to upgrade and where to get it.
+    The expected client is named per surface so the 426 body can say which
+    client to upgrade even when the request names none.
     """
     expected_requirement = CLIENT_VERSION_REQUIREMENTS[expected_client]
 
     async def dependency(
         client_header: Annotated[str | None, Header(alias=CLIENT_VERSION_HEADER)] = None,
     ) -> None:
-        # A header that is present but says nothing names no client either, so
-        # it takes the same branch as no header at all -- otherwise an empty
-        # value would read as an unknown client and sail straight through.
+        # An empty value names no client, so it must not pass as an unknown one.
         announced = "" if client_header is None else client_header.strip()
         if not announced:
             _upgrade_required(expected_client, expected_requirement, received_version=None)
@@ -116,8 +98,7 @@ def require_client_version(expected_client: str) -> Callable[[str | None], Await
 
         version = _parse_version(raw_version)
         if version is None:
-            # Fail closed: a client of ours whose version we cannot read is not
-            # a client we can claim meets the minimum.
+            # Fail closed: an unreadable version is no evidence of a new enough client.
             _upgrade_required(name, requirement, received_version=None)
 
         if version < requirement.min_version:
@@ -128,8 +109,8 @@ def require_client_version(expected_client: str) -> Callable[[str | None], Await
 
 require_koreader_plugin: Final = require_client_version(KOREADER_PLUGIN)
 
-# Shared OpenAPI metadata for the gated endpoints. 426 is unique to this gate
-# across the API, so the status code alone identifies the failure.
+# Shared OpenAPI metadata: 426 is unique to this gate across the API, so the
+# status code alone identifies the failure.
 UPGRADE_REQUIRED_RESPONSES: Final[dict[int | str, dict[str, Any]]] = {
     status.HTTP_426_UPGRADE_REQUIRED: {
         "description": (

--- a/backend/src/infrastructure/library/routers/ereader.py
+++ b/backend/src/infrastructure/library/routers/ereader.py
@@ -40,8 +40,7 @@ from src.infrastructure.reading.schemas.ereader_highlight_schemas import (
     EreaderHighlightItem,
 )
 
-# Every route here exists for the KOReader plugin alone, so the whole router
-# is gated on the plugin being new enough for the contract this code speaks.
+# Every route here is called by the KOReader plugin alone, hence a router-wide gate.
 router = APIRouter(
     prefix="/ereader",
     tags=["ereader"],

--- a/backend/src/infrastructure/library/routers/ereader.py
+++ b/backend/src/infrastructure/library/routers/ereader.py
@@ -22,6 +22,10 @@ from src.core import container
 from src.domain.common.exceptions import ValidationError
 from src.domain.common.value_objects.ids import UserId
 from src.domain.identity.entities.user import User
+from src.infrastructure.common.client_version import (
+    UPGRADE_REQUIRED_RESPONSES,
+    require_koreader_plugin,
+)
 from src.infrastructure.common.di import inject_use_case
 from src.infrastructure.common.schemas import CollectionResponse, SuccessResponse
 from src.infrastructure.identity.dependencies import get_current_user
@@ -36,7 +40,14 @@ from src.infrastructure.reading.schemas.ereader_highlight_schemas import (
     EreaderHighlightItem,
 )
 
-router = APIRouter(prefix="/ereader", tags=["ereader"])
+# Every route here exists for the KOReader plugin alone, so the whole router
+# is gated on the plugin being new enough for the contract this code speaks.
+router = APIRouter(
+    prefix="/ereader",
+    tags=["ereader"],
+    dependencies=[Depends(require_koreader_plugin)],
+    responses=UPGRADE_REQUIRED_RESPONSES,
+)
 
 
 @router.post(

--- a/backend/src/infrastructure/reading/routers/highlights.py
+++ b/backend/src/infrastructure/reading/routers/highlights.py
@@ -55,8 +55,7 @@ def _build_chapter_schema(chapter: SearchChapterView) -> ChapterWithHighlights:
     )
 
 
-# Gated where the router is not: the rest of this router serves the web app,
-# but only the KOReader plugin uploads highlights.
+# Gated per route: only the KOReader plugin uploads, the rest serves the web app.
 @router.post(
     "/highlights/upload",
     response_model=HighlightUploadResponse,

--- a/backend/src/infrastructure/reading/routers/highlights.py
+++ b/backend/src/infrastructure/reading/routers/highlights.py
@@ -19,6 +19,10 @@ from src.application.reading.queries.highlight_search_use_case import (
 )
 from src.core import container
 from src.domain.identity.entities.user import User
+from src.infrastructure.common.client_version import (
+    UPGRADE_REQUIRED_RESPONSES,
+    require_koreader_plugin,
+)
 from src.infrastructure.common.di import inject_use_case
 from src.infrastructure.identity.dependencies import get_current_user
 from src.infrastructure.reading.schemas import (
@@ -51,10 +55,14 @@ def _build_chapter_schema(chapter: SearchChapterView) -> ChapterWithHighlights:
     )
 
 
+# Gated where the router is not: the rest of this router serves the web app,
+# but only the KOReader plugin uploads highlights.
 @router.post(
     "/highlights/upload",
     response_model=HighlightUploadResponse,
     status_code=status.HTTP_200_OK,
+    dependencies=[Depends(require_koreader_plugin)],
+    responses=UPGRADE_REQUIRED_RESPONSES,
 )
 async def upload_highlights(
     request: HighlightUploadRequest,

--- a/backend/src/infrastructure/reading/routers/reading_sessions.py
+++ b/backend/src/infrastructure/reading/routers/reading_sessions.py
@@ -83,8 +83,7 @@ def _build_session_schema(view: ReadingSessionView) -> ReadingSession:
     )
 
 
-# Gated where the router is not: the rest of this router serves the web app,
-# but only the KOReader plugin uploads reading sessions.
+# Gated per route: only the KOReader plugin uploads, the rest serves the web app.
 @router.post(
     "/reading_sessions/upload",
     response_model=ReadingSessionUploadResponse,

--- a/backend/src/infrastructure/reading/routers/reading_sessions.py
+++ b/backend/src/infrastructure/reading/routers/reading_sessions.py
@@ -17,6 +17,10 @@ from src.application.reading.queries.get_book_reading_sessions_use_case import (
 from src.application.reading.queries.reading_sessions import ReadingSessionView
 from src.core import container
 from src.domain.identity.entities.user import User
+from src.infrastructure.common.client_version import (
+    UPGRADE_REQUIRED_RESPONSES,
+    require_koreader_plugin,
+)
 from src.infrastructure.common.dependencies import require_ai_enabled
 from src.infrastructure.common.di import inject_use_case
 from src.infrastructure.common.schemas import PaginatedResponse
@@ -79,10 +83,14 @@ def _build_session_schema(view: ReadingSessionView) -> ReadingSession:
     )
 
 
+# Gated where the router is not: the rest of this router serves the web app,
+# but only the KOReader plugin uploads reading sessions.
 @router.post(
     "/reading_sessions/upload",
     response_model=ReadingSessionUploadResponse,
     status_code=status.HTTP_200_OK,
+    dependencies=[Depends(require_koreader_plugin)],
+    responses=UPGRADE_REQUIRED_RESPONSES,
 )
 async def upload_reading_sessions(
     request: ReadingSessionUploadRequest,

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -215,9 +215,10 @@ async def create_test_highlight_style(
     return style
 
 
-# What a plugin new enough for this server calls itself. Sent by default from
-# the shared client so every test speaks for a current plugin; the gate's own
-# tests build clients that say something else, or nothing at all.
+# What a plugin new enough for this server calls itself. Sent only by
+# ``plugin_client``: the shared ``client`` announces nothing, like the web app,
+# so a gate accidentally placed over a web endpoint fails a test instead of
+# passing unnoticed behind a suite-wide header.
 SUPPORTED_CLIENT_HEADER_VALUE = (
     f"{KOREADER_PLUGIN}/{format_version(CLIENT_VERSION_REQUIREMENTS[KOREADER_PLUGIN].min_version)}"
 )
@@ -352,16 +353,28 @@ async def client(db_session: AsyncSession, test_user: User) -> AsyncGenerator[As
     container.job_queue_service.override(contract_checked_queue())
 
     transport = ASGITransport(app=app)
-    async with AsyncClient(
-        transport=transport,
-        base_url="http://test",
-        headers={CLIENT_VERSION_HEADER: SUPPORTED_CLIENT_HEADER_VALUE},
-    ) as test_client:
+    async with AsyncClient(transport=transport, base_url="http://test") as test_client:
         yield test_client
 
     container.job_queue_service.reset_override()
     container.shared.file_repository.reset_override()
     app.dependency_overrides.clear()
+
+
+@pytest.fixture
+async def plugin_client(client: AsyncClient) -> AsyncGenerator[AsyncClient, None]:
+    """The shared client speaking for a KOReader plugin new enough to be served.
+
+    Tests of the plugin-only endpoints need this: those routes sit behind the
+    client-version gate and answer 426 to a caller that announces nothing.
+    """
+    transport = ASGITransport(app=app)
+    async with AsyncClient(
+        transport=transport,
+        base_url="http://test",
+        headers={CLIENT_VERSION_HEADER: SUPPORTED_CLIENT_HEADER_VALUE},
+    ) as announced_client:
+        yield announced_client
 
 
 @pytest.fixture
@@ -461,11 +474,15 @@ CreateBookFunc = Callable[[dict[str, Any]], Awaitable[EreaderBookMetadata]]
 
 
 @pytest.fixture
-async def create_book_via_api(client: AsyncClient) -> CreateBookFunc:
-    """Fixture factory for creating books via the API endpoint."""
+async def create_book_via_api(plugin_client: AsyncClient) -> CreateBookFunc:
+    """Fixture factory for creating books via the API endpoint.
+
+    Books are created through the plugin-only ``/ereader/books`` route, so this
+    speaks for a supported plugin rather than for the web app.
+    """
 
     async def _create_book(book_data: dict[str, Any]) -> EreaderBookMetadata:
-        response = await client.post("/api/v1/ereader/books", json=book_data)
+        response = await plugin_client.post("/api/v1/ereader/books", json=book_data)
         assert response.status_code == 200
         return EreaderBookMetadata(**response.json())
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -215,10 +215,8 @@ async def create_test_highlight_style(
     return style
 
 
-# What a plugin new enough for this server calls itself. Sent only by
-# ``plugin_client``: the shared ``client`` announces nothing, like the web app,
-# so a gate accidentally placed over a web endpoint fails a test instead of
-# passing unnoticed behind a suite-wide header.
+# Sent only by ``plugin_client``: the shared ``client`` announces nothing, like
+# the web app, so a gate misplaced over a web endpoint fails a test.
 SUPPORTED_CLIENT_HEADER_VALUE = (
     f"{KOREADER_PLUGIN}/{format_version(CLIENT_VERSION_REQUIREMENTS[KOREADER_PLUGIN].min_version)}"
 )
@@ -363,11 +361,7 @@ async def client(db_session: AsyncSession, test_user: User) -> AsyncGenerator[As
 
 @pytest.fixture
 async def plugin_client(client: AsyncClient) -> AsyncGenerator[AsyncClient, None]:
-    """The shared client speaking for a KOReader plugin new enough to be served.
-
-    Tests of the plugin-only endpoints need this: those routes sit behind the
-    client-version gate and answer 426 to a caller that announces nothing.
-    """
+    """A client announcing a KOReader plugin new enough to pass the version gate."""
     transport = ASGITransport(app=app)
     async with AsyncClient(
         transport=transport,
@@ -475,11 +469,7 @@ CreateBookFunc = Callable[[dict[str, Any]], Awaitable[EreaderBookMetadata]]
 
 @pytest.fixture
 async def create_book_via_api(plugin_client: AsyncClient) -> CreateBookFunc:
-    """Fixture factory for creating books via the API endpoint.
-
-    Books are created through the plugin-only ``/ereader/books`` route, so this
-    speaks for a supported plugin rather than for the web app.
-    """
+    """Fixture factory for creating books via the plugin-only ``/ereader/books``."""
 
     async def _create_book(book_data: dict[str, Any]) -> EreaderBookMetadata:
         response = await plugin_client.post("/api/v1/ereader/books", json=book_data)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -38,6 +38,12 @@ from src.database import Base, get_db
 from src.domain.common.value_objects import ContentHash
 from src.domain.common.value_objects.ids import UserId
 from src.domain.identity.entities.user import User as DomainUser
+from src.infrastructure.common.client_version import (
+    CLIENT_VERSION_HEADER,
+    CLIENT_VERSION_REQUIREMENTS,
+    KOREADER_PLUGIN,
+    format_version,
+)
 from src.infrastructure.identity.dependencies import get_current_user
 from src.infrastructure.library.repositories import file_repository
 from src.infrastructure.library.schemas import EreaderBookMetadata
@@ -209,6 +215,14 @@ async def create_test_highlight_style(
     return style
 
 
+# What a plugin new enough for this server calls itself. Sent by default from
+# the shared client so every test speaks for a current plugin; the gate's own
+# tests build clients that say something else, or nothing at all.
+SUPPORTED_CLIENT_HEADER_VALUE = (
+    f"{KOREADER_PLUGIN}/{format_version(CLIENT_VERSION_REQUIREMENTS[KOREADER_PLUGIN].min_version)}"
+)
+
+
 # Test database URL (in-memory SQLite with aiosqlite)
 TEST_DATABASE_URL = "sqlite+aiosqlite:///:memory:"
 
@@ -338,7 +352,11 @@ async def client(db_session: AsyncSession, test_user: User) -> AsyncGenerator[As
     container.job_queue_service.override(contract_checked_queue())
 
     transport = ASGITransport(app=app)
-    async with AsyncClient(transport=transport, base_url="http://test") as test_client:
+    async with AsyncClient(
+        transport=transport,
+        base_url="http://test",
+        headers={CLIENT_VERSION_HEADER: SUPPORTED_CLIENT_HEADER_VALUE},
+    ) as test_client:
         yield test_client
 
     container.job_queue_service.reset_override()

--- a/backend/tests/semantic_helpers.py
+++ b/backend/tests/semantic_helpers.py
@@ -253,10 +253,10 @@ async def plant_one_of_each_type(
 
 
 async def upload_highlights(
-    client: AsyncClient, client_book_id: str, *texts: str
+    plugin_client: AsyncClient, client_book_id: str, *texts: str
 ) -> dict[str, PrimitiveData]:
     """Upload highlights through the API -- the one write path that opens a batch."""
-    response = await client.post(
+    response = await plugin_client.post(
         "/api/v1/highlights/upload",
         json={
             "client_book_id": client_book_id,

--- a/backend/tests/test_books.py
+++ b/backend/tests/test_books.py
@@ -459,7 +459,7 @@ class TestHighlightSyncWithSoftDelete:
 
     async def test_sync_skips_soft_deleted_highlights(
         self,
-        client: AsyncClient,
+        plugin_client: AsyncClient,
         db_session: AsyncSession,
     ) -> None:
         """Test that sync does not recreate soft-deleted highlights."""
@@ -494,7 +494,7 @@ class TestHighlightSyncWithSoftDelete:
             ],
         }
 
-        response = await client.post("/api/v1/highlights/upload", json=payload)
+        response = await plugin_client.post("/api/v1/highlights/upload", json=payload)
 
         assert response.status_code == status.HTTP_200_OK
         data = response.json()
@@ -508,7 +508,7 @@ class TestHighlightSyncWithSoftDelete:
         assert highlights[0].deleted_at is not None
 
     async def test_sync_creates_new_highlights_skips_deleted(
-        self, client: AsyncClient, db_session: AsyncSession
+        self, plugin_client: AsyncClient, db_session: AsyncSession
     ) -> None:
         """Test that sync creates new highlights but skips deleted ones."""
         # This test needs specific book without ISBN to test author-based matching
@@ -547,7 +547,7 @@ class TestHighlightSyncWithSoftDelete:
             ],
         }
 
-        response = await client.post("/api/v1/highlights/upload", json=payload)
+        response = await plugin_client.post("/api/v1/highlights/upload", json=payload)
 
         assert response.status_code == status.HTTP_200_OK
         data = response.json()

--- a/backend/tests/test_client_version_gate.py
+++ b/backend/tests/test_client_version_gate.py
@@ -2,6 +2,12 @@
 
 Driven through the endpoints because the gate is a property of the surface, not
 of a function: which routes carry it is half of what can go wrong.
+
+Every value of the contract -- the header name, the minimum version, the code
+and the update URL -- is written out as a literal here rather than read from
+``client_version``. Deriving them from the module under test would mean a wrong
+minimum still matched itself and the whole file stayed green; a plugin in the
+wild reads these strings, so a test has to say them out loud.
 """
 
 from collections.abc import AsyncGenerator
@@ -14,22 +20,33 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from starlette import status
 
 from src import models
-from src.infrastructure.common.client_version import (
-    CLIENT_VERSION_HEADER,
-    CLIENT_VERSION_REQUIREMENTS,
-    KOREADER_PLUGIN,
-    UPGRADE_REQUIRED_CODE,
-    format_version,
-)
+from src.infrastructure.identity.dependencies import get_current_user
 from src.infrastructure.identity.services.password_service import hash_password
 from src.main import app
 from src.models import User
 from tests.conftest import create_test_book
 
-REQUIREMENT = CLIENT_VERSION_REQUIREMENTS[KOREADER_PLUGIN]
-MIN_VERSION = format_version(REQUIREMENT.min_version)
+CLIENT_HEADER = "X-Crossbill-Client"
+PLUGIN = "koreader-plugin"
+MIN_VERSION = "0.13.0"
+UPGRADE_REQUIRED_CODE = "client_upgrade_required"
+UPDATE_URL = "https://github.com/Crossbill-App/koreader-plugin"
 
 CLIENT_BOOK_ID = "gated-book"
+
+# The whole plugin-only surface: the five ereader routes plus the two uploads
+# that live on otherwise ungated routers. ``test_route_tree`` holds this list to
+# the app's own routing table, so a new gated route that is missing here fails
+# there rather than going untested.
+GATED_ROUTES: list[tuple[str, str]] = [
+    ("POST", "/api/v1/ereader/books"),
+    ("GET", f"/api/v1/ereader/books/{CLIENT_BOOK_ID}"),
+    ("POST", f"/api/v1/ereader/books/{CLIENT_BOOK_ID}/epub"),
+    ("GET", f"/api/v1/ereader/books/{CLIENT_BOOK_ID}/digest"),
+    ("GET", f"/api/v1/ereader/books/{CLIENT_BOOK_ID}/highlights"),
+    ("POST", "/api/v1/highlights/upload"),
+    ("POST", "/api/v1/reading_sessions/upload"),
+]
 
 HIGHLIGHT_UPLOAD = {
     "client_book_id": CLIENT_BOOK_ID,
@@ -53,13 +70,20 @@ SESSION_UPLOAD = {
 }
 
 
-def expected_detail(received_version: str | None) -> dict[str, Any]:
+def expected_body(received_version: str | None) -> dict[str, Any]:
+    """The entire 426 response body, not only its ``detail``.
+
+    A plugin parses this whole document, so an extra top-level key -- or the
+    detail arriving as a bare string -- is a contract change either way.
+    """
     return {
-        "code": UPGRADE_REQUIRED_CODE,
-        "client": KOREADER_PLUGIN,
-        "min_supported_version": MIN_VERSION,
-        "received_version": received_version,
-        "update_url": REQUIREMENT.update_url,
+        "detail": {
+            "code": UPGRADE_REQUIRED_CODE,
+            "client": PLUGIN,
+            "min_supported_version": MIN_VERSION,
+            "received_version": received_version,
+            "update_url": UPDATE_URL,
+        }
     }
 
 
@@ -75,49 +99,72 @@ async def gated_book(db_session: AsyncSession) -> models.Book:
 
 
 @pytest.fixture
-async def headerless_client(client: AsyncClient) -> AsyncGenerator[AsyncClient, None]:
-    """A client sending no X-Crossbill-Client header, as old plugins do.
+async def unauthenticated_client(client: AsyncClient) -> AsyncGenerator[AsyncClient, None]:
+    """A client with no current-user override, so authentication really runs.
 
-    Built on top of ``client`` so the app-wide overrides that fixture installs
-    (database session, current user, file repository, job queue) are in place;
-    only the default header the shared client carries is dropped.
+    Built on ``client`` for the database and container overrides, then drops the
+    one override that would hide the order the gate and the login check run in.
     """
+    app.dependency_overrides.pop(get_current_user, None)
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as bare_client:
         yield bare_client
 
 
-async def test_ereader_route_rejects_a_client_that_names_none(
-    headerless_client: AsyncClient, gated_book: models.Book
+@pytest.mark.parametrize(
+    ("method", "path"),
+    GATED_ROUTES,
+    ids=[f"{method} {path}" for method, path in GATED_ROUTES],
+)
+async def test_every_gated_route_rejects_a_client_that_names_none(
+    client: AsyncClient, gated_book: models.Book, method: str, path: str
 ) -> None:
-    response = await headerless_client.get(f"/api/v1/ereader/books/{CLIENT_BOOK_ID}")
+    """The gate answers before the body is read, so an empty request is enough."""
+    response = await client.request(method, path)
 
     assert response.status_code == status.HTTP_426_UPGRADE_REQUIRED, response.text
-    assert response.json()["detail"] == expected_detail(received_version=None)
+    assert response.json() == expected_body(received_version=None)
 
 
-async def test_highlight_upload_rejects_a_client_that_names_none(
-    headerless_client: AsyncClient, db_session: AsyncSession, gated_book: models.Book
+async def test_highlight_upload_writes_nothing_for_a_client_that_names_none(
+    client: AsyncClient, db_session: AsyncSession, gated_book: models.Book
 ) -> None:
-    response = await headerless_client.post("/api/v1/highlights/upload", json=HIGHLIGHT_UPLOAD)
+    response = await client.post("/api/v1/highlights/upload", json=HIGHLIGHT_UPLOAD)
 
     assert response.status_code == status.HTTP_426_UPGRADE_REQUIRED, response.text
-    assert response.json()["detail"] == expected_detail(received_version=None)
-
     stored = await db_session.execute(select(models.Highlight))
     assert stored.scalars().all() == []
 
 
-async def test_reading_session_upload_rejects_a_client_that_names_none(
-    headerless_client: AsyncClient, db_session: AsyncSession, gated_book: models.Book
+async def test_reading_session_upload_writes_nothing_for_a_client_that_names_none(
+    client: AsyncClient, db_session: AsyncSession, gated_book: models.Book
 ) -> None:
-    response = await headerless_client.post("/api/v1/reading_sessions/upload", json=SESSION_UPLOAD)
+    response = await client.post("/api/v1/reading_sessions/upload", json=SESSION_UPLOAD)
 
     assert response.status_code == status.HTTP_426_UPGRADE_REQUIRED, response.text
-    assert response.json()["detail"] == expected_detail(received_version=None)
-
     stored = await db_session.execute(select(models.ReadingSession))
     assert stored.scalars().all() == []
+
+
+async def test_an_outdated_plugin_is_turned_away_before_it_authenticates(
+    unauthenticated_client: AsyncClient, gated_book: models.Book
+) -> None:
+    """A plugin too old to be served learns that, not that its token is missing.
+
+    The 401 half is the control: without it this passes on a route that answers
+    426 to everyone, authenticated or not.
+    """
+    outdated = await unauthenticated_client.get(f"/api/v1/ereader/books/{CLIENT_BOOK_ID}")
+
+    assert outdated.status_code == status.HTTP_426_UPGRADE_REQUIRED, outdated.text
+    assert outdated.json() == expected_body(received_version=None)
+
+    current = await unauthenticated_client.get(
+        f"/api/v1/ereader/books/{CLIENT_BOOK_ID}",
+        headers={CLIENT_HEADER: f"{PLUGIN}/{MIN_VERSION}"},
+    )
+
+    assert current.status_code == status.HTTP_401_UNAUTHORIZED, current.text
 
 
 @pytest.mark.parametrize(
@@ -130,15 +177,15 @@ async def test_reading_session_upload_rejects_a_client_that_names_none(
     ],
 )
 async def test_version_below_the_minimum_is_rejected(
-    headerless_client: AsyncClient, gated_book: models.Book, version: str
+    client: AsyncClient, gated_book: models.Book, version: str
 ) -> None:
-    response = await headerless_client.get(
+    response = await client.get(
         f"/api/v1/ereader/books/{CLIENT_BOOK_ID}",
-        headers={CLIENT_VERSION_HEADER: f"{KOREADER_PLUGIN}/{version}"},
+        headers={CLIENT_HEADER: f"{PLUGIN}/{version}"},
     )
 
     assert response.status_code == status.HTTP_426_UPGRADE_REQUIRED, response.text
-    assert response.json()["detail"] == expected_detail(received_version=version)
+    assert response.json() == expected_body(received_version=version)
 
 
 @pytest.mark.parametrize(
@@ -154,63 +201,56 @@ async def test_version_below_the_minimum_is_rejected(
     ],
 )
 async def test_version_we_cannot_read_is_rejected(
-    headerless_client: AsyncClient, gated_book: models.Book, version: str
+    client: AsyncClient, gated_book: models.Book, version: str
 ) -> None:
     """Fail closed: an unreadable version is not evidence of a new enough client."""
-    response = await headerless_client.get(
+    response = await client.get(
         f"/api/v1/ereader/books/{CLIENT_BOOK_ID}",
-        headers={CLIENT_VERSION_HEADER: f"{KOREADER_PLUGIN}/{version}"},
+        headers={CLIENT_HEADER: f"{PLUGIN}/{version}"},
     )
 
     assert response.status_code == status.HTTP_426_UPGRADE_REQUIRED, response.text
-    assert response.json()["detail"] == expected_detail(received_version=None)
+    assert response.json() == expected_body(received_version=None)
 
 
 async def test_an_oversized_version_number_is_rejected_not_crashed(
-    headerless_client: AsyncClient, gated_book: models.Book
+    client: AsyncClient, gated_book: models.Book
 ) -> None:
     """``int()`` refuses more than 4300 digits, and this route runs before auth.
 
     An unbounded pattern would hand the segment to ``int``, which raises, and
     any stranger could turn a header into a 500 without logging in.
     """
-    response = await headerless_client.get(
+    response = await client.get(
         f"/api/v1/ereader/books/{CLIENT_BOOK_ID}",
-        headers={CLIENT_VERSION_HEADER: f"{KOREADER_PLUGIN}/1.1.{'9' * 5000}"},
+        headers={CLIENT_HEADER: f"{PLUGIN}/1.1.{'9' * 5000}"},
     )
 
     assert response.status_code == status.HTTP_426_UPGRADE_REQUIRED, response.text
-    assert response.json()["detail"] == expected_detail(received_version=None)
+    assert response.json() == expected_body(received_version=None)
 
 
 @pytest.mark.parametrize("header_value", ["", "   "])
 async def test_a_header_that_names_no_client_is_rejected(
-    headerless_client: AsyncClient, gated_book: models.Book, header_value: str
+    client: AsyncClient, gated_book: models.Book, header_value: str
 ) -> None:
     """An empty value names no client, so it cannot pass as an unknown one."""
-    response = await headerless_client.get(
+    response = await client.get(
         f"/api/v1/ereader/books/{CLIENT_BOOK_ID}",
-        headers={CLIENT_VERSION_HEADER: header_value},
+        headers={CLIENT_HEADER: header_value},
     )
 
     assert response.status_code == status.HTTP_426_UPGRADE_REQUIRED, response.text
-    assert response.json()["detail"] == expected_detail(received_version=None)
+    assert response.json() == expected_body(received_version=None)
 
 
-@pytest.mark.parametrize(
-    "version",
-    [
-        MIN_VERSION,
-        format_version((REQUIREMENT.min_version[0], REQUIREMENT.min_version[1], 99)),
-        format_version((REQUIREMENT.min_version[0] + 1, 0, 0)),
-    ],
-)
+@pytest.mark.parametrize("version", [MIN_VERSION, "0.13.99", "1.0.0"])
 async def test_version_at_or_above_the_minimum_is_served(
-    headerless_client: AsyncClient, gated_book: models.Book, version: str
+    client: AsyncClient, gated_book: models.Book, version: str
 ) -> None:
-    response = await headerless_client.get(
+    response = await client.get(
         f"/api/v1/ereader/books/{CLIENT_BOOK_ID}",
-        headers={CLIENT_VERSION_HEADER: f"{KOREADER_PLUGIN}/{version}"},
+        headers={CLIENT_HEADER: f"{PLUGIN}/{version}"},
     )
 
     assert response.status_code == status.HTTP_200_OK, response.text
@@ -218,12 +258,12 @@ async def test_version_at_or_above_the_minimum_is_served(
 
 
 async def test_client_we_have_no_requirement_for_is_served(
-    headerless_client: AsyncClient, gated_book: models.Book
+    client: AsyncClient, gated_book: models.Book
 ) -> None:
     """The gate polices our own clients' versions, not who may call the API."""
-    response = await headerless_client.get(
+    response = await client.get(
         f"/api/v1/ereader/books/{CLIENT_BOOK_ID}",
-        headers={CLIENT_VERSION_HEADER: "someones-script/0.0.1"},
+        headers={CLIENT_HEADER: "someones-script/0.0.1"},
     )
 
     assert response.status_code == status.HTTP_200_OK, response.text
@@ -231,24 +271,24 @@ async def test_client_we_have_no_requirement_for_is_served(
 
 
 async def test_ungated_endpoint_serves_a_client_that_names_none(
-    headerless_client: AsyncClient, gated_book: models.Book
+    client: AsyncClient, gated_book: models.Book
 ) -> None:
     """The web app sends no such header and must keep working."""
-    response = await headerless_client.get("/api/v1/books/")
+    response = await client.get("/api/v1/books/")
 
     assert response.status_code == status.HTTP_200_OK, response.text
     assert [book["title"] for book in response.json()["items"]] == ["Gated Book"]
 
 
 async def test_login_serves_a_client_that_names_none(
-    headerless_client: AsyncClient, db_session: AsyncSession, test_user: User
+    client: AsyncClient, db_session: AsyncSession, test_user: User
 ) -> None:
     """A plugin too old to be served still has to be able to authenticate."""
     password = "correct-horse-battery-staple"
     test_user.hashed_password = await hash_password(password)
     await db_session.commit()
 
-    response = await headerless_client.post(
+    response = await client.post(
         "/api/v1/auth/login",
         data={"username": test_user.email, "password": password},
     )

--- a/backend/tests/test_client_version_gate.py
+++ b/backend/tests/test_client_version_gate.py
@@ -14,12 +14,14 @@ from collections.abc import AsyncGenerator
 from typing import Any
 
 import pytest
+from fastapi.routing import iter_route_contexts
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from starlette import status
 
 from src import models
+from src.infrastructure.common.client_version import require_koreader_plugin
 from src.infrastructure.identity.dependencies import get_current_user
 from src.infrastructure.identity.services.password_service import hash_password
 from src.main import app
@@ -35,9 +37,9 @@ UPDATE_URL = "https://github.com/Crossbill-App/koreader-plugin"
 CLIENT_BOOK_ID = "gated-book"
 
 # The whole plugin-only surface: the five ereader routes plus the two uploads
-# that live on otherwise ungated routers. ``test_route_tree`` holds this list to
-# the app's own routing table, so a new gated route that is missing here fails
-# there rather than going untested.
+# that live on otherwise ungated routers. The two structural tests at the bottom
+# hold this list against the app's own routing table and its OpenAPI schema, so a
+# gate added or lost anywhere fails here rather than going untested.
 GATED_ROUTES: list[tuple[str, str]] = [
     ("POST", "/api/v1/ereader/books"),
     ("GET", f"/api/v1/ereader/books/{CLIENT_BOOK_ID}"),
@@ -47,6 +49,13 @@ GATED_ROUTES: list[tuple[str, str]] = [
     ("POST", "/api/v1/highlights/upload"),
     ("POST", "/api/v1/reading_sessions/upload"),
 ]
+
+# The same surface as route templates, which is how the app describes itself.
+EXPECTED_GATED_OPERATIONS = {
+    (method, path.replace(CLIENT_BOOK_ID, "{client_book_id}")) for method, path in GATED_ROUTES
+}
+
+HTTP_METHODS = {"GET", "PUT", "POST", "DELETE", "OPTIONS", "HEAD", "PATCH", "TRACE"}
 
 HIGHLIGHT_UPLOAD = {
     "client_book_id": CLIENT_BOOK_ID,
@@ -295,3 +304,41 @@ async def test_login_serves_a_client_that_names_none(
 
     assert response.status_code == status.HTTP_200_OK, response.text
     assert response.json()["access_token"]
+
+
+def test_exactly_the_named_operations_carry_the_gate() -> None:
+    """Read the app's routing table rather than trusting where the code looks gated.
+
+    Two mistakes hide from every request-level test: a gate silently lost from a
+    router someone reorganised, and a gate spreading onto a route the web app
+    needs. Routers are included lazily, so the dependency lists live behind
+    ``iter_route_contexts`` rather than on ``app.routes``.
+    """
+    gated = {
+        (method, context.path)
+        for context in iter_route_contexts(app.routes)
+        if any(
+            depends.dependency is require_koreader_plugin
+            for depends in getattr(context, "dependencies", None) or ()
+        )
+        for method in context.methods or ()
+    }
+
+    assert gated == EXPECTED_GATED_OPERATIONS
+
+
+def test_426_is_documented_on_exactly_the_gated_operations() -> None:
+    """426 identifies this gate across the whole API, which only holds if it is unique.
+
+    The plugin is told to read the status code alone, so a second endpoint
+    answering 426 for an unrelated reason would make that instruction wrong.
+    """
+    documented = {
+        (method.upper(), path)
+        for path, operations in app.openapi()["paths"].items()
+        for method, operation in operations.items()
+        if method.upper() in HTTP_METHODS
+        if str(status.HTTP_426_UPGRADE_REQUIRED) in operation.get("responses", {})
+    }
+
+    assert documented == EXPECTED_GATED_OPERATIONS

--- a/backend/tests/test_client_version_gate.py
+++ b/backend/tests/test_client_version_gate.py
@@ -1,13 +1,9 @@
 """The client-version gate over the endpoints only the KOReader plugin calls.
 
-Driven through the endpoints because the gate is a property of the surface, not
-of a function: which routes carry it is half of what can go wrong.
-
-Every value of the contract -- the header name, the minimum version, the code
-and the update URL -- is written out as a literal here rather than read from
-``client_version``. Deriving them from the module under test would mean a wrong
-minimum still matched itself and the whole file stayed green; a plugin in the
-wild reads these strings, so a test has to say them out loud.
+Driven through the endpoints because which routes carry the gate is half of
+what can go wrong. The contract values are literals rather than imports from
+``client_version``: a plugin in the wild reads these strings, and a value
+derived from the module under test would always match itself.
 """
 
 from collections.abc import AsyncGenerator
@@ -36,10 +32,9 @@ UPDATE_URL = "https://github.com/Crossbill-App/koreader-plugin"
 
 CLIENT_BOOK_ID = "gated-book"
 
-# The whole plugin-only surface: the five ereader routes plus the two uploads
-# that live on otherwise ungated routers. The two structural tests at the bottom
-# hold this list against the app's own routing table and its OpenAPI schema, so a
-# gate added or lost anywhere fails here rather than going untested.
+# The whole plugin-only surface. The structural tests at the bottom hold this
+# list against the app's routing table and its OpenAPI schema, so a gate added
+# or lost anywhere fails here.
 GATED_ROUTES: list[tuple[str, str]] = [
     ("POST", "/api/v1/ereader/books"),
     ("GET", f"/api/v1/ereader/books/{CLIENT_BOOK_ID}"),
@@ -82,8 +77,8 @@ SESSION_UPLOAD = {
 def expected_body(received_version: str | None) -> dict[str, Any]:
     """The entire 426 response body, not only its ``detail``.
 
-    A plugin parses this whole document, so an extra top-level key -- or the
-    detail arriving as a bare string -- is a contract change either way.
+    A plugin parses the whole document, so an extra top-level key or a bare
+    string ``detail`` is a contract change too.
     """
     return {
         "detail": {
@@ -111,8 +106,8 @@ async def gated_book(db_session: AsyncSession) -> models.Book:
 async def unauthenticated_client(client: AsyncClient) -> AsyncGenerator[AsyncClient, None]:
     """A client with no current-user override, so authentication really runs.
 
-    Built on ``client`` for the database and container overrides, then drops the
-    one override that would hide the order the gate and the login check run in.
+    Built on ``client`` for the database and container overrides, minus the
+    override that would hide the order of the gate and the login check.
     """
     app.dependency_overrides.pop(get_current_user, None)
     transport = ASGITransport(app=app)
@@ -160,8 +155,8 @@ async def test_an_outdated_plugin_is_turned_away_before_it_authenticates(
 ) -> None:
     """A plugin too old to be served learns that, not that its token is missing.
 
-    The 401 half is the control: without it this passes on a route that answers
-    426 to everyone, authenticated or not.
+    The 401 half is the control: without it this would pass on a route that
+    answers 426 to everyone.
     """
     outdated = await unauthenticated_client.get(f"/api/v1/ereader/books/{CLIENT_BOOK_ID}")
 
@@ -180,8 +175,7 @@ async def test_an_outdated_plugin_is_turned_away_before_it_authenticates(
     "version",
     [
         "0.12.0",
-        # Below the minimum on the numbers and above it as a string: the one
-        # case that tells a version comparison from a lexicographic one.
+        # Below the minimum numerically, above it lexicographically.
         "0.9.0",
     ],
 )
@@ -202,8 +196,7 @@ async def test_version_below_the_minimum_is_rejected(
     [
         "banana",
         "v0.13.0",
-        # Two parts only. A lenient parse would read this as newer than the
-        # minimum and let it through.
+        # A lenient parse would read two parts as newer than the minimum.
         "1.2",
         "0.13.0-beta.1",
         "",
@@ -225,11 +218,7 @@ async def test_version_we_cannot_read_is_rejected(
 async def test_an_oversized_version_number_is_rejected_not_crashed(
     client: AsyncClient, gated_book: models.Book
 ) -> None:
-    """``int()`` refuses more than 4300 digits, and this route runs before auth.
-
-    An unbounded pattern would hand the segment to ``int``, which raises, and
-    any stranger could turn a header into a 500 without logging in.
-    """
+    """A version too long for ``int()`` is unreadable, not a 500 before auth."""
     response = await client.get(
         f"/api/v1/ereader/books/{CLIENT_BOOK_ID}",
         headers={CLIENT_HEADER: f"{PLUGIN}/1.1.{'9' * 5000}"},
@@ -307,11 +296,9 @@ async def test_login_serves_a_client_that_names_none(
 
 
 def test_exactly_the_named_operations_carry_the_gate() -> None:
-    """Read the app's routing table rather than trusting where the code looks gated.
+    """Exactly these operations carry the gate -- none lost, none spread further.
 
-    Two mistakes hide from every request-level test: a gate silently lost from a
-    router someone reorganised, and a gate spreading onto a route the web app
-    needs. Routers are included lazily, so the dependency lists live behind
+    Routers are included lazily, so the dependency lists live behind
     ``iter_route_contexts`` rather than on ``app.routes``.
     """
     gated = {
@@ -328,11 +315,7 @@ def test_exactly_the_named_operations_carry_the_gate() -> None:
 
 
 def test_426_is_documented_on_exactly_the_gated_operations() -> None:
-    """426 identifies this gate across the whole API, which only holds if it is unique.
-
-    The plugin is told to read the status code alone, so a second endpoint
-    answering 426 for an unrelated reason would make that instruction wrong.
-    """
+    """The plugin identifies the gate by status code alone, so 426 must be unique."""
     documented = {
         (method.upper(), path)
         for path, operations in app.openapi()["paths"].items()

--- a/backend/tests/test_client_version_gate.py
+++ b/backend/tests/test_client_version_gate.py
@@ -1,0 +1,226 @@
+"""The client-version gate over the endpoints only the KOReader plugin calls.
+
+Driven through the endpoints because the gate is a property of the surface, not
+of a function: which routes carry it is half of what can go wrong.
+"""
+
+from collections.abc import AsyncGenerator
+from typing import Any
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from starlette import status
+
+from src import models
+from src.infrastructure.common.client_version import (
+    CLIENT_VERSION_HEADER,
+    CLIENT_VERSION_REQUIREMENTS,
+    KOREADER_PLUGIN,
+    UPGRADE_REQUIRED_CODE,
+    format_version,
+)
+from src.infrastructure.identity.services.password_service import hash_password
+from src.main import app
+from src.models import User
+from tests.conftest import create_test_book
+
+REQUIREMENT = CLIENT_VERSION_REQUIREMENTS[KOREADER_PLUGIN]
+MIN_VERSION = format_version(REQUIREMENT.min_version)
+
+CLIENT_BOOK_ID = "gated-book"
+
+HIGHLIGHT_UPLOAD = {
+    "client_book_id": CLIENT_BOOK_ID,
+    "highlights": [
+        {
+            "text": "A sentence worth keeping",
+            "datetime": "2026-01-15 14:30:22",
+        }
+    ],
+}
+
+SESSION_UPLOAD = {
+    "client_book_id": CLIENT_BOOK_ID,
+    "sessions": [
+        {
+            "start_time": "2026-01-15T10:00:00Z",
+            "end_time": "2026-01-15T11:00:00Z",
+            "device_id": "kobo-1",
+        }
+    ],
+}
+
+
+def expected_detail(received_version: str | None) -> dict[str, Any]:
+    return {
+        "code": UPGRADE_REQUIRED_CODE,
+        "client": KOREADER_PLUGIN,
+        "min_supported_version": MIN_VERSION,
+        "received_version": received_version,
+        "update_url": REQUIREMENT.update_url,
+    }
+
+
+@pytest.fixture
+async def gated_book(db_session: AsyncSession) -> models.Book:
+    """A book the plugin would address by its client_book_id."""
+    return await create_test_book(
+        db_session=db_session,
+        user_id=1,
+        title="Gated Book",
+        client_book_id=CLIENT_BOOK_ID,
+    )
+
+
+@pytest.fixture
+async def headerless_client(client: AsyncClient) -> AsyncGenerator[AsyncClient, None]:
+    """A client sending no X-Crossbill-Client header, as old plugins do.
+
+    Built on top of ``client`` so the app-wide overrides that fixture installs
+    (database session, current user, file repository, job queue) are in place;
+    only the default header the shared client carries is dropped.
+    """
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as bare_client:
+        yield bare_client
+
+
+async def test_ereader_route_rejects_a_client_that_names_none(
+    headerless_client: AsyncClient, gated_book: models.Book
+) -> None:
+    response = await headerless_client.get(f"/api/v1/ereader/books/{CLIENT_BOOK_ID}")
+
+    assert response.status_code == status.HTTP_426_UPGRADE_REQUIRED, response.text
+    assert response.json()["detail"] == expected_detail(received_version=None)
+
+
+async def test_highlight_upload_rejects_a_client_that_names_none(
+    headerless_client: AsyncClient, db_session: AsyncSession, gated_book: models.Book
+) -> None:
+    response = await headerless_client.post("/api/v1/highlights/upload", json=HIGHLIGHT_UPLOAD)
+
+    assert response.status_code == status.HTTP_426_UPGRADE_REQUIRED, response.text
+    assert response.json()["detail"] == expected_detail(received_version=None)
+
+    stored = await db_session.execute(select(models.Highlight))
+    assert stored.scalars().all() == []
+
+
+async def test_reading_session_upload_rejects_a_client_that_names_none(
+    headerless_client: AsyncClient, db_session: AsyncSession, gated_book: models.Book
+) -> None:
+    response = await headerless_client.post("/api/v1/reading_sessions/upload", json=SESSION_UPLOAD)
+
+    assert response.status_code == status.HTTP_426_UPGRADE_REQUIRED, response.text
+    assert response.json()["detail"] == expected_detail(received_version=None)
+
+    stored = await db_session.execute(select(models.ReadingSession))
+    assert stored.scalars().all() == []
+
+
+@pytest.mark.parametrize(
+    "version",
+    [
+        "0.12.0",
+        # Below the minimum on the numbers and above it as a string: the one
+        # case that tells a version comparison from a lexicographic one.
+        "0.9.0",
+    ],
+)
+async def test_version_below_the_minimum_is_rejected(
+    headerless_client: AsyncClient, gated_book: models.Book, version: str
+) -> None:
+    response = await headerless_client.get(
+        f"/api/v1/ereader/books/{CLIENT_BOOK_ID}",
+        headers={CLIENT_VERSION_HEADER: f"{KOREADER_PLUGIN}/{version}"},
+    )
+
+    assert response.status_code == status.HTTP_426_UPGRADE_REQUIRED, response.text
+    assert response.json()["detail"] == expected_detail(received_version=version)
+
+
+@pytest.mark.parametrize(
+    "version",
+    [
+        "banana",
+        "v0.13.0",
+        # Two parts only. A lenient parse would read this as newer than the
+        # minimum and let it through.
+        "1.2",
+        "0.13.0-beta.1",
+        "",
+    ],
+)
+async def test_version_we_cannot_read_is_rejected(
+    headerless_client: AsyncClient, gated_book: models.Book, version: str
+) -> None:
+    """Fail closed: an unreadable version is not evidence of a new enough client."""
+    response = await headerless_client.get(
+        f"/api/v1/ereader/books/{CLIENT_BOOK_ID}",
+        headers={CLIENT_VERSION_HEADER: f"{KOREADER_PLUGIN}/{version}"},
+    )
+
+    assert response.status_code == status.HTTP_426_UPGRADE_REQUIRED, response.text
+    assert response.json()["detail"] == expected_detail(received_version=None)
+
+
+@pytest.mark.parametrize(
+    "version",
+    [
+        MIN_VERSION,
+        format_version((REQUIREMENT.min_version[0], REQUIREMENT.min_version[1], 99)),
+        format_version((REQUIREMENT.min_version[0] + 1, 0, 0)),
+    ],
+)
+async def test_version_at_or_above_the_minimum_is_served(
+    headerless_client: AsyncClient, gated_book: models.Book, version: str
+) -> None:
+    response = await headerless_client.get(
+        f"/api/v1/ereader/books/{CLIENT_BOOK_ID}",
+        headers={CLIENT_VERSION_HEADER: f"{KOREADER_PLUGIN}/{version}"},
+    )
+
+    assert response.status_code == status.HTTP_200_OK, response.text
+    assert response.json()["bookname"] == "Gated Book"
+
+
+async def test_client_we_have_no_requirement_for_is_served(
+    headerless_client: AsyncClient, gated_book: models.Book
+) -> None:
+    """The gate polices our own clients' versions, not who may call the API."""
+    response = await headerless_client.get(
+        f"/api/v1/ereader/books/{CLIENT_BOOK_ID}",
+        headers={CLIENT_VERSION_HEADER: "someones-script/0.0.1"},
+    )
+
+    assert response.status_code == status.HTTP_200_OK, response.text
+    assert response.json()["bookname"] == "Gated Book"
+
+
+async def test_ungated_endpoint_serves_a_client_that_names_none(
+    headerless_client: AsyncClient, gated_book: models.Book
+) -> None:
+    """The web app sends no such header and must keep working."""
+    response = await headerless_client.get("/api/v1/books/")
+
+    assert response.status_code == status.HTTP_200_OK, response.text
+    assert [book["title"] for book in response.json()["items"]] == ["Gated Book"]
+
+
+async def test_login_serves_a_client_that_names_none(
+    headerless_client: AsyncClient, db_session: AsyncSession, test_user: User
+) -> None:
+    """A plugin too old to be served still has to be able to authenticate."""
+    password = "correct-horse-battery-staple"
+    test_user.hashed_password = await hash_password(password)
+    await db_session.commit()
+
+    response = await headerless_client.post(
+        "/api/v1/auth/login",
+        data={"username": test_user.email, "password": password},
+    )
+
+    assert response.status_code == status.HTTP_200_OK, response.text
+    assert response.json()["access_token"]

--- a/backend/tests/test_client_version_gate.py
+++ b/backend/tests/test_client_version_gate.py
@@ -166,6 +166,37 @@ async def test_version_we_cannot_read_is_rejected(
     assert response.json()["detail"] == expected_detail(received_version=None)
 
 
+async def test_an_oversized_version_number_is_rejected_not_crashed(
+    headerless_client: AsyncClient, gated_book: models.Book
+) -> None:
+    """``int()`` refuses more than 4300 digits, and this route runs before auth.
+
+    An unbounded pattern would hand the segment to ``int``, which raises, and
+    any stranger could turn a header into a 500 without logging in.
+    """
+    response = await headerless_client.get(
+        f"/api/v1/ereader/books/{CLIENT_BOOK_ID}",
+        headers={CLIENT_VERSION_HEADER: f"{KOREADER_PLUGIN}/1.1.{'9' * 5000}"},
+    )
+
+    assert response.status_code == status.HTTP_426_UPGRADE_REQUIRED, response.text
+    assert response.json()["detail"] == expected_detail(received_version=None)
+
+
+@pytest.mark.parametrize("header_value", ["", "   "])
+async def test_a_header_that_names_no_client_is_rejected(
+    headerless_client: AsyncClient, gated_book: models.Book, header_value: str
+) -> None:
+    """An empty value names no client, so it cannot pass as an unknown one."""
+    response = await headerless_client.get(
+        f"/api/v1/ereader/books/{CLIENT_BOOK_ID}",
+        headers={CLIENT_VERSION_HEADER: header_value},
+    )
+
+    assert response.status_code == status.HTTP_426_UPGRADE_REQUIRED, response.text
+    assert response.json()["detail"] == expected_detail(received_version=None)
+
+
 @pytest.mark.parametrize(
     "version",
     [

--- a/backend/tests/test_ereader_digest.py
+++ b/backend/tests/test_ereader_digest.py
@@ -45,7 +45,7 @@ async def digest_book(db_session: AsyncSession, test_user: Book) -> Book:
 
 
 async def test_returns_items_ordered_by_chapter_number(
-    client: AsyncClient, db_session: AsyncSession, digest_book: Book
+    plugin_client: AsyncClient, db_session: AsyncSession, digest_book: Book
 ) -> None:
     parent = await create_test_chapter(db_session, digest_book, "Topic 1", chapter_number=1)
     ch_a = await create_test_chapter(
@@ -57,7 +57,7 @@ async def test_returns_items_ordered_by_chapter_number(
     await _add_digest(db_session, ch_a, summary="Exercises summary")
     await _add_digest(db_session, ch_b, summary="Intro summary")
 
-    response = await client.get("/api/v1/ereader/books/client-abc/digest")
+    response = await plugin_client.get("/api/v1/ereader/books/client-abc/digest")
 
     assert response.status_code == 200
     items = response.json()["items"]
@@ -70,18 +70,20 @@ async def test_returns_items_ordered_by_chapter_number(
 
 
 async def test_old_prereading_path_is_gone(
-    client: AsyncClient, db_session: AsyncSession, digest_book: Book
+    plugin_client: AsyncClient, db_session: AsyncSession, digest_book: Book
 ) -> None:
     """The rename is a clean break: plugins older than 0.11 stop fetching digests."""
     chapter = await create_test_chapter(db_session, digest_book, "Intro", chapter_number=1)
     await _add_digest(db_session, chapter, summary="Intro summary")
 
-    assert (await client.get("/api/v1/ereader/books/client-abc/digest")).status_code == 200
-    assert (await client.get("/api/v1/ereader/books/client-abc/prereading")).status_code == 404
+    assert (await plugin_client.get("/api/v1/ereader/books/client-abc/digest")).status_code == 200
+    assert (
+        await plugin_client.get("/api/v1/ereader/books/client-abc/prereading")
+    ).status_code == 404
 
 
 async def test_duplicate_chapter_names_disambiguated_by_parent(
-    client: AsyncClient, db_session: AsyncSession, digest_book: Book
+    plugin_client: AsyncClient, db_session: AsyncSession, digest_book: Book
 ) -> None:
     topic1 = await create_test_chapter(db_session, digest_book, "Topic 1", chapter_number=1)
     topic2 = await create_test_chapter(db_session, digest_book, "Topic 2", chapter_number=2)
@@ -94,7 +96,7 @@ async def test_duplicate_chapter_names_disambiguated_by_parent(
     await _add_digest(db_session, ex1)
     await _add_digest(db_session, ex2)
 
-    response = await client.get("/api/v1/ereader/books/client-abc/digest")
+    response = await plugin_client.get("/api/v1/ereader/books/client-abc/digest")
 
     assert response.status_code == 200
     items = response.json()["items"]
@@ -105,12 +107,12 @@ async def test_duplicate_chapter_names_disambiguated_by_parent(
 
 
 async def test_root_chapter_has_null_parent_name(
-    client: AsyncClient, db_session: AsyncSession, digest_book: Book
+    plugin_client: AsyncClient, db_session: AsyncSession, digest_book: Book
 ) -> None:
     root = await create_test_chapter(db_session, digest_book, "Root Chapter", chapter_number=1)
     await _add_digest(db_session, root)
 
-    response = await client.get("/api/v1/ereader/books/client-abc/digest")
+    response = await plugin_client.get("/api/v1/ereader/books/client-abc/digest")
 
     assert response.status_code == 200
     items = response.json()["items"]
@@ -119,13 +121,13 @@ async def test_root_chapter_has_null_parent_name(
 
 
 async def test_chapters_without_digest_are_omitted(
-    client: AsyncClient, db_session: AsyncSession, digest_book: Book
+    plugin_client: AsyncClient, db_session: AsyncSession, digest_book: Book
 ) -> None:
     ch_with = await create_test_chapter(db_session, digest_book, "Has digest", chapter_number=1)
     await create_test_chapter(db_session, digest_book, "No digest", chapter_number=2)
     await _add_digest(db_session, ch_with)
 
-    response = await client.get("/api/v1/ereader/books/client-abc/digest")
+    response = await plugin_client.get("/api/v1/ereader/books/client-abc/digest")
 
     assert response.status_code == 200
     items = response.json()["items"]
@@ -134,24 +136,24 @@ async def test_chapters_without_digest_are_omitted(
 
 
 async def test_book_with_zero_digest_returns_empty_list(
-    client: AsyncClient, db_session: AsyncSession, digest_book: Book
+    plugin_client: AsyncClient, db_session: AsyncSession, digest_book: Book
 ) -> None:
     await create_test_chapter(db_session, digest_book, "Lonely chapter", chapter_number=1)
 
-    response = await client.get("/api/v1/ereader/books/client-abc/digest")
+    response = await plugin_client.get("/api/v1/ereader/books/client-abc/digest")
 
     assert response.status_code == 200
     assert response.json()["items"] == []
 
 
-async def test_unknown_client_book_id_returns_404(client: AsyncClient) -> None:
-    response = await client.get("/api/v1/ereader/books/does-not-exist/digest")
+async def test_unknown_client_book_id_returns_404(plugin_client: AsyncClient) -> None:
+    response = await plugin_client.get("/api/v1/ereader/books/does-not-exist/digest")
 
     assert response.status_code == 404
 
 
 async def test_questions_contain_only_question_strings(
-    client: AsyncClient, db_session: AsyncSession, digest_book: Book
+    plugin_client: AsyncClient, db_session: AsyncSession, digest_book: Book
 ) -> None:
     chapter = await create_test_chapter(db_session, digest_book, "Chapter", chapter_number=1)
     await _add_digest(
@@ -166,7 +168,7 @@ async def test_questions_contain_only_question_strings(
         ],
     )
 
-    response = await client.get("/api/v1/ereader/books/client-abc/digest")
+    response = await plugin_client.get("/api/v1/ereader/books/client-abc/digest")
 
     assert response.status_code == 200
     questions = response.json()["items"][0]["questions"]

--- a/backend/tests/test_ereader_epub_upload.py
+++ b/backend/tests/test_ereader_epub_upload.py
@@ -27,13 +27,13 @@ async def ereader_book(db_session: AsyncSession, test_user: models.User) -> mode
 class TestEpubUpload:
     async def test_upload_success_stores_file(
         self,
-        client: AsyncClient,
+        plugin_client: AsyncClient,
         db_session: AsyncSession,
         ereader_book: models.Book,
         epub_bytes: bytes,
         storage_dir: Path,
     ) -> None:
-        response = await client.post(
+        response = await plugin_client.post(
             f"/api/v1/ereader/books/{CLIENT_BOOK_ID}/epub",
             files={"epub": ("book.epub", epub_bytes, "application/epub+zip")},
         )
@@ -47,13 +47,13 @@ class TestEpubUpload:
 
     async def test_upload_creates_chapters_from_toc(
         self,
-        client: AsyncClient,
+        plugin_client: AsyncClient,
         db_session: AsyncSession,
         ereader_book: models.Book,
         epub_bytes: bytes,
         storage_dir: Path,
     ) -> None:
-        response = await client.post(
+        response = await plugin_client.post(
             f"/api/v1/ereader/books/{CLIENT_BOOK_ID}/epub",
             files={"epub": ("book.epub", epub_bytes, "application/epub+zip")},
         )
@@ -65,10 +65,10 @@ class TestEpubUpload:
 
     async def test_upload_rejects_wrong_content_type(
         self,
-        client: AsyncClient,
+        plugin_client: AsyncClient,
         ereader_book: models.Book,
     ) -> None:
-        response = await client.post(
+        response = await plugin_client.post(
             f"/api/v1/ereader/books/{CLIENT_BOOK_ID}/epub",
             files={"epub": ("book.txt", b"not an epub", "text/plain")},
         )
@@ -77,11 +77,11 @@ class TestEpubUpload:
 
     async def test_upload_rejects_invalid_epub_content(
         self,
-        client: AsyncClient,
+        plugin_client: AsyncClient,
         ereader_book: models.Book,
         storage_dir: Path,
     ) -> None:
-        response = await client.post(
+        response = await plugin_client.post(
             f"/api/v1/ereader/books/{CLIENT_BOOK_ID}/epub",
             files={"epub": ("book.epub", b"garbage bytes", "application/epub+zip")},
         )
@@ -90,11 +90,11 @@ class TestEpubUpload:
 
     async def test_upload_unknown_client_book_id_returns_404(
         self,
-        client: AsyncClient,
+        plugin_client: AsyncClient,
         epub_bytes: bytes,
         storage_dir: Path,
     ) -> None:
-        response = await client.post(
+        response = await plugin_client.post(
             "/api/v1/ereader/books/no-such-book/epub",
             files={"epub": ("book.epub", epub_bytes, "application/epub+zip")},
         )
@@ -103,13 +103,13 @@ class TestEpubUpload:
 
     async def test_upload_backfills_positions_of_existing_highlights(
         self,
-        client: AsyncClient,
+        plugin_client: AsyncClient,
         db_session: AsyncSession,
         ereader_book: models.Book,
         epub_bytes: bytes,
         storage_dir: Path,
     ) -> None:
-        upload = await client.post(
+        upload = await plugin_client.post(
             "/api/v1/highlights/upload",
             json={
                 "client_book_id": CLIENT_BOOK_ID,
@@ -125,7 +125,7 @@ class TestEpubUpload:
         )
         assert upload.json()["highlights_created"] == 1
 
-        response = await client.post(
+        response = await plugin_client.post(
             f"/api/v1/ereader/books/{CLIENT_BOOK_ID}/epub",
             files={"epub": ("book.epub", epub_bytes, "application/epub+zip")},
         )

--- a/backend/tests/test_ereader_highlights.py
+++ b/backend/tests/test_ereader_highlights.py
@@ -12,7 +12,7 @@ from tests.conftest import create_test_book, create_test_chapter, create_test_hi
 
 
 async def _upload(
-    client: AsyncClient,
+    plugin_client: AsyncClient,
     client_book_id: str,
     highlights: list[dict[str, Any]],
     device_id: str | None = None,
@@ -20,7 +20,7 @@ async def _upload(
     payload: dict[str, Any] = {"client_book_id": client_book_id, "highlights": highlights}
     if device_id is not None:
         payload["device_id"] = device_id
-    response = await client.post("/api/v1/highlights/upload", json=payload)
+    response = await plugin_client.post("/api/v1/highlights/upload", json=payload)
     assert response.status_code == 200, response.text
     assert response.json()["highlights_created"] == len(highlights)
 
@@ -37,10 +37,10 @@ async def ereader_book(db_session: AsyncSession, test_user: User) -> Book:
 
 
 async def test_returns_uploaded_highlights_with_device_fields(
-    client: AsyncClient, ereader_book: Book
+    plugin_client: AsyncClient, ereader_book: Book
 ) -> None:
     await _upload(
-        client,
+        plugin_client,
         "client-pull",
         [
             {
@@ -63,7 +63,7 @@ async def test_returns_uploaded_highlights_with_device_fields(
         device_id="Kobo Clara",
     )
 
-    response = await client.get("/api/v1/ereader/books/client-pull/highlights")
+    response = await plugin_client.get("/api/v1/ereader/books/client-pull/highlights")
 
     assert response.status_code == 200
     items = response.json()["items"]
@@ -90,10 +90,12 @@ async def test_returns_uploaded_highlights_with_device_fields(
     assert unplaceable["placeable"] is False
 
 
-async def test_highlights_without_a_page_sort_last(client: AsyncClient, ereader_book: Book) -> None:
+async def test_highlights_without_a_page_sort_last(
+    plugin_client: AsyncClient, ereader_book: Book
+) -> None:
     """Page orders the list; a device that sends none puts the highlight at the end."""
     await _upload(
-        client,
+        plugin_client,
         "client-pull",
         [
             {"text": "Pageless", "datetime": "2024-01-15 13:00:00"},
@@ -102,25 +104,29 @@ async def test_highlights_without_a_page_sort_last(client: AsyncClient, ereader_
         ],
     )
 
-    response = await client.get("/api/v1/ereader/books/client-pull/highlights")
+    response = await plugin_client.get("/api/v1/ereader/books/client-pull/highlights")
 
     assert response.status_code == 200
     assert [i["text"] for i in response.json()["items"]] == ["Page one", "Page two", "Pageless"]
 
 
-async def test_soft_deleted_highlight_is_excluded(client: AsyncClient, ereader_book: Book) -> None:
+async def test_soft_deleted_highlight_is_excluded(
+    plugin_client: AsyncClient, ereader_book: Book
+) -> None:
     await _upload(
-        client,
+        plugin_client,
         "client-pull",
         [
             {"text": "Kept", "page": 1, "datetime": "2024-01-15 14:00:00"},
             {"text": "Removed", "page": 2, "datetime": "2024-01-15 14:01:00"},
         ],
     )
-    items = (await client.get("/api/v1/ereader/books/client-pull/highlights")).json()["items"]
+    items = (await plugin_client.get("/api/v1/ereader/books/client-pull/highlights")).json()[
+        "items"
+    ]
     doomed = next(i for i in items if i["text"] == "Removed")
 
-    deletion = await client.request(
+    deletion = await plugin_client.request(
         "DELETE",
         f"/api/v1/books/{ereader_book.id}/highlight",
         json={"highlight_ids": [doomed["id"]]},
@@ -128,20 +134,20 @@ async def test_soft_deleted_highlight_is_excluded(client: AsyncClient, ereader_b
     assert deletion.status_code == 200
     assert deletion.json()["deleted_count"] == 1
 
-    response = await client.get("/api/v1/ereader/books/client-pull/highlights")
+    response = await plugin_client.get("/api/v1/ereader/books/client-pull/highlights")
 
     assert response.status_code == 200
     assert [i["text"] for i in response.json()["items"]] == ["Kept"]
 
 
-async def test_unknown_client_book_id_returns_404(client: AsyncClient) -> None:
-    response = await client.get("/api/v1/ereader/books/does-not-exist/highlights")
+async def test_unknown_client_book_id_returns_404(plugin_client: AsyncClient) -> None:
+    response = await plugin_client.get("/api/v1/ereader/books/does-not-exist/highlights")
 
     assert response.status_code == 404
 
 
 async def test_another_users_book_with_the_same_client_id_is_invisible(
-    client: AsyncClient, db_session: AsyncSession, ereader_book: Book
+    plugin_client: AsyncClient, db_session: AsyncSession, ereader_book: Book
 ) -> None:
     """Two devices can share a client_book_id; the highlights must not cross users."""
     other_user = User(email="other-pull@test.com")
@@ -154,7 +160,9 @@ async def test_another_users_book_with_the_same_client_id_is_invisible(
         title="Their Copy",
         client_book_id="client-pull",
     )
-    await _upload(client, "client-pull", [{"text": "Mine", "datetime": "2024-01-15 14:00:00"}])
+    await _upload(
+        plugin_client, "client-pull", [{"text": "Mine", "datetime": "2024-01-15 14:00:00"}]
+    )
 
     await create_test_highlight(
         db_session=db_session,
@@ -164,14 +172,14 @@ async def test_another_users_book_with_the_same_client_id_is_invisible(
         datetime_str="2024-01-15 14:00:00",
     )
 
-    response = await client.get("/api/v1/ereader/books/client-pull/highlights")
+    response = await plugin_client.get("/api/v1/ereader/books/client-pull/highlights")
 
     assert response.status_code == 200
     assert [i["text"] for i in response.json()["items"]] == ["Mine"]
 
 
 async def test_a_client_book_id_only_another_user_owns_is_a_404(
-    client: AsyncClient, db_session: AsyncSession
+    plugin_client: AsyncClient, db_session: AsyncSession
 ) -> None:
     other_user = User(email="stranger-pull@test.com")
     db_session.add(other_user)
@@ -191,17 +199,17 @@ async def test_a_client_book_id_only_another_user_owns_is_a_404(
         datetime_str="2024-01-15 14:00:00",
     )
 
-    response = await client.get("/api/v1/ereader/books/client-theirs/highlights")
+    response = await plugin_client.get("/api/v1/ereader/books/client-theirs/highlights")
 
     assert response.status_code == 404
 
 
 async def test_chapter_fields_come_from_the_books_chapters(
-    client: AsyncClient, db_session: AsyncSession, ereader_book: Book
+    plugin_client: AsyncClient, db_session: AsyncSession, ereader_book: Book
 ) -> None:
     await create_test_chapter(db_session, ereader_book, "The Opening", chapter_number=1)
     await _upload(
-        client,
+        plugin_client,
         "client-pull",
         [
             {
@@ -215,7 +223,7 @@ async def test_chapter_fields_come_from_the_books_chapters(
         ],
     )
 
-    response = await client.get("/api/v1/ereader/books/client-pull/highlights")
+    response = await plugin_client.get("/api/v1/ereader/books/client-pull/highlights")
 
     assert response.status_code == 200
     in_chapter, chapterless = response.json()["items"]
@@ -226,16 +234,16 @@ async def test_chapter_fields_come_from_the_books_chapters(
 
 
 async def test_book_without_highlights_returns_empty_list(
-    client: AsyncClient, ereader_book: Book
+    plugin_client: AsyncClient, ereader_book: Book
 ) -> None:
-    response = await client.get("/api/v1/ereader/books/client-pull/highlights")
+    response = await plugin_client.get("/api/v1/ereader/books/client-pull/highlights")
 
     assert response.status_code == 200
     assert response.json()["items"] == []
 
 
 async def test_highlight_removed_from_devices_is_excluded(
-    db_session: AsyncSession, client: AsyncClient, ereader_book: Book, test_user: User
+    db_session: AsyncSession, plugin_client: AsyncClient, ereader_book: Book, test_user: User
 ) -> None:
     """A highlight the user deleted on a device stays away from every device."""
     await create_test_highlight(
@@ -256,7 +264,7 @@ async def test_highlight_removed_from_devices_is_excluded(
         removed_from_devices_at=datetime(2024, 3, 1, tzinfo=UTC),
     )
 
-    response = await client.get("/api/v1/ereader/books/client-pull/highlights")
+    response = await plugin_client.get("/api/v1/ereader/books/client-pull/highlights")
 
     assert response.status_code == 200
     assert [i["text"] for i in response.json()["items"]] == ["Kept"]

--- a/backend/tests/test_highlight_chapter_association.py
+++ b/backend/tests/test_highlight_chapter_association.py
@@ -13,7 +13,7 @@ class TestHighlightChapterAssociation:
     """Test suite for highlight-chapter association using chapter_number."""
 
     async def test_highlight_association_with_duplicate_names_using_chapter_number(
-        self, client: AsyncClient, db_session: AsyncSession, test_user: models.User
+        self, plugin_client: AsyncClient, db_session: AsyncSession, test_user: models.User
     ) -> None:
         """Test that highlights are correctly associated when duplicate chapter names exist.
 
@@ -78,7 +78,7 @@ class TestHighlightChapterAssociation:
             ],
         }
 
-        response = await client.post("/api/v1/highlights/upload", json=payload)
+        response = await plugin_client.post("/api/v1/highlights/upload", json=payload)
 
         assert response.status_code == 200
         data = response.json()
@@ -113,7 +113,7 @@ class TestHighlightChapterAssociation:
 
     async def test_highlight_without_chapter_number_logs_warning(
         self,
-        client: AsyncClient,
+        plugin_client: AsyncClient,
         db_session: AsyncSession,
         test_user: models.User,
         caplog: LogCaptureFixture,
@@ -155,7 +155,7 @@ class TestHighlightChapterAssociation:
             ],
         }
 
-        response = await client.post("/api/v1/highlights/upload", json=payload)
+        response = await plugin_client.post("/api/v1/highlights/upload", json=payload)
 
         assert response.status_code == 200
         data = response.json()
@@ -175,7 +175,7 @@ class TestHighlightChapterAssociation:
         )
 
     async def test_mixed_highlights_with_and_without_chapter_numbers(
-        self, client: AsyncClient, db_session: AsyncSession, test_user: models.User
+        self, plugin_client: AsyncClient, db_session: AsyncSession, test_user: models.User
     ) -> None:
         """Test uploading a mix of highlights with and without chapter_numbers.
 
@@ -224,7 +224,7 @@ class TestHighlightChapterAssociation:
             ],
         }
 
-        response = await client.post("/api/v1/highlights/upload", json=payload)
+        response = await plugin_client.post("/api/v1/highlights/upload", json=payload)
 
         assert response.status_code == 200
         data = response.json()

--- a/backend/tests/test_highlight_labels.py
+++ b/backend/tests/test_highlight_labels.py
@@ -21,7 +21,10 @@ class TestHighlightUploadCreatesStyles:
     """Test that uploading highlights creates highlight_style rows."""
 
     async def test_upload_with_color_and_drawer_creates_style(
-        self, client: AsyncClient, db_session: AsyncSession, create_book_via_api: CreateBookFunc
+        self,
+        plugin_client: AsyncClient,
+        db_session: AsyncSession,
+        create_book_via_api: CreateBookFunc,
     ) -> None:
         """Test that uploading highlights with color and drawer creates highlight style rows."""
         await create_book_via_api(
@@ -52,7 +55,7 @@ class TestHighlightUploadCreatesStyles:
             ],
         }
 
-        response = await client.post("/api/v1/highlights/upload", json=payload)
+        response = await plugin_client.post("/api/v1/highlights/upload", json=payload)
         assert response.status_code == status.HTTP_200_OK
         data = response.json()
         assert data["highlights_created"] == 2
@@ -71,7 +74,10 @@ class TestHighlightUploadCreatesStyles:
         assert ("green", "lighten") in style_combos
 
     async def test_upload_duplicate_color_drawer_reuses_style(
-        self, client: AsyncClient, db_session: AsyncSession, create_book_via_api: CreateBookFunc
+        self,
+        plugin_client: AsyncClient,
+        db_session: AsyncSession,
+        create_book_via_api: CreateBookFunc,
     ) -> None:
         """Test that uploading highlights with same color+drawer reuses the same style."""
         await create_book_via_api(
@@ -102,7 +108,7 @@ class TestHighlightUploadCreatesStyles:
             ],
         }
 
-        response = await client.post("/api/v1/highlights/upload", json=payload)
+        response = await plugin_client.post("/api/v1/highlights/upload", json=payload)
         assert response.status_code == status.HTTP_200_OK
         assert response.json()["highlights_created"] == 2
 
@@ -125,7 +131,11 @@ class TestHighlightUploadCreatesStyles:
         assert highlights[1].highlight_style_id == styles[0].id
 
     async def test_highlight_response_includes_highlight_style_id(
-        self, client: AsyncClient, db_session: AsyncSession, create_book_via_api: CreateBookFunc
+        self,
+        client: AsyncClient,
+        plugin_client: AsyncClient,
+        db_session: AsyncSession,
+        create_book_via_api: CreateBookFunc,
     ) -> None:
         """Test that highlight responses include highlight_style_id field."""
         await create_book_via_api(
@@ -149,7 +159,7 @@ class TestHighlightUploadCreatesStyles:
                 },
             ],
         }
-        response = await client.post("/api/v1/highlights/upload", json=payload)
+        response = await plugin_client.post("/api/v1/highlights/upload", json=payload)
         assert response.status_code == status.HTTP_200_OK
 
         # Get book details and check highlight_style_id is in the response
@@ -436,7 +446,11 @@ class TestHighlightUploadWithLabels:
     """Test highlight upload integration with highlight labels."""
 
     async def test_upload_creates_styles_and_labels_endpoint_works(
-        self, client: AsyncClient, db_session: AsyncSession, create_book_via_api: CreateBookFunc
+        self,
+        client: AsyncClient,
+        plugin_client: AsyncClient,
+        db_session: AsyncSession,
+        create_book_via_api: CreateBookFunc,
     ) -> None:
         """End-to-end test: upload highlights, then query labels."""
         await create_book_via_api(
@@ -474,7 +488,7 @@ class TestHighlightUploadWithLabels:
                 },
             ],
         }
-        response = await client.post("/api/v1/highlights/upload", json=payload)
+        response = await plugin_client.post("/api/v1/highlights/upload", json=payload)
         assert response.status_code == status.HTTP_200_OK
         assert response.json()["highlights_created"] == 3
 
@@ -501,7 +515,10 @@ class TestHighlightUploadWithLabels:
         assert green_labels[0]["highlight_count"] == 1
 
     async def test_upload_without_color_drawer_still_creates_style(
-        self, client: AsyncClient, db_session: AsyncSession, create_book_via_api: CreateBookFunc
+        self,
+        plugin_client: AsyncClient,
+        db_session: AsyncSession,
+        create_book_via_api: CreateBookFunc,
     ) -> None:
         """Test that highlights without color/drawer still get a style (with None values)."""
         await create_book_via_api(
@@ -522,7 +539,7 @@ class TestHighlightUploadWithLabels:
                 },
             ],
         }
-        response = await client.post("/api/v1/highlights/upload", json=payload)
+        response = await plugin_client.post("/api/v1/highlights/upload", json=payload)
         assert response.status_code == status.HTTP_200_OK
 
         result = await db_session.execute(select(models.Book).filter_by(title="No Color Book"))

--- a/backend/tests/test_highlights.py
+++ b/backend/tests/test_highlights.py
@@ -1330,7 +1330,7 @@ class TestHighlightUploadRemovals:
     async def test_a_negative_removed_id_is_rejected(
         self, plugin_client: AsyncClient, synced_book: tuple[models.Book, dict[str, int]]
     ) -> None:
-        """A malformed ID is a plugin_client error, not an unhandled domain exception."""
+        """A malformed ID is a client error, not an unhandled domain exception."""
         response = await plugin_client.post(
             "/api/v1/highlights/upload",
             json={"client_book_id": CLIENT_BOOK_ID, "highlights": [], "removed_ids": [-1]},

--- a/backend/tests/test_highlights.py
+++ b/backend/tests/test_highlights.py
@@ -20,7 +20,7 @@ from tests.conftest import (
 
 
 async def resync_edited_highlight(
-    client: AsyncClient,
+    plugin_client: AsyncClient,
     db_session: AsyncSession,
     create_book_via_api: CreateBookFunc,
     client_book_id: str,
@@ -33,13 +33,13 @@ async def resync_edited_highlight(
     """
     await create_book_via_api({"client_book_id": client_book_id, "title": client_book_id})
 
-    created = await client.post(
+    created = await plugin_client.post(
         "/api/v1/highlights/upload",
         json={"client_book_id": client_book_id, "highlights": [first]},
     )
     assert created.json()["highlights_created"] == 1
 
-    resynced = await client.post(
+    resynced = await plugin_client.post(
         "/api/v1/highlights/upload",
         json={"client_book_id": client_book_id, "highlights": [edited]},
     )
@@ -51,21 +51,21 @@ async def resync_edited_highlight(
 
 
 async def upload_then_delete_highlight(
-    client: AsyncClient,
+    plugin_client: AsyncClient,
     db_session: AsyncSession,
     client_book_id: str,
     book_id: int,
     highlight: dict[str, Any],
 ) -> None:
     """Upload one highlight and soft-delete it again, as a reader would."""
-    upload = await client.post(
+    upload = await plugin_client.post(
         "/api/v1/highlights/upload",
         json={"client_book_id": client_book_id, "highlights": [highlight]},
     )
     assert upload.json()["highlights_created"] == 1
 
     result = await db_session.execute(select(models.Highlight).filter_by(text=highlight["text"]))
-    deletion = await client.request(
+    deletion = await plugin_client.request(
         "DELETE",
         f"/api/v1/books/{book_id}/highlight",
         json={"highlight_ids": [result.scalar_one().id]},
@@ -77,7 +77,10 @@ class TestHighlightsUpload:
     """Test suite for highlights upload endpoint."""
 
     async def test_upload_highlights_success(
-        self, client: AsyncClient, db_session: AsyncSession, create_book_via_api: CreateBookFunc
+        self,
+        plugin_client: AsyncClient,
+        db_session: AsyncSession,
+        create_book_via_api: CreateBookFunc,
     ) -> None:
         """Test successful upload of highlights."""
         # Create the book via the fixture
@@ -109,7 +112,7 @@ class TestHighlightsUpload:
             ],
         }
 
-        response = await client.post("/api/v1/highlights/upload", json=payload)
+        response = await plugin_client.post("/api/v1/highlights/upload", json=payload)
 
         assert response.status_code == status.HTTP_200_OK
         data = response.json()
@@ -144,7 +147,10 @@ class TestHighlightsUpload:
             assert highlight.chapter_id is None
 
     async def test_upload_highlights_with_xpoints(
-        self, client: AsyncClient, db_session: AsyncSession, create_book_via_api: CreateBookFunc
+        self,
+        plugin_client: AsyncClient,
+        db_session: AsyncSession,
+        create_book_via_api: CreateBookFunc,
     ) -> None:
         """Test uploading highlights with start_xpoint and end_xpoint fields."""
         # Create the book
@@ -177,7 +183,7 @@ class TestHighlightsUpload:
             ],
         }
 
-        response = await client.post("/api/v1/highlights/upload", json=payload)
+        response = await plugin_client.post("/api/v1/highlights/upload", json=payload)
 
         assert response.status_code == status.HTTP_200_OK
         data = response.json()
@@ -207,7 +213,10 @@ class TestHighlightsUpload:
         assert highlights[1].end_xpoint is None
 
     async def test_upload_keeps_device_datetime_and_note(
-        self, client: AsyncClient, db_session: AsyncSession, create_book_via_api: CreateBookFunc
+        self,
+        plugin_client: AsyncClient,
+        db_session: AsyncSession,
+        create_book_via_api: CreateBookFunc,
     ) -> None:
         """The e-reader's own datetime and note are stored, not replaced by server values."""
         await create_book_via_api(
@@ -234,7 +243,7 @@ class TestHighlightsUpload:
             ],
         }
 
-        response = await client.post("/api/v1/highlights/upload", json=payload)
+        response = await plugin_client.post("/api/v1/highlights/upload", json=payload)
         assert response.status_code == status.HTTP_200_OK
         assert response.json()["highlights_created"] == 2
 
@@ -249,7 +258,10 @@ class TestHighlightsUpload:
         assert [h.origin_device_id for h in highlights] == ["Kobo Clara", "Kobo Clara"]
 
     async def test_upload_without_device_id_stores_none(
-        self, client: AsyncClient, db_session: AsyncSession, create_book_via_api: CreateBookFunc
+        self,
+        plugin_client: AsyncClient,
+        db_session: AsyncSession,
+        create_book_via_api: CreateBookFunc,
     ) -> None:
         """Older plugins send no device_id; the highlight simply has no origin."""
         await create_book_via_api(
@@ -260,7 +272,7 @@ class TestHighlightsUpload:
             }
         )
 
-        response = await client.post(
+        response = await plugin_client.post(
             "/api/v1/highlights/upload",
             json={
                 "client_book_id": "test-client-book-no-device",
@@ -278,13 +290,16 @@ class TestHighlightsUpload:
         assert result.scalar_one().origin_device_id is None
 
     async def test_reupload_applies_a_newer_note_edit(
-        self, client: AsyncClient, db_session: AsyncSession, create_book_via_api: CreateBookFunc
+        self,
+        plugin_client: AsyncClient,
+        db_session: AsyncSession,
+        create_book_via_api: CreateBookFunc,
     ) -> None:
         """The highlight itself is still skipped, but a later device edit lands."""
         highlight = {"text": "Same passage", "datetime": "2019-06-01 08:15:30"}
 
         stored = await resync_edited_highlight(
-            client,
+            plugin_client,
             db_session,
             create_book_via_api,
             "test-client-book-note-rewrite",
@@ -296,13 +311,16 @@ class TestHighlightsUpload:
         assert stored.koreader_updated_at == "2019-06-02 09:00:00"
 
     async def test_reupload_ignores_an_older_note_edit(
-        self, client: AsyncClient, db_session: AsyncSession, create_book_via_api: CreateBookFunc
+        self,
+        plugin_client: AsyncClient,
+        db_session: AsyncSession,
+        create_book_via_api: CreateBookFunc,
     ) -> None:
         """A device syncing its stale copy must not undo a newer edit from elsewhere."""
         highlight = {"text": "Passage edited elsewhere", "datetime": "2019-06-01 08:15:30"}
 
         stored = await resync_edited_highlight(
-            client,
+            plugin_client,
             db_session,
             create_book_via_api,
             "test-client-book-note-stale",
@@ -314,7 +332,10 @@ class TestHighlightsUpload:
         assert stored.koreader_updated_at == "2019-06-05 10:00:00"
 
     async def test_first_edit_is_accepted_even_when_older_than_the_stored_datetime(
-        self, client: AsyncClient, db_session: AsyncSession, create_book_via_api: CreateBookFunc
+        self,
+        plugin_client: AsyncClient,
+        db_session: AsyncSession,
+        create_book_via_api: CreateBookFunc,
     ) -> None:
         """A row that never received a device edit has nothing to protect.
 
@@ -322,7 +343,7 @@ class TestHighlightsUpload:
         a note written on the device before that upload would never beat.
         """
         stored = await resync_edited_highlight(
-            client,
+            plugin_client,
             db_session,
             create_book_via_api,
             "test-client-book-first-edit",
@@ -339,7 +360,10 @@ class TestHighlightsUpload:
         assert stored.koreader_updated_at == "2025-06-01 09:00:00"
 
     async def test_reupload_with_the_same_edit_time_keeps_the_stored_note(
-        self, client: AsyncClient, db_session: AsyncSession, create_book_via_api: CreateBookFunc
+        self,
+        plugin_client: AsyncClient,
+        db_session: AsyncSession,
+        create_book_via_api: CreateBookFunc,
     ) -> None:
         """Equal timestamps are not newer, so the server's copy stands."""
         highlight = {
@@ -349,7 +373,7 @@ class TestHighlightsUpload:
         }
 
         stored = await resync_edited_highlight(
-            client,
+            plugin_client,
             db_session,
             create_book_via_api,
             "test-client-book-note-tie",
@@ -360,11 +384,14 @@ class TestHighlightsUpload:
         assert stored.koreader_note == "note on the server"
 
     async def test_reupload_without_an_edit_time_compares_creation_datetimes(
-        self, client: AsyncClient, db_session: AsyncSession, create_book_via_api: CreateBookFunc
+        self,
+        plugin_client: AsyncClient,
+        db_session: AsyncSession,
+        create_book_via_api: CreateBookFunc,
     ) -> None:
         """A highlight never edited on the device carries only its creation time."""
         stored = await resync_edited_highlight(
-            client,
+            plugin_client,
             db_session,
             create_book_via_api,
             "test-client-book-note-no-edit-time",
@@ -384,13 +411,16 @@ class TestHighlightsUpload:
         assert stored.koreader_updated_at == "2019-06-02 08:15:30"
 
     async def test_reupload_applies_a_newer_style_change(
-        self, client: AsyncClient, db_session: AsyncSession, create_book_via_api: CreateBookFunc
+        self,
+        plugin_client: AsyncClient,
+        db_session: AsyncSession,
+        create_book_via_api: CreateBookFunc,
     ) -> None:
         """Recolouring a highlight on the device moves it to the new style."""
         highlight = {"text": "Passage recoloured", "datetime": "2019-06-01 08:15:30"}
 
         stored = await resync_edited_highlight(
-            client,
+            plugin_client,
             db_session,
             create_book_via_api,
             "test-client-book-style-change",
@@ -411,13 +441,16 @@ class TestHighlightsUpload:
         assert style.device_style == "underscore"
 
     async def test_reupload_without_note_clears_stored_note(
-        self, client: AsyncClient, db_session: AsyncSession, create_book_via_api: CreateBookFunc
+        self,
+        plugin_client: AsyncClient,
+        db_session: AsyncSession,
+        create_book_via_api: CreateBookFunc,
     ) -> None:
         """Deleting the note on the device clears it on the server too."""
         highlight = {"text": "Passage once annotated", "datetime": "2019-06-01 08:15:30"}
 
         stored = await resync_edited_highlight(
-            client,
+            plugin_client,
             db_session,
             create_book_via_api,
             "test-client-book-note-clearing",
@@ -428,7 +461,10 @@ class TestHighlightsUpload:
         assert stored.koreader_note is None
 
     async def test_reupload_leaves_soft_deleted_duplicate_alone(
-        self, client: AsyncClient, db_session: AsyncSession, create_book_via_api: CreateBookFunc
+        self,
+        plugin_client: AsyncClient,
+        db_session: AsyncSession,
+        create_book_via_api: CreateBookFunc,
     ) -> None:
         """A deleted highlight stays deleted and keeps its note; it is not revived."""
         book = await create_book_via_api(
@@ -441,14 +477,14 @@ class TestHighlightsUpload:
         highlight = {"text": "Deleted passage", "datetime": "2019-06-01 08:15:30"}
 
         await upload_then_delete_highlight(
-            client,
+            plugin_client,
             db_session,
             "test-client-book-note-deleted",
             book.book_id,
             {**highlight, "note": "note on a deleted highlight"},
         )
 
-        second = await client.post(
+        second = await plugin_client.post(
             "/api/v1/highlights/upload",
             json={
                 "client_book_id": "test-client-book-note-deleted",
@@ -472,7 +508,10 @@ class TestHighlightsUpload:
         assert stored.koreader_note == "note on a deleted highlight"
 
     async def test_reupload_fills_missing_xpoints(
-        self, client: AsyncClient, db_session: AsyncSession, create_book_via_api: CreateBookFunc
+        self,
+        plugin_client: AsyncClient,
+        db_session: AsyncSession,
+        create_book_via_api: CreateBookFunc,
     ) -> None:
         """A highlight stored before the device sent xpoints gets them from a re-upload."""
         await create_book_via_api(
@@ -484,7 +523,7 @@ class TestHighlightsUpload:
         )
         highlight = {"text": "Passage without xpoints", "datetime": "2019-06-01 08:15:30"}
 
-        first = await client.post(
+        first = await plugin_client.post(
             "/api/v1/highlights/upload",
             json={
                 "client_book_id": "test-client-book-xpoint-backfill",
@@ -493,7 +532,7 @@ class TestHighlightsUpload:
         )
         assert first.json()["highlights_created"] == 1
 
-        second = await client.post(
+        second = await plugin_client.post(
             "/api/v1/highlights/upload",
             json={
                 "client_book_id": "test-client-book-xpoint-backfill",
@@ -517,7 +556,10 @@ class TestHighlightsUpload:
         assert stored.end_xpoint == "/body/DocFragment[2]/body/p[1]/text().13"
 
     async def test_reupload_does_not_overwrite_existing_xpoints(
-        self, client: AsyncClient, db_session: AsyncSession, create_book_via_api: CreateBookFunc
+        self,
+        plugin_client: AsyncClient,
+        db_session: AsyncSession,
+        create_book_via_api: CreateBookFunc,
     ) -> None:
         """Xpoints already stored stay put; only a missing pair is filled in."""
         await create_book_via_api(
@@ -529,7 +571,7 @@ class TestHighlightsUpload:
         )
         highlight = {"text": "Passage anchored once", "datetime": "2019-06-01 08:15:30"}
 
-        first = await client.post(
+        first = await plugin_client.post(
             "/api/v1/highlights/upload",
             json={
                 "client_book_id": "test-client-book-xpoint-keeping",
@@ -544,7 +586,7 @@ class TestHighlightsUpload:
         )
         assert first.json()["highlights_created"] == 1
 
-        second = await client.post(
+        second = await plugin_client.post(
             "/api/v1/highlights/upload",
             json={
                 "client_book_id": "test-client-book-xpoint-keeping",
@@ -568,7 +610,7 @@ class TestHighlightsUpload:
 
     async def test_reupload_with_xpoints_resolves_position_when_epub_present(
         self,
-        client: AsyncClient,
+        plugin_client: AsyncClient,
         db_session: AsyncSession,
         create_book_via_api: CreateBookFunc,
         epub_bytes: bytes,
@@ -582,14 +624,14 @@ class TestHighlightsUpload:
                 "author": "Test Author",
             }
         )
-        epub_upload = await client.post(
+        epub_upload = await plugin_client.post(
             "/api/v1/ereader/books/test-client-book-position-backfill/epub",
             files={"epub": ("book.epub", epub_bytes, "application/epub+zip")},
         )
         assert epub_upload.status_code == status.HTTP_200_OK
 
         highlight = {"text": "Some content.", "datetime": "2019-06-01 08:15:30"}
-        first = await client.post(
+        first = await plugin_client.post(
             "/api/v1/highlights/upload",
             json={
                 "client_book_id": "test-client-book-position-backfill",
@@ -601,7 +643,7 @@ class TestHighlightsUpload:
         result = await db_session.execute(select(models.Highlight).filter_by(text="Some content."))
         assert result.scalar_one().position is None
 
-        second = await client.post(
+        second = await plugin_client.post(
             "/api/v1/highlights/upload",
             json={
                 "client_book_id": "test-client-book-position-backfill",
@@ -621,7 +663,10 @@ class TestHighlightsUpload:
         assert result.scalar_one().position is not None
 
     async def test_reupload_leaves_soft_deleted_duplicate_unplaced(
-        self, client: AsyncClient, db_session: AsyncSession, create_book_via_api: CreateBookFunc
+        self,
+        plugin_client: AsyncClient,
+        db_session: AsyncSession,
+        create_book_via_api: CreateBookFunc,
     ) -> None:
         """A deleted highlight is not given xpoints: it must stay out of the book."""
         book = await create_book_via_api(
@@ -634,10 +679,10 @@ class TestHighlightsUpload:
         highlight = {"text": "Deleted unplaced passage", "datetime": "2019-06-01 08:15:30"}
 
         await upload_then_delete_highlight(
-            client, db_session, "test-client-book-xpoint-deleted", book.book_id, highlight
+            plugin_client, db_session, "test-client-book-xpoint-deleted", book.book_id, highlight
         )
 
-        second = await client.post(
+        second = await plugin_client.post(
             "/api/v1/highlights/upload",
             json={
                 "client_book_id": "test-client-book-xpoint-deleted",
@@ -661,7 +706,10 @@ class TestHighlightsUpload:
         assert stored.end_xpoint is None
 
     async def test_upload_duplicate_highlights(
-        self, client: AsyncClient, db_session: AsyncSession, create_book_via_api: CreateBookFunc
+        self,
+        plugin_client: AsyncClient,
+        db_session: AsyncSession,
+        create_book_via_api: CreateBookFunc,
     ) -> None:
         """Test that duplicate highlights are properly skipped."""
         # Create the book
@@ -685,14 +733,14 @@ class TestHighlightsUpload:
         }
 
         # First upload
-        response1 = await client.post("/api/v1/highlights/upload", json=payload)
+        response1 = await plugin_client.post("/api/v1/highlights/upload", json=payload)
         assert response1.status_code == status.HTTP_200_OK
         data1 = response1.json()
         assert data1["highlights_created"] == 1
         assert data1["highlights_skipped"] == 0
 
         # Second upload (should skip duplicate)
-        response2 = await client.post("/api/v1/highlights/upload", json=payload)
+        response2 = await plugin_client.post("/api/v1/highlights/upload", json=payload)
         assert response2.status_code == status.HTTP_200_OK
         data2 = response2.json()
         assert data2["highlights_created"] == 0
@@ -709,7 +757,7 @@ class TestHighlightsUpload:
         assert len(highlights) == 1
 
     async def test_upload_partial_duplicates(
-        self, client: AsyncClient, create_book_via_api: CreateBookFunc
+        self, plugin_client: AsyncClient, create_book_via_api: CreateBookFunc
     ) -> None:
         """Test uploading mix of new and duplicate highlights."""
         # Create the book
@@ -736,7 +784,7 @@ class TestHighlightsUpload:
             ],
         }
 
-        response1 = await client.post("/api/v1/highlights/upload", json=payload1)
+        response1 = await plugin_client.post("/api/v1/highlights/upload", json=payload1)
         assert response1.status_code == status.HTTP_200_OK
         assert response1.json()["highlights_created"] == 2
 
@@ -755,14 +803,14 @@ class TestHighlightsUpload:
             ],
         }
 
-        response2 = await client.post("/api/v1/highlights/upload", json=payload2)
+        response2 = await plugin_client.post("/api/v1/highlights/upload", json=payload2)
         assert response2.status_code == status.HTTP_200_OK
         data2 = response2.json()
         assert data2["highlights_created"] == 1
         assert data2["highlights_skipped"] == 1
 
     async def test_upload_empty_highlights_list(
-        self, client: AsyncClient, create_book_via_api: CreateBookFunc
+        self, plugin_client: AsyncClient, create_book_via_api: CreateBookFunc
     ) -> None:
         """Test uploading with empty highlights list."""
         # Create the book
@@ -779,7 +827,7 @@ class TestHighlightsUpload:
             "highlights": [],
         }
 
-        response = await client.post("/api/v1/highlights/upload", json=payload)
+        response = await plugin_client.post("/api/v1/highlights/upload", json=payload)
 
         assert response.status_code == status.HTTP_200_OK
         data = response.json()
@@ -788,7 +836,7 @@ class TestHighlightsUpload:
         assert data["highlights_skipped"] == 0
 
     async def test_upload_same_text_different_datetime_is_duplicate(
-        self, client: AsyncClient, create_book_via_api: CreateBookFunc
+        self, plugin_client: AsyncClient, create_book_via_api: CreateBookFunc
     ) -> None:
         """Test that same text at different times is considered duplicate (hash-based dedup).
 
@@ -818,7 +866,7 @@ class TestHighlightsUpload:
             ],
         }
 
-        response = await client.post("/api/v1/highlights/upload", json=payload)
+        response = await plugin_client.post("/api/v1/highlights/upload", json=payload)
 
         assert response.status_code == status.HTTP_200_OK
         data = response.json()
@@ -827,7 +875,7 @@ class TestHighlightsUpload:
         assert data["highlights_skipped"] == 1
 
     async def test_upload_same_text_different_book_not_duplicate(
-        self, client: AsyncClient, create_book_via_api: CreateBookFunc
+        self, plugin_client: AsyncClient, create_book_via_api: CreateBookFunc
     ) -> None:
         """Test that same text in different books is treated as duplicate.
 
@@ -855,7 +903,7 @@ class TestHighlightsUpload:
             ],
         }
 
-        response1 = await client.post("/api/v1/highlights/upload", json=payload1)
+        response1 = await plugin_client.post("/api/v1/highlights/upload", json=payload1)
         assert response1.status_code == status.HTTP_200_OK
         assert response1.json()["highlights_created"] == 1
 
@@ -879,14 +927,14 @@ class TestHighlightsUpload:
             ],
         }
 
-        response2 = await client.post("/api/v1/highlights/upload", json=payload2)
+        response2 = await plugin_client.post("/api/v1/highlights/upload", json=payload2)
         assert response2.status_code == status.HTTP_200_OK
         # Same text in different book = NOT a duplicate (scoped by book)
         # Allows highlighting the same passage in multiple books
         assert response2.json()["highlights_created"] == 1
         assert response2.json()["highlights_skipped"] == 0
 
-    async def test_upload_invalid_payload_missing_book(self, client: AsyncClient) -> None:
+    async def test_upload_invalid_payload_missing_book(self, plugin_client: AsyncClient) -> None:
         """Test upload with missing book data."""
         payload = {
             "highlights": [
@@ -897,12 +945,12 @@ class TestHighlightsUpload:
             ],
         }
 
-        response = await client.post("/api/v1/highlights/upload", json=payload)
+        response = await plugin_client.post("/api/v1/highlights/upload", json=payload)
 
         assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
     async def test_upload_invalid_payload_missing_required_fields(
-        self, client: AsyncClient
+        self, plugin_client: AsyncClient
     ) -> None:
         """Test upload with missing required fields."""
         payload = {
@@ -915,7 +963,7 @@ class TestHighlightsUpload:
             ],
         }
 
-        response = await client.post("/api/v1/highlights/upload", json=payload)
+        response = await plugin_client.post("/api/v1/highlights/upload", json=payload)
 
         assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
@@ -1041,7 +1089,7 @@ PUSHED_HIGHLIGHTS: list[dict[str, Any]] = [
 
 
 async def sync(
-    client: AsyncClient,
+    plugin_client: AsyncClient,
     removed_ids: list[int] | None = None,
     highlights: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
@@ -1053,21 +1101,21 @@ async def sync(
     if removed_ids is not None:
         payload["removed_ids"] = removed_ids
 
-    response = await client.post("/api/v1/highlights/upload", json=payload)
+    response = await plugin_client.post("/api/v1/highlights/upload", json=payload)
     assert response.status_code == status.HTTP_200_OK, response.text
     return response.json()
 
 
-async def pulled_ids(client: AsyncClient) -> dict[str, int]:
+async def pulled_ids(plugin_client: AsyncClient) -> dict[str, int]:
     """What the e-reader gets back on its next pull, each text mapped to its ID."""
-    response = await client.get(f"/api/v1/ereader/books/{CLIENT_BOOK_ID}/highlights")
+    response = await plugin_client.get(f"/api/v1/ereader/books/{CLIENT_BOOK_ID}/highlights")
     assert response.status_code == status.HTTP_200_OK
     return {item["text"]: item["id"] for item in response.json()["items"]}
 
 
-async def pulled_texts(client: AsyncClient) -> list[str]:
+async def pulled_texts(plugin_client: AsyncClient) -> list[str]:
     """The texts the e-reader gets back on its next pull."""
-    response = await client.get(f"/api/v1/ereader/books/{CLIENT_BOOK_ID}/highlights")
+    response = await plugin_client.get(f"/api/v1/ereader/books/{CLIENT_BOOK_ID}/highlights")
     assert response.status_code == status.HTTP_200_OK
     return [item["text"] for item in response.json()["items"]]
 
@@ -1112,7 +1160,7 @@ async def another_readers_copy(
 
 @pytest.fixture
 async def synced_book(
-    client: AsyncClient, db_session: AsyncSession, test_user: models.User
+    plugin_client: AsyncClient, db_session: AsyncSession, test_user: models.User
 ) -> tuple[models.Book, dict[str, int]]:
     """A book whose two highlights have been uploaded; maps each text to its ID."""
     book = await create_test_book(
@@ -1123,94 +1171,94 @@ async def synced_book(
     )
     await create_test_chapter(db_session, book, "Chapter One", chapter_number=1)
 
-    assert (await sync(client))["highlights_created"] == 2
+    assert (await sync(plugin_client))["highlights_created"] == 2
 
-    return book, await pulled_ids(client)
+    return book, await pulled_ids(plugin_client)
 
 
 class TestHighlightUploadRemovals:
     """A highlight deleted on an e-reader rides out in the next upload request."""
 
     async def test_removed_highlight_leaves_the_pull_but_stays_on_the_web(
-        self, client: AsyncClient, synced_book: tuple[models.Book, dict[str, int]]
+        self, plugin_client: AsyncClient, synced_book: tuple[models.Book, dict[str, int]]
     ) -> None:
         book, ids = synced_book
 
         # The device pushes its whole set again, so the removed highlight's own
         # text arrives alongside the removal. Removals run first, so the push is
         # skipped as the duplicate it is instead of resurrecting the highlight.
-        result = await sync(client, removed_ids=[ids["Deleted on the device"]])
+        result = await sync(plugin_client, removed_ids=[ids["Deleted on the device"]])
 
         assert result["highlights_removed"] == 1
         assert result["highlights_created"] == 0
         assert result["highlights_skipped"] == 2
-        assert await pulled_texts(client) == ["Kept on the device"]
+        assert await pulled_texts(plugin_client) == ["Kept on the device"]
 
-        details = await client.get(f"/api/v1/books/{book.id}")
+        details = await plugin_client.get(f"/api/v1/books/{book.id}")
         assert details.status_code == status.HTTP_200_OK
         on_the_web = [h["text"] for c in details.json()["chapters"] for h in c["highlights"]]
         assert sorted(on_the_web) == ["Deleted on the device", "Kept on the device"]
 
     async def test_flashcards_and_bookmarks_of_a_removed_highlight_survive(
-        self, client: AsyncClient, synced_book: tuple[models.Book, dict[str, int]]
+        self, plugin_client: AsyncClient, synced_book: tuple[models.Book, dict[str, int]]
     ) -> None:
         """The reason a device deletion cannot become a real delete."""
         book, ids = synced_book
         removed_id = ids["Deleted on the device"]
 
-        flashcard = await client.post(
+        flashcard = await plugin_client.post(
             f"/api/v1/highlights/{removed_id}/flashcards",
             json={"question": "Why keep it?", "answer": "The flashcard hangs off it"},
         )
         assert flashcard.status_code == status.HTTP_201_CREATED
-        bookmark = await client.post(
+        bookmark = await plugin_client.post(
             f"/api/v1/books/{book.id}/bookmarks", json={"highlight_id": removed_id}
         )
         assert bookmark.status_code == status.HTTP_201_CREATED
 
-        assert (await sync(client, removed_ids=[removed_id]))["highlights_removed"] == 1
+        assert (await sync(plugin_client, removed_ids=[removed_id]))["highlights_removed"] == 1
 
-        details = await client.get(f"/api/v1/books/{book.id}")
+        details = await plugin_client.get(f"/api/v1/books/{book.id}")
         highlights = {h["id"]: h for c in details.json()["chapters"] for h in c["highlights"]}
         assert [f["question"] for f in highlights[removed_id]["flashcards"]] == ["Why keep it?"]
 
-        bookmarks = await client.get(f"/api/v1/books/{book.id}/bookmarks")
+        bookmarks = await plugin_client.get(f"/api/v1/books/{book.id}/bookmarks")
         assert [b["highlight_id"] for b in bookmarks.json()["items"]] == [removed_id]
 
     async def test_resending_the_same_removal_changes_nothing(
-        self, client: AsyncClient, synced_book: tuple[models.Book, dict[str, int]]
+        self, plugin_client: AsyncClient, synced_book: tuple[models.Book, dict[str, int]]
     ) -> None:
         """A sync interrupted after the removal is retried whole by the plugin."""
         _, ids = synced_book
         removed_ids = [ids["Deleted on the device"]]
-        assert (await sync(client, removed_ids=removed_ids))["highlights_removed"] == 1
+        assert (await sync(plugin_client, removed_ids=removed_ids))["highlights_removed"] == 1
 
-        repeat = await sync(client, removed_ids=removed_ids)
+        repeat = await sync(plugin_client, removed_ids=removed_ids)
 
         assert repeat["highlights_removed"] == 0
         assert repeat["highlights_created"] == 0
-        assert await pulled_texts(client) == ["Kept on the device"]
+        assert await pulled_texts(plugin_client) == ["Kept on the device"]
 
     async def test_unknown_and_soft_deleted_ids_are_ignored(
-        self, client: AsyncClient, synced_book: tuple[models.Book, dict[str, int]]
+        self, plugin_client: AsyncClient, synced_book: tuple[models.Book, dict[str, int]]
     ) -> None:
         book, ids = synced_book
         deleted_id = ids["Deleted on the device"]
-        deletion = await client.request(
+        deletion = await plugin_client.request(
             "DELETE",
             f"/api/v1/books/{book.id}/highlight",
             json={"highlight_ids": [deleted_id]},
         )
         assert deletion.json()["deleted_count"] == 1
 
-        result = await sync(client, removed_ids=[deleted_id, 999999])
+        result = await sync(plugin_client, removed_ids=[deleted_id, 999999])
 
         assert result["highlights_removed"] == 0
-        assert await pulled_texts(client) == ["Kept on the device"]
+        assert await pulled_texts(plugin_client) == ["Kept on the device"]
 
     async def test_another_users_highlight_is_left_alone(
         self,
-        client: AsyncClient,
+        plugin_client: AsyncClient,
         db_session: AsyncSession,
         synced_book: tuple[models.Book, dict[str, int]],
     ) -> None:
@@ -1219,23 +1267,23 @@ class TestHighlightUploadRemovals:
             db_session, "other-removals@test.com", "Theirs", "2024-01-15 14:00:00"
         )
 
-        result = await sync(client, removed_ids=[theirs.id])
+        result = await sync(plugin_client, removed_ids=[theirs.id])
 
         assert result["highlights_removed"] == 0
         await db_session.refresh(theirs)
         assert theirs.removed_from_devices_at is None
 
     async def test_upload_without_removed_ids_removes_nothing(
-        self, client: AsyncClient, synced_book: tuple[models.Book, dict[str, int]]
+        self, plugin_client: AsyncClient, synced_book: tuple[models.Book, dict[str, int]]
     ) -> None:
         """A legacy plugin omits the field and gets today's behaviour."""
-        result = await sync(client)
+        result = await sync(plugin_client)
 
         assert result["highlights_removed"] == 0
-        assert await pulled_texts(client) == ["Kept on the device", "Deleted on the device"]
+        assert await pulled_texts(plugin_client) == ["Kept on the device", "Deleted on the device"]
 
     async def test_a_withheld_highlight_ignores_later_device_edits(
-        self, client: AsyncClient, db_session: AsyncSession, test_user: models.User
+        self, plugin_client: AsyncClient, db_session: AsyncSession, test_user: models.User
     ) -> None:
         """A device that still holds the highlight cannot rewrite the web copy."""
         await create_test_book(
@@ -1253,7 +1301,7 @@ class TestHighlightUploadRemovals:
                 "note": "keep this",
             }
         ]
-        first = await client.post(
+        first = await plugin_client.post(
             "/api/v1/highlights/upload",
             json={"client_book_id": "client-edited", "highlights": noted},
         )
@@ -1265,7 +1313,7 @@ class TestHighlightUploadRemovals:
         # The same batch removes the highlight and pushes a newer, note-less edit
         # of it. Without the removal the edit would win and clear the note.
         edited = [{**noted[0], "datetime_updated": "2026-01-01 00:00:00", "note": ""}]
-        second = await client.post(
+        second = await plugin_client.post(
             "/api/v1/highlights/upload",
             json={
                 "client_book_id": "client-edited",
@@ -1280,83 +1328,85 @@ class TestHighlightUploadRemovals:
         assert stored.koreader_updated_at == "2025-01-01 00:00:00"
 
     async def test_a_negative_removed_id_is_rejected(
-        self, client: AsyncClient, synced_book: tuple[models.Book, dict[str, int]]
+        self, plugin_client: AsyncClient, synced_book: tuple[models.Book, dict[str, int]]
     ) -> None:
-        """A malformed ID is a client error, not an unhandled domain exception."""
-        response = await client.post(
+        """A malformed ID is a plugin_client error, not an unhandled domain exception."""
+        response = await plugin_client.post(
             "/api/v1/highlights/upload",
             json={"client_book_id": CLIENT_BOOK_ID, "highlights": [], "removed_ids": [-1]},
         )
 
         assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
-        assert await pulled_texts(client) == ["Kept on the device", "Deleted on the device"]
+        assert await pulled_texts(plugin_client) == ["Kept on the device", "Deleted on the device"]
 
 
 class TestHighlightUploadRehighlights:
     """A passage marked again on the device brings its highlight back."""
 
-    async def _remove_from_devices(self, client: AsyncClient, highlight_id: int) -> None:
-        assert (await sync(client, removed_ids=[highlight_id]))["highlights_removed"] == 1
-        assert await pulled_texts(client) == ["Kept on the device"]
+    async def _remove_from_devices(self, plugin_client: AsyncClient, highlight_id: int) -> None:
+        assert (await sync(plugin_client, removed_ids=[highlight_id]))["highlights_removed"] == 1
+        assert await pulled_texts(plugin_client) == ["Kept on the device"]
 
-    async def _delete_on_the_web(self, client: AsyncClient, book_id: int, ids: list[int]) -> None:
-        deletion = await client.request(
+    async def _delete_on_the_web(
+        self, plugin_client: AsyncClient, book_id: int, ids: list[int]
+    ) -> None:
+        deletion = await plugin_client.request(
             "DELETE", f"/api/v1/books/{book_id}/highlight", json={"highlight_ids": ids}
         )
         assert deletion.status_code == status.HTTP_200_OK
         assert deletion.json()["deleted_count"] == len(ids)
 
     async def test_a_flagged_rehighlight_returns_a_removed_highlight_to_devices(
-        self, client: AsyncClient, synced_book: tuple[models.Book, dict[str, int]]
+        self, plugin_client: AsyncClient, synced_book: tuple[models.Book, dict[str, int]]
     ) -> None:
         _, ids = synced_book
-        await self._remove_from_devices(client, ids["Deleted on the device"])
+        await self._remove_from_devices(plugin_client, ids["Deleted on the device"])
 
         result = await sync(
-            client,
+            plugin_client,
             highlights=[PUSHED_HIGHLIGHTS[0], pushed_as_new("Deleted on the device")],
         )
 
         assert result["highlights_created"] == 0
         assert result["highlights_skipped"] == 2
         # The same row is back, not a second one beside it.
-        assert await pulled_ids(client) == ids
+        assert await pulled_ids(plugin_client) == ids
 
     async def test_a_flagged_rehighlight_restores_a_web_deleted_highlight(
-        self, client: AsyncClient, synced_book: tuple[models.Book, dict[str, int]]
+        self, plugin_client: AsyncClient, synced_book: tuple[models.Book, dict[str, int]]
     ) -> None:
         """What the web delete cascaded away stays gone; the highlight itself returns."""
         book, ids = synced_book
         deleted_id = ids["Deleted on the device"]
-        flashcard = await client.post(
+        flashcard = await plugin_client.post(
             f"/api/v1/highlights/{deleted_id}/flashcards",
             json={"question": "Does it come back?", "answer": "The highlight does"},
         )
         assert flashcard.status_code == status.HTTP_201_CREATED
-        await self._delete_on_the_web(client, book.id, [deleted_id])
+        await self._delete_on_the_web(plugin_client, book.id, [deleted_id])
 
-        result = await sync(client, highlights=[pushed_as_new("Deleted on the device")])
+        result = await sync(plugin_client, highlights=[pushed_as_new("Deleted on the device")])
 
         assert result["highlights_created"] == 0
-        assert await pulled_ids(client) == ids
+        assert await pulled_ids(plugin_client) == ids
 
-        details = await client.get(f"/api/v1/books/{book.id}")
+        details = await plugin_client.get(f"/api/v1/books/{book.id}")
         on_the_web = {h["id"]: h for c in details.json()["chapters"] for h in c["highlights"]}
         assert deleted_id in on_the_web
         assert on_the_web[deleted_id]["flashcards"] == []
 
     async def test_a_flagged_rehighlight_takes_the_note_written_with_it(
         self,
-        client: AsyncClient,
+        plugin_client: AsyncClient,
         db_session: AsyncSession,
         synced_book: tuple[models.Book, dict[str, int]],
     ) -> None:
         """Reviving happens before reconciliation, so the push's edits land on the row."""
         _, ids = synced_book
-        await self._remove_from_devices(client, ids["Deleted on the device"])
+        await self._remove_from_devices(plugin_client, ids["Deleted on the device"])
 
         await sync(
-            client,
+            plugin_client,
             highlights=[
                 pushed_as_new(
                     "Deleted on the device",
@@ -1376,34 +1426,34 @@ class TestHighlightUploadRehighlights:
         assert stored.removed_from_devices_at is None
 
     async def test_an_unflagged_push_leaves_a_removed_highlight_removed(
-        self, client: AsyncClient, synced_book: tuple[models.Book, dict[str, int]]
+        self, plugin_client: AsyncClient, synced_book: tuple[models.Book, dict[str, int]]
     ) -> None:
         """A device that never learned the flag keeps today's behaviour."""
         _, ids = synced_book
-        await self._remove_from_devices(client, ids["Deleted on the device"])
+        await self._remove_from_devices(plugin_client, ids["Deleted on the device"])
 
-        result = await sync(client)
+        result = await sync(plugin_client)
 
         assert result["highlights_created"] == 0
-        assert await pulled_texts(client) == ["Kept on the device"]
+        assert await pulled_texts(plugin_client) == ["Kept on the device"]
 
     async def test_an_unflagged_push_leaves_a_web_deleted_highlight_deleted(
-        self, client: AsyncClient, synced_book: tuple[models.Book, dict[str, int]]
+        self, plugin_client: AsyncClient, synced_book: tuple[models.Book, dict[str, int]]
     ) -> None:
         book, ids = synced_book
-        await self._delete_on_the_web(client, book.id, [ids["Deleted on the device"]])
+        await self._delete_on_the_web(plugin_client, book.id, [ids["Deleted on the device"]])
 
-        result = await sync(client)
+        result = await sync(plugin_client)
 
         assert result["highlights_created"] == 0
-        assert await pulled_texts(client) == ["Kept on the device"]
-        details = await client.get(f"/api/v1/books/{book.id}")
+        assert await pulled_texts(plugin_client) == ["Kept on the device"]
+        details = await plugin_client.get(f"/api/v1/books/{book.id}")
         on_the_web = [h["text"] for c in details.json()["chapters"] for h in c["highlights"]]
         assert on_the_web == ["Kept on the device"]
 
     async def test_a_flagged_push_of_a_live_highlight_only_merges_its_edits(
         self,
-        client: AsyncClient,
+        plugin_client: AsyncClient,
         db_session: AsyncSession,
         synced_book: tuple[models.Book, dict[str, int]],
     ) -> None:
@@ -1411,7 +1461,7 @@ class TestHighlightUploadRehighlights:
         _, ids = synced_book
 
         result = await sync(
-            client,
+            plugin_client,
             highlights=[
                 pushed_as_new(
                     "Kept on the device", note="Still here", datetime_updated="2026-01-01 00:00:00"
@@ -1422,7 +1472,7 @@ class TestHighlightUploadRehighlights:
 
         assert result["highlights_created"] == 0
         assert result["highlights_skipped"] == 2
-        assert await pulled_ids(client) == ids
+        assert await pulled_ids(plugin_client) == ids
 
         stored = (
             await db_session.execute(
@@ -1433,23 +1483,23 @@ class TestHighlightUploadRehighlights:
         assert stored.koreader_note == "Still here"
 
     async def test_a_flagged_rehighlight_outlives_a_removal_in_the_same_request(
-        self, client: AsyncClient, synced_book: tuple[models.Book, dict[str, int]]
+        self, plugin_client: AsyncClient, synced_book: tuple[models.Book, dict[str, int]]
     ) -> None:
         """Removals run first, so re-marking the passage wins -- deterministically."""
         _, ids = synced_book
 
         result = await sync(
-            client,
+            plugin_client,
             removed_ids=[ids["Deleted on the device"]],
             highlights=[PUSHED_HIGHLIGHTS[0], pushed_as_new("Deleted on the device")],
         )
 
         assert result["highlights_removed"] == 1
-        assert await pulled_ids(client) == ids
+        assert await pulled_ids(plugin_client) == ids
 
     async def test_another_users_removed_highlight_is_not_revived(
         self,
-        client: AsyncClient,
+        plugin_client: AsyncClient,
         db_session: AsyncSession,
         synced_book: tuple[models.Book, dict[str, int]],
     ) -> None:
@@ -1462,7 +1512,7 @@ class TestHighlightUploadRehighlights:
             removed_from_devices_at=datetime(2024, 3, 1, tzinfo=UTC),
         )
 
-        await sync(client, highlights=[pushed_as_new("Deleted on the device")])
+        await sync(plugin_client, highlights=[pushed_as_new("Deleted on the device")])
 
         await db_session.refresh(theirs)
         assert theirs.removed_from_devices_at is not None

--- a/backend/tests/test_reading_sessions.py
+++ b/backend/tests/test_reading_sessions.py
@@ -118,10 +118,10 @@ class TestUploadReadingSessions:
     """Test suite for POST /reading_sessions/upload endpoint."""
 
     async def test_upload_single_session_success(
-        self, client: AsyncClient, db_session: AsyncSession, test_book: models.Book
+        self, plugin_client: AsyncClient, db_session: AsyncSession, test_book: models.Book
     ) -> None:
         """Test successful upload of a single reading session."""
-        response = await client.post(
+        response = await plugin_client.post(
             "/api/v1/reading_sessions/upload",
             json={
                 "client_book_id": "test-client-book-id",
@@ -156,10 +156,10 @@ class TestUploadReadingSessions:
         assert session.end_xpoint == "/body/DocFragment[1]/body/div[1]/p[50]"
 
     async def test_upload_bulk_sessions_success(
-        self, client: AsyncClient, db_session: AsyncSession, test_book: models.Book
+        self, plugin_client: AsyncClient, db_session: AsyncSession, test_book: models.Book
     ) -> None:
         """Test successful bulk upload of multiple sessions for a single book."""
-        response = await client.post(
+        response = await plugin_client.post(
             "/api/v1/reading_sessions/upload",
             json={
                 "client_book_id": "test-client-book-id",
@@ -207,7 +207,7 @@ class TestUploadReadingSessions:
         assert sessions[2].end_page == 25
 
     async def test_upload_duplicate_sessions_skipped(
-        self, client: AsyncClient, db_session: AsyncSession, test_book: models.Book
+        self, plugin_client: AsyncClient, db_session: AsyncSession, test_book: models.Book
     ) -> None:
         """Test that duplicate sessions are skipped and reported in count."""
         session_data = {
@@ -224,14 +224,14 @@ class TestUploadReadingSessions:
         }
 
         # First upload
-        response1 = await client.post("/api/v1/reading_sessions/upload", json=session_data)
+        response1 = await plugin_client.post("/api/v1/reading_sessions/upload", json=session_data)
         assert response1.status_code == status.HTTP_200_OK
         data1 = response1.json()
         assert data1["created_count"] == 1
         assert data1["skipped_duplicate_count"] == 0
 
         # Second upload (duplicate)
-        response2 = await client.post("/api/v1/reading_sessions/upload", json=session_data)
+        response2 = await plugin_client.post("/api/v1/reading_sessions/upload", json=session_data)
         assert response2.status_code == status.HTTP_200_OK
         data2 = response2.json()
         assert data2["created_count"] == 0
@@ -243,10 +243,10 @@ class TestUploadReadingSessions:
         assert len(sessions) == 1
 
     async def test_upload_same_time_different_device_allowed(
-        self, client: AsyncClient, db_session: AsyncSession, test_book: models.Book
+        self, plugin_client: AsyncClient, db_session: AsyncSession, test_book: models.Book
     ) -> None:
         """Test that same start time from different devices is allowed."""
-        response = await client.post(
+        response = await plugin_client.post(
             "/api/v1/reading_sessions/upload",
             json={
                 "client_book_id": "test-client-book-id",
@@ -279,10 +279,10 @@ class TestUploadReadingSessions:
         assert device_ids == {"device-1", "device-2"}
 
     async def test_upload_session_with_page_positions(
-        self, client: AsyncClient, db_session: AsyncSession, test_book: models.Book
+        self, plugin_client: AsyncClient, db_session: AsyncSession, test_book: models.Book
     ) -> None:
         """Test uploading a session with page positions."""
-        response = await client.post(
+        response = await plugin_client.post(
             "/api/v1/reading_sessions/upload",
             json={
                 "client_book_id": "test-client-book-id",
@@ -310,9 +310,9 @@ class TestUploadReadingSessions:
         assert session.end_xpoint is None
 
     async def test_filter_sessions_with_same_pages_for_start_and_end(
-        self, client: AsyncClient, db_session: AsyncSession, test_book: models.Book
+        self, plugin_client: AsyncClient, db_session: AsyncSession, test_book: models.Book
     ) -> None:
-        response = await client.post(
+        response = await plugin_client.post(
             "/api/v1/reading_sessions/upload",
             json={
                 "client_book_id": "test-client-book-id",
@@ -335,9 +335,9 @@ class TestUploadReadingSessions:
         assert session is None
 
     async def test_filter_sessions_with_same_xpoints_for_start_and_end(
-        self, client: AsyncClient, db_session: AsyncSession, test_book: models.Book
+        self, plugin_client: AsyncClient, db_session: AsyncSession, test_book: models.Book
     ) -> None:
-        response = await client.post(
+        response = await plugin_client.post(
             "/api/v1/reading_sessions/upload",
             json={
                 "client_book_id": "test-client-book-id",
@@ -360,9 +360,9 @@ class TestUploadReadingSessions:
         assert session is None
 
     async def test_not_filter_sessions_with_same_pages_for_start_and_end_but_different_points(
-        self, client: AsyncClient, db_session: AsyncSession, test_book: models.Book
+        self, plugin_client: AsyncClient, db_session: AsyncSession, test_book: models.Book
     ) -> None:
-        response = await client.post(
+        response = await plugin_client.post(
             "/api/v1/reading_sessions/upload",
             json={
                 "client_book_id": "test-client-book-id",
@@ -422,13 +422,13 @@ class TestUploadReadingSessions:
     )
     async def test_upload_invalid_sessions_returns_422(
         self,
-        client: AsyncClient,
+        plugin_client: AsyncClient,
         db_session: AsyncSession,
         test_book: models.Book,
         sessions: list[dict[str, object]],
     ) -> None:
         """Test that invalid session payloads return 422 and nothing is saved."""
-        response = await client.post(
+        response = await plugin_client.post(
             "/api/v1/reading_sessions/upload",
             json={"client_book_id": "test-client-book-id", "sessions": sessions},
         )

--- a/backend/tests/test_semantic_backfill.py
+++ b/backend/tests/test_semantic_backfill.py
@@ -197,6 +197,7 @@ class TestOneBackfillAtATime:
     async def test_an_upload_still_enqueues_while_a_backfill_is_running(
         self,
         client: AsyncClient,
+        plugin_client: AsyncClient,
         job_queue: AsyncMock,
         db_session: AsyncSession,
         test_book: Book,
@@ -213,7 +214,7 @@ class TestOneBackfillAtATime:
 
         with embeddings_enabled():
             backfill = await client.post("/api/v1/semantic/backfill")
-            await upload_highlights(client, "book-1", "fresh one", "fresh two")
+            await upload_highlights(plugin_client, "book-1", "fresh one", "fresh two")
 
         assert backfill.status_code == status.HTTP_202_ACCEPTED
         uploaded = {
@@ -264,13 +265,14 @@ class TestActiveBackfillEndpoint:
     async def test_ignores_a_batch_an_upload_opened(
         self,
         client: AsyncClient,
+        plugin_client: AsyncClient,
         job_queue: AsyncMock,
         create_book_via_api: CreateBookFunc,
     ) -> None:
         await create_book_via_api({"client_book_id": "book-1", "title": "Crime and Punishment"})
 
         with embeddings_enabled():
-            await upload_highlights(client, "book-1", "just uploaded")
+            await upload_highlights(plugin_client, "book-1", "just uploaded")
             response = await client.get("/api/v1/semantic/backfill/active")
 
         assert response.json() is None

--- a/backend/tests/test_semantic_live_enqueue.py
+++ b/backend/tests/test_semantic_live_enqueue.py
@@ -56,18 +56,20 @@ async def create_note(client: AsyncClient, book: Book) -> dict[str, Any]:
 
 
 async def upload_one_highlight(
-    client: AsyncClient, db_session: AsyncSession, job_queue: AsyncMock
+    plugin_client: AsyncClient, db_session: AsyncSession, job_queue: AsyncMock
 ) -> models.Highlight:
     """Upload REHIGHLIGHTED_TEXT and hand back its row, with the queue reset after."""
-    await upload_highlights(client, "book-1", REHIGHLIGHTED_TEXT)
+    await upload_highlights(plugin_client, "book-1", REHIGHLIGHTED_TEXT)
     stored = (await db_session.execute(select(models.Highlight))).scalars().one()
     job_queue.enqueue.reset_mock()
     return stored
 
 
-async def rehighlight(client: AsyncClient, removed_ids: list[int] | None = None) -> dict[str, Any]:
+async def rehighlight(
+    plugin_client: AsyncClient, removed_ids: list[int] | None = None
+) -> dict[str, Any]:
     """Push REHIGHLIGHTED_TEXT as a highlight the device made after its last pull."""
-    response = await client.post(
+    response = await plugin_client.post(
         "/api/v1/highlights/upload",
         json={
             "client_book_id": "book-1",
@@ -163,7 +165,7 @@ class TestNoteWrites:
 class TestHighlightUpload:
     async def test_enqueues_a_batch_covering_exactly_the_created_highlights(
         self,
-        client: AsyncClient,
+        plugin_client: AsyncClient,
         job_queue: AsyncMock,
         db_session: AsyncSession,
         create_book_via_api: CreateBookFunc,
@@ -171,7 +173,7 @@ class TestHighlightUpload:
         await create_book_via_api({"client_book_id": "book-1", "title": "Crime and Punishment"})
 
         with embeddings_enabled():
-            result = await upload_highlights(client, "book-1", "first idea", "second idea")
+            result = await upload_highlights(plugin_client, "book-1", "first idea", "second idea")
 
         assert result["highlights_created"] == 2
         stored_ids = set(
@@ -182,7 +184,7 @@ class TestHighlightUpload:
         assert {call["content_type"] for call in calls} == {"highlight"}
 
     async def test_skipped_duplicates_are_not_re_enqueued(
-        self, client: AsyncClient, job_queue: AsyncMock, create_book_via_api: CreateBookFunc
+        self, plugin_client: AsyncClient, job_queue: AsyncMock, create_book_via_api: CreateBookFunc
     ) -> None:
         """A KOReader sync resends the whole book, so this is the common case.
 
@@ -193,9 +195,9 @@ class TestHighlightUpload:
         await create_book_via_api({"client_book_id": "book-1", "title": "Crime and Punishment"})
 
         with embeddings_enabled():
-            await upload_highlights(client, "book-1", "first idea")
+            await upload_highlights(plugin_client, "book-1", "first idea")
             job_queue.enqueue.reset_mock()
-            second = await upload_highlights(client, "book-1", "first idea", "second idea")
+            second = await upload_highlights(plugin_client, "book-1", "first idea", "second idea")
 
         assert (second["highlights_created"], second["highlights_skipped"]) == (1, 1)
         assert len(embedding_calls(job_queue)) == 1
@@ -203,7 +205,7 @@ class TestHighlightUpload:
 
     async def test_batch_is_sized_to_slices_not_units(
         self,
-        client: AsyncClient,
+        plugin_client: AsyncClient,
         job_queue: AsyncMock,
         db_session: AsyncSession,
         create_book_via_api: CreateBookFunc,
@@ -212,7 +214,7 @@ class TestHighlightUpload:
         await create_book_via_api({"client_book_id": "book-1", "title": "Crime and Punishment"})
 
         with embeddings_enabled(), patch(SLICE_SIZE, 2):
-            await upload_highlights(client, "book-1", "a", "b", "c", "d", "e")
+            await upload_highlights(plugin_client, "book-1", "a", "b", "c", "d", "e")
 
         calls = embedding_calls(job_queue)
         assert [len(call["content_ids"]) for call in calls] == [2, 2, 1]
@@ -224,7 +226,7 @@ class TestHighlightUpload:
 
     async def test_a_broken_queue_does_not_fail_the_upload(
         self,
-        client: AsyncClient,
+        plugin_client: AsyncClient,
         job_queue: AsyncMock,
         db_session: AsyncSession,
         create_book_via_api: CreateBookFunc,
@@ -233,7 +235,7 @@ class TestHighlightUpload:
         job_queue.enqueue.side_effect = RuntimeError("redis is down")
 
         with embeddings_enabled():
-            result = await upload_highlights(client, "book-1", "first idea", "second idea")
+            result = await upload_highlights(plugin_client, "book-1", "first idea", "second idea")
 
         assert result["highlights_created"] == 2
         texts = (await db_session.execute(select(models.Highlight.text))).scalars().all()
@@ -242,6 +244,7 @@ class TestHighlightUpload:
     async def test_a_restored_highlight_is_enqueued_again(
         self,
         client: AsyncClient,
+        plugin_client: AsyncClient,
         job_queue: AsyncMock,
         db_session: AsyncSession,
         create_book_via_api: CreateBookFunc,
@@ -252,7 +255,7 @@ class TestHighlightUpload:
         )
 
         with embeddings_enabled():
-            stored = await upload_one_highlight(client, db_session, job_queue)
+            stored = await upload_one_highlight(plugin_client, db_session, job_queue)
             deletion = await client.request(
                 "DELETE",
                 f"/api/v1/books/{book.book_id}/highlight",
@@ -261,14 +264,14 @@ class TestHighlightUpload:
             assert deletion.json()["deleted_count"] == 1
             job_queue.enqueue.reset_mock()
 
-            revived = await rehighlight(client)
+            revived = await rehighlight(plugin_client)
 
         assert revived["highlights_created"] == 0
         assert [call["content_ids"] for call in embedding_calls(job_queue)] == [[stored.id]]
 
     async def test_a_highlight_only_returned_to_devices_is_not_enqueued_again(
         self,
-        client: AsyncClient,
+        plugin_client: AsyncClient,
         job_queue: AsyncMock,
         db_session: AsyncSession,
         create_book_via_api: CreateBookFunc,
@@ -277,21 +280,21 @@ class TestHighlightUpload:
         await create_book_via_api({"client_book_id": "book-1", "title": "Crime and Punishment"})
 
         with embeddings_enabled():
-            stored = await upload_one_highlight(client, db_session, job_queue)
-            returned = await rehighlight(client, removed_ids=[stored.id])
+            stored = await upload_one_highlight(plugin_client, db_session, job_queue)
+            returned = await rehighlight(plugin_client, removed_ids=[stored.id])
 
         assert returned["highlights_removed"] == 1
         assert embedding_calls(job_queue) == []
 
     async def test_an_upload_that_creates_nothing_enqueues_nothing(
-        self, client: AsyncClient, job_queue: AsyncMock, create_book_via_api: CreateBookFunc
+        self, plugin_client: AsyncClient, job_queue: AsyncMock, create_book_via_api: CreateBookFunc
     ) -> None:
         await create_book_via_api({"client_book_id": "book-1", "title": "Crime and Punishment"})
 
         with embeddings_enabled():
-            await upload_highlights(client, "book-1", "first idea")
+            await upload_highlights(plugin_client, "book-1", "first idea")
             job_queue.enqueue.reset_mock()
-            repeat = await upload_highlights(client, "book-1", "first idea")
+            repeat = await upload_highlights(plugin_client, "book-1", "first idea")
 
         assert repeat["highlights_created"] == 0
         assert embedding_calls(job_queue) == []


### PR DESCRIPTION
Closes #615.

The KOReader plugin now identifies itself with `X-Crossbill-Client: koreader-plugin/<x.y.z>`; this adds the server half of the gate, per the design agreed in the issue comment:

- New `require_client_version` dependency + per-client requirements map in `backend/src/infrastructure/common/client_version.py` (`koreader-plugin` → min **0.13.0**, update URL to the plugin repo). The minimum is a property of the deployed code — bump it in the same PR as any breaking change to the gated surface.
- Gated surface: all of `/ereader/*` (router-level) plus `/highlights/upload` and `/reading_sessions/upload` (endpoint-level). Everything else, `/auth/*` included, stays open.
- Rejection: HTTP **426** (unique in the API) with `{"detail": {"code": "client_upgrade_required", "client", "min_supported_version", "received_version", "update_url"}}`. Missing header → 426 (deployed old plugins send nothing — absence is the enforcement mechanism); unparseable version → 426; unknown client name → pass; `(major, minor, patch)` tuple compare, `>=` passes.
- 16 API-tier tests; 426 documented in OpenAPI on exactly the seven gated routes; CLAUDE.md notes the bump discipline.

**Deploy order:** merge the plugin PR (Crossbill-App/koreader-plugin#40) and dispatch its Release workflow (`minor` → v0.13.0) *before* deploying this — the gate refuses every ≤0.12.0 client from the moment it goes live, by design.

Checks: ruff, pyright, import-linter, 871 tests, duplication ratchet — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EpipxtqKFVvxnGLm86Ts3y