### PR TITLE
Stamp the release version into every version file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,11 +154,27 @@ jobs:
           echo "New version: $NEW_VERSION"
           echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
 
-          # Update package.json
+          # Update the root package.json and lockfile
           npm version $NEW_VERSION --no-git-tag-version
 
+          # Update the frontend workspace and its entry in the root lockfile
+          npm pkg set version=$NEW_VERSION --workspace frontend
+          node -e '
+            const fs = require("fs");
+            const lock = JSON.parse(fs.readFileSync("package-lock.json", "utf8"));
+            lock.packages["frontend"].version = process.argv[1];
+            fs.writeFileSync("package-lock.json", JSON.stringify(lock, null, 2) + "\n");
+          ' "$NEW_VERSION"
+
+          # Update the docs site, which has its own lockfile
+          cd site && npm version $NEW_VERSION --no-git-tag-version && cd ..
+
+          # Update the backend package version (only the [project] version line)
+          sed -i -E "s|^version = \".*\"|version = \"$NEW_VERSION\"|" backend/pyproject.toml
+
           # Commit version bump
-          git add package.json
+          git add package.json package-lock.json frontend/package.json \
+            site/package.json site/package-lock.json backend/pyproject.toml
           git commit -m "chore: bump version to $NEW_VERSION"
           git push origin main
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "crossbill-backend"
-version = "0.1.0"
+version = "0.24.1"
 description = "crossbill backend - KOReader highlights sync server"
 authors = [{ name = "User", email = "user@example.com" }]
 readme = "README.md"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "crossbill-frontend",
   "private": true,
-  "version": "0.0.1",
+  "version": "0.24.1",
   "type": "module",
   "scripts": {
     "dev": "npm run routes:generate && vite",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "crossbill",
-  "version": "0.23.0",
+  "version": "0.24.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "crossbill",
-      "version": "0.23.0",
+      "version": "0.24.1",
       "workspaces": [
         "frontend"
       ],
@@ -18,7 +18,7 @@
     },
     "frontend": {
       "name": "crossbill-frontend",
-      "version": "0.0.1",
+      "version": "0.24.1",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "site",
-  "version": "0.0.1",
+  "version": "0.24.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "site",
-      "version": "0.0.1",
+      "version": "0.24.1",
       "dependencies": {
         "@astrojs/starlight": "^0.41.6",
         "@fontsource/lora": "^5.3.0",

--- a/site/package.json
+++ b/site/package.json
@@ -1,7 +1,7 @@
 {
   "name": "site",
   "type": "module",
-  "version": "0.0.1",
+  "version": "0.24.1",
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",


### PR DESCRIPTION
## Why

The Release workflow bumped only the root `package.json`, so every other
version file drifted away from the published release:

| File | Before | Now |
| --- | --- | --- |
| `package.json` | 0.24.1 | 0.24.1 |
| `backend/pyproject.toml` | 0.1.0 | 0.24.1 |
| `frontend/package.json` | 0.0.1 | 0.24.1 |
| `site/package.json` | 0.0.1 | 0.24.1 |
| `package-lock.json` | 0.23.0 | 0.24.1 |
| `site/package-lock.json` | 0.0.1 | 0.24.1 |

The root lockfile was a second symptom of the same bug: `npm version`
already rewrote it, but the step's `git add package.json` never staged
it, so the change was thrown away on every release.

## What

1. **One-time alignment** — all six files now carry v0.24.1, the current
   GitHub release.
2. **Workflow change** — the "Bump version" step writes the new version
   into `backend/pyproject.toml`, `frontend/package.json` and
   `site/package.json` too, and stages both lockfiles, so the whole set
   stays stamped from here on.

Notes on the mechanics:

- The pyproject edit is a `sed` anchored to `^version = "`, which matches
  only the `[project]` version line — ruff's `target-version` and friends
  cannot match.
- `frontend/` is an npm workspace with no lockfile of its own, so it is
  bumped with `npm pkg set -w frontend` plus a targeted edit of the
  `frontend` entry in the root lockfile. Using `npm version -w` instead
  would trigger a full `npm install` inside the release job; this way the
  step stays offline.
- `site/` has its own lockfile, so plain `npm version` covers both files.

## Verification

Ran the "Bump version" step's script, extracted from the parsed YAML,
against a scratch copy of the six files, simulating a `patch` bump from
0.24.1. Every file landed on 0.24.2, the resulting commit was exactly six
one-line changes, and the working tree was clean afterwards (no install,
no collateral edits). The workflow YAML parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EpipxtqKFVvxnGLm86Ts3y
