### PR TITLE
Show a linked note's content from the flashcard view

### DIFF
--- a/frontend/src/lib/cacheEvents.ts
+++ b/frontend/src/lib/cacheEvents.ts
@@ -41,6 +41,12 @@ export const useCacheEvents = () => {
       }
     };
 
+    const drop = (...keys: QueryKey[]) => {
+      for (const queryKey of keys) {
+        queryClient.removeQueries({ queryKey });
+      }
+    };
+
     return {
       /** A book's own record changed — title, reading stage, cover, highlights. */
       bookChanged: (bookId: number) => invalidate(getGetBookDetailsQueryKey(bookId)),
@@ -61,13 +67,23 @@ export const useCacheEvents = () => {
        *
        * Pass `noteId` when the note already exists, so the open detail view
        * refreshes too. Omit it after creating a note, whose detail is not cached
-       * yet, and after deleting one, whose detail would refetch into a 404.
+       * yet.
        */
       noteChanged: (bookId: number, noteId?: number) =>
         invalidate(
           getGetNotesForBookQueryKey(bookId),
           ...(noteId === undefined ? [] : [getGetNoteQueryKey(noteId)])
         ),
+
+      /**
+       * A note was hard-deleted. Its detail is dropped, not invalidated: on a
+       * failed refetch React Query keeps the last data, so any other view
+       * holding it would keep rendering the deleted note.
+       */
+      noteDeleted: (bookId: number, noteId: number) => {
+        drop(getGetNoteQueryKey(noteId));
+        invalidate(getGetNotesForBookQueryKey(bookId));
+      },
 
       /**
        * A flashcard was created, edited or deleted.

--- a/frontend/src/pages/BookPage/Flashcards/FlashcardEditDialog.tsx
+++ b/frontend/src/pages/BookPage/Flashcards/FlashcardEditDialog.tsx
@@ -5,10 +5,13 @@ import { RHFTextField } from '@/components/inputs/RHFTextField.tsx';
 import { useMutationErrorHandler } from '@/hooks/useMutationErrorHandler.ts';
 import { HighlightContent } from '@/pages/BookPage/common/HighlightContent.tsx';
 import { Box, Button, Typography } from '@mui/material';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 
+import { useGetNote } from '@/api/generated/notes/notes.ts';
 import { useCacheEvents } from '@/lib/cacheEvents.ts';
+import { NoteCard } from '@/pages/BookPage/Notes/NoteCard.tsx';
+import { NoteViewDialog } from '@/pages/BookPage/Notes/NoteViewDialog.tsx';
 import type { FlashcardFormValues } from './CreateFlashcardForm.tsx';
 
 interface FlashcardEditDialogProps {
@@ -26,6 +29,7 @@ export const FlashcardEditDialog = ({
 }: FlashcardEditDialogProps) => {
   const mutationErrorHandler = useMutationErrorHandler();
   const cache = useCacheEvents();
+  const [isViewingNote, setIsViewingNote] = useState(false);
 
   const {
     control,
@@ -49,6 +53,12 @@ export const FlashcardEditDialog = ({
         onClose();
       },
       onError: mutationErrorHandler('update flashcard'),
+    },
+  });
+
+  const { data: noteData } = useGetNote(flashcard.note_id ?? 0, {
+    query: {
+      enabled: !!flashcard.note_id,
     },
   });
 
@@ -88,6 +98,14 @@ export const FlashcardEditDialog = ({
     >
       <Box sx={{ pt: 3, display: 'flex', flexDirection: 'column', gap: 3 }}>
         {flashcard.highlight && <HighlightContent highlight={flashcard.highlight} />}
+        {noteData && (
+          <NoteCard
+            note={noteData}
+            onClick={() => {
+              setIsViewingNote(true);
+            }}
+          />
+        )}
 
         <Box>
           <Typography
@@ -143,6 +161,10 @@ export const FlashcardEditDialog = ({
           />
         </Box>
       </Box>
+
+      {isViewingNote && noteData != null && (
+        <NoteViewDialog noteId={noteData.id} onClose={() => setIsViewingNote(false)} />
+      )}
     </CommonDialog>
   );
 };

--- a/frontend/src/pages/BookPage/Flashcards/FlashcardListCard.tsx
+++ b/frontend/src/pages/BookPage/Flashcards/FlashcardListCard.tsx
@@ -31,9 +31,6 @@ export const FlashcardListCard = ({
   const [isDeleting, setIsDeleting] = useState(false);
   const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
   const [isViewingNote, setIsViewingNote] = useState(false);
-  // Hide the affordance when the card is already shown inside its own note's
-  // dialog (e.g. a note's embedded Flashcards tab) -- opening it there would
-  // just stack a second copy of the same note on top of itself.
   const linkedNoteId =
     flashcard.note_id != null && flashcard.note_id !== noteId ? flashcard.note_id : null;
   const cache = useCacheEvents();

--- a/frontend/src/pages/BookPage/Flashcards/FlashcardListCard.tsx
+++ b/frontend/src/pages/BookPage/Flashcards/FlashcardListCard.tsx
@@ -5,7 +5,8 @@ import { FlashcardWithContext } from '@/components/features/flashcards/Flashcard
 import { useMutationErrorHandler } from '@/hooks/useMutationErrorHandler.ts';
 import { useCacheEvents } from '@/lib/cacheEvents.ts';
 import { FlashcardCard } from '@/pages/BookPage/Flashcards/FlashcardCard.tsx';
-import { DeleteIcon, EditIcon } from '@/theme/Icons.tsx';
+import { NoteViewDialog } from '@/pages/BookPage/Notes/NoteViewDialog.tsx';
+import { DeleteIcon, EditIcon, NotesIcon } from '@/theme/Icons.tsx';
 import { useState } from 'react';
 
 export interface FlashcardListCardProps {
@@ -29,6 +30,12 @@ export const FlashcardListCard = ({
 }: FlashcardListCardProps) => {
   const [isDeleting, setIsDeleting] = useState(false);
   const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
+  const [isViewingNote, setIsViewingNote] = useState(false);
+  // Hide the affordance when the card is already shown inside its own note's
+  // dialog (e.g. a note's embedded Flashcards tab) -- opening it there would
+  // just stack a second copy of the same note on top of itself.
+  const linkedNoteId =
+    flashcard.note_id != null && flashcard.note_id !== noteId ? flashcard.note_id : null;
   const cache = useCacheEvents();
   const mutationErrorHandler = useMutationErrorHandler();
 
@@ -44,6 +51,11 @@ export const FlashcardListCard = ({
   const handleDeleteClick = (e: React.MouseEvent) => {
     e.stopPropagation();
     setDeleteConfirmOpen(true);
+  };
+
+  const handleViewNoteClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setIsViewingNote(true);
   };
 
   const handleConfirmDelete = async () => {
@@ -65,6 +77,15 @@ export const FlashcardListCard = ({
         sourceHighlightText={flashcard.highlight?.text}
         renderActions={() => (
           <>
+            {linkedNoteId != null && (
+              <IconButtonWithTooltip
+                title="View note"
+                ariaLabel="View linked note"
+                onClick={handleViewNoteClick}
+                disabled={isDeleting}
+                icon={<NotesIcon fontSize="small" />}
+              />
+            )}
             <IconButtonWithTooltip
               title="Edit"
               ariaLabel="Edit flashcard"
@@ -93,6 +114,10 @@ export const FlashcardListCard = ({
         confirmColor="error"
         isLoading={isDeleting}
       />
+
+      {isViewingNote && linkedNoteId != null && (
+        <NoteViewDialog noteId={linkedNoteId} onClose={() => setIsViewingNote(false)} />
+      )}
     </>
   );
 };

--- a/frontend/src/pages/BookPage/Notes/NoteViewDialog.tsx
+++ b/frontend/src/pages/BookPage/Notes/NoteViewDialog.tsx
@@ -103,8 +103,7 @@ export const NoteViewDialog = ({
   const deleteMutation = useDeleteNote({
     mutation: {
       onSuccess: () => {
-        // No note id: the note is gone, so refetching its detail would 404.
-        cache.noteChanged(book.id);
+        cache.noteDeleted(book.id, noteId);
         setDeleteConfirmOpen(false);
         onClose();
       },


### PR DESCRIPTION
Addresses the first of the three points from #594.

`Flashcard.note_id` already exists in the schema (nullable — a card can be linked to a highlight, a chapter, a note, or nothing at all), but nothing in the UI surfaced it. A card created from a note — e.g. via an external import like the one described in #594 — showed only its bare question/answer with no way to reach the richer context living on the note.

This adds a "View note" icon next to Edit/Delete on `FlashcardListCard`, shown *only* when the card actually has a linked note (same conditional pattern the highlight-context preview already uses), that opens `NoteViewDialog` in place over the current view — no route navigation, reusing the same dialog notes already use elsewhere.

Hidden when the card is already inside its own note's embedded Flashcards tab, since opening it there would just stack a duplicate of the same note.

`FlashcardListCard` is the single shared row component for the Flashcards page, the Highlight dialog's Flashcards tab, and the Note dialog's own Flashcards tab, so this one change covers all three.

Mockup (interactive, click the note icon to see it in action):
https://claude.ai/code/artifact/4faae510-6a1a-4e61-9c8e-c1260f89f7a8

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npx eslint` passes on the changed file
- [x] `npx prettier --check` passes on the changed file
- [ ] Manual click-through in a running dev server