### PR TITLE
Cap chapter text sent to digest, quiz and chat

### DIFF
--- a/backend/src/application/learning/commands/chat/start_chat_session_use_case.py
+++ b/backend/src/application/learning/commands/chat/start_chat_session_use_case.py
@@ -83,7 +83,9 @@ class StartChatSessionUseCase:
 
         # 4. Seed the message history with the chapter content (no AI round-trip);
         #    the model reads it when the reader sends their first message.
-        session.message_history = self.ai_chat_service.seed_chat_context(content, CHAT_OPENER)
+        session.message_history = self.ai_chat_service.seed_chat_context(
+            content, CHAT_OPENER, chapter_id=chapter_id
+        )
         saved_session = await self.ai_chat_session_repo.create(session)
 
         logger.info(

--- a/backend/src/application/learning/protocols/ai_chat_service.py
+++ b/backend/src/application/learning/protocols/ai_chat_service.py
@@ -6,7 +6,7 @@ from src.domain.common.types import SerializedMessageHistory
 
 class AIChatServiceProtocol(Protocol):
     def seed_chat_context(
-        self, chapter_content: str, assistant_opener: str
+        self, chapter_content: str, assistant_opener: str, *, chapter_id: int
     ) -> SerializedMessageHistory: ...
 
     async def continue_chat(

--- a/backend/src/infrastructure/ai/ai_service.py
+++ b/backend/src/infrastructure/ai/ai_service.py
@@ -25,15 +25,19 @@ from src.infrastructure.ai.ai_agents import (
 
 logger = structlog.get_logger(__name__)
 
-#: Longest chapter text sent to the model as context, in characters.
-#:
-#: Digest already capped at this figure; quiz and chat did not, so a chapter
-#: with no real chapter boundaries (the whole book parsed as one chapter, as
-#: happens when an EPUB's nav data is missing) sent the entire book as
-#: context on every turn. Applying the same cap everywhere keeps behavior
-#: consistent and bounds request size. Like the embedding truncation in
-#: ADR-0002, the tail of an over-long chapter is simply not sent.
 MAX_CHAPTER_CONTEXT_CHARS = 10000
+
+#: The one ``AIUsageContext.entity_type`` whose ``entity_id`` names a chapter.
+CHAPTER_ENTITY_TYPE = "chapter"
+
+
+def chapter_id_of(usage_context: AIUsageContext) -> int:
+    if usage_context.entity_type != CHAPTER_ENTITY_TYPE:
+        raise ValueError(
+            f"chapter content truncation needs a {CHAPTER_ENTITY_TYPE} usage context, "
+            f"got {usage_context.entity_type!r}"
+        )
+    return usage_context.entity_id
 
 
 def truncate_chapter_content(content: str, *, chapter_id: int) -> str:
@@ -91,7 +95,7 @@ class AIService:
 
     async def generate_digest(self, content: str, usage_context: AIUsageContext) -> DigestResult:
         agent = get_digest_agent()
-        content = truncate_chapter_content(content, chapter_id=usage_context.entity_id)
+        content = truncate_chapter_content(content, chapter_id=chapter_id_of(usage_context))
         result = await agent.run(content)
         usage = result.usage()
         await self._save_usage(
@@ -136,7 +140,7 @@ class AIService:
     ) -> tuple[str, SerializedMessageHistory]:
         agent = get_quiz_agent()
         chapter_content = truncate_chapter_content(
-            chapter_content, chapter_id=usage_context.entity_id
+            chapter_content, chapter_id=chapter_id_of(usage_context)
         )
         prompt = f"The reader wants to be quizzed on this chapter. Ask {question_count} questions total.\n\n--- CHAPTER CONTENT ---\n{chapter_content}"
         return await self._respond(agent, usage_context, prompt=prompt)

--- a/backend/src/infrastructure/ai/ai_service.py
+++ b/backend/src/infrastructure/ai/ai_service.py
@@ -25,6 +25,28 @@ from src.infrastructure.ai.ai_agents import (
 
 logger = structlog.get_logger(__name__)
 
+#: Longest chapter text sent to the model as context, in characters.
+#:
+#: Digest already capped at this figure; quiz and chat did not, so a chapter
+#: with no real chapter boundaries (the whole book parsed as one chapter, as
+#: happens when an EPUB's nav data is missing) sent the entire book as
+#: context on every turn. Applying the same cap everywhere keeps behavior
+#: consistent and bounds request size. Like the embedding truncation in
+#: ADR-0002, the tail of an over-long chapter is simply not sent.
+MAX_CHAPTER_CONTEXT_CHARS = 10000
+
+
+def truncate_chapter_content(content: str, *, chapter_id: int) -> str:
+    if len(content) <= MAX_CHAPTER_CONTEXT_CHARS:
+        return content
+    dropped_chars = len(content) - MAX_CHAPTER_CONTEXT_CHARS
+    logger.info(
+        "chapter_content_truncated",
+        chapter_id=chapter_id,
+        dropped_chars=dropped_chars,
+    )
+    return content[:MAX_CHAPTER_CONTEXT_CHARS]
+
 
 class AIService:
     def __init__(self, usage_repository: AIUsageRepositoryProtocol) -> None:
@@ -69,7 +91,8 @@ class AIService:
 
     async def generate_digest(self, content: str, usage_context: AIUsageContext) -> DigestResult:
         agent = get_digest_agent()
-        result = await agent.run(content[:10000])
+        content = truncate_chapter_content(content, chapter_id=usage_context.entity_id)
+        result = await agent.run(content)
         usage = result.usage()
         await self._save_usage(
             usage_context, result.response.model_name, usage.input_tokens, usage.output_tokens
@@ -112,6 +135,9 @@ class AIService:
         self, chapter_content: str, question_count: int, usage_context: AIUsageContext
     ) -> tuple[str, SerializedMessageHistory]:
         agent = get_quiz_agent()
+        chapter_content = truncate_chapter_content(
+            chapter_content, chapter_id=usage_context.entity_id
+        )
         prompt = f"The reader wants to be quizzed on this chapter. Ask {question_count} questions total.\n\n--- CHAPTER CONTENT ---\n{chapter_content}"
         return await self._respond(agent, usage_context, prompt=prompt)
 
@@ -128,12 +154,13 @@ class AIService:
         )
 
     def seed_chat_context(
-        self, chapter_content: str, assistant_opener: str
+        self, chapter_content: str, assistant_opener: str, *, chapter_id: int
     ) -> SerializedMessageHistory:
         """Build an initial chat history seeded with the chapter content, without
         calling the model. The content is stored as the opening user turn (paired
         with the fixed opener as the assistant turn) so that later continue_chat
         calls have the chapter in context."""
+        chapter_content = truncate_chapter_content(chapter_content, chapter_id=chapter_id)
         prompt = f"The reader wants to chat about the contents of this chapter.\n\n--- CHAPTER CONTENT ---\n{chapter_content}"
         messages: list[ModelMessage] = [
             ModelRequest(parts=[UserPromptPart(content=prompt)]),

--- a/backend/tests/ai_helpers.py
+++ b/backend/tests/ai_helpers.py
@@ -1,0 +1,63 @@
+"""Stand-ins for the pydantic-ai agents ``AIService`` runs."""
+
+from types import SimpleNamespace
+from typing import Any
+
+from pydantic_ai import ModelMessage
+from pydantic_ai.messages import ModelRequest, ModelResponse, TextPart, UserPromptPart
+
+FAKE_MODEL_NAME = "fake-model"
+
+
+class FakeRunResult:
+    """The parts of pydantic-ai's ``AgentRunResult`` that ``AIService`` reads."""
+
+    def __init__(self, prompt: str, output: Any) -> None:  # noqa: ANN401
+        self.output = output
+        self.response = SimpleNamespace(model_name=FAKE_MODEL_NAME)
+        self._prompt = prompt
+
+    def usage(self) -> SimpleNamespace:
+        return SimpleNamespace(input_tokens=1, output_tokens=1)
+
+    def all_messages(self) -> list[ModelMessage]:
+        return [
+            ModelRequest(parts=[UserPromptPart(content=self._prompt)]),
+            ModelResponse(parts=[TextPart(content=str(self.output))]),
+        ]
+
+
+class FakeAgent:
+    """Records the prompts it was run with, and answers with a fixed output."""
+
+    def __init__(self, output: Any) -> None:  # noqa: ANN401
+        self.output = output
+        self.received_prompts: list[str] = []
+
+    async def run(
+        self,
+        content: str | None = None,
+        *,
+        user_prompt: str | None = None,
+        message_history: object = None,
+    ) -> FakeRunResult:
+        prompt = content if content is not None else user_prompt
+        assert prompt is not None, "agent run without a prompt"
+        self.received_prompts.append(prompt)
+        return FakeRunResult(prompt, self.output)
+
+
+def digest_output(
+    summary: str = "A summary.",
+    keypoints: list[str] | None = None,
+    questions: list[tuple[str, str]] | None = None,
+) -> SimpleNamespace:
+    """The shape ``generate_digest`` unpacks out of its agent's output."""
+    return SimpleNamespace(
+        summary=summary,
+        keypoints=keypoints if keypoints is not None else ["A key point."],
+        questions_and_answers=[
+            SimpleNamespace(question=question, answer=answer)
+            for question, answer in (questions if questions is not None else [("Q?", "A.")])
+        ],
+    )

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -16,12 +16,12 @@ os.environ.setdefault("RATE_LIMIT_ENABLED", "false")
 
 import inspect
 import itertools
-from collections.abc import AsyncGenerator, Awaitable, Callable
+from collections.abc import AsyncGenerator, Awaitable, Callable, Iterator
 from datetime import datetime as dt
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from ebooklib import epub
@@ -60,6 +60,7 @@ from src.models import (
 from src.models import (
     HighlightStyle as HighlightStyleModel,
 )
+from tests.ai_helpers import FakeAgent, digest_output
 
 logging.getLogger("aiosqlite").setLevel(logging.WARNING)
 
@@ -477,3 +478,63 @@ async def create_book_via_api(plugin_client: AsyncClient) -> CreateBookFunc:
         return EreaderBookMetadata(**response.json())
 
     return _create_book
+
+
+# --- AI endpoints -----------------------------------------------------------
+
+
+@pytest.fixture
+def ai_enabled() -> Iterator[None]:
+    """Let the AI endpoints past ``require_ai_enabled``."""
+    with patch("src.infrastructure.common.dependencies.is_ai_enabled", return_value=True):
+        yield
+
+
+@pytest.fixture
+async def epub_chapter(db_session: AsyncSession, test_book: Book) -> Chapter:
+    """A chapter of an EPUB book, carrying the xpoints extraction needs."""
+    test_book.ebook_file = "/path/to/test.epub"
+    test_book.file_type = "epub"
+    chapter = Chapter(
+        book_id=test_book.id,
+        name="Test Chapter",
+        start_xpoint="/body/text/chapter[1]",
+        end_xpoint="/body/text/chapter[2]",
+    )
+    db_session.add(chapter)
+    await db_session.commit()
+    await db_session.refresh(chapter)
+    return chapter
+
+
+@pytest.fixture
+def chapter_text(client: AsyncClient) -> Iterator[MagicMock]:
+    """The extracted text of the chapter under test: set ``.return_value``."""
+    from src.core import container  # noqa: PLC0415
+
+    file_repo = AsyncMock()
+    file_repo.get_epub.return_value = b"PK\x03\x04 not really an EPUB"
+    extraction = MagicMock()
+    extraction.extract_chapter_text.return_value = "The chapter is about testing."
+
+    container.shared.file_repository.override(file_repo)
+    container.shared.ebook_text_extraction_service.override(extraction)
+    yield extraction.extract_chapter_text
+    container.shared.ebook_text_extraction_service.reset_last_overriding()
+    container.shared.file_repository.reset_last_overriding()
+
+
+@pytest.fixture
+def digest_agent() -> Iterator[FakeAgent]:
+    """The agent ``generate_digest`` runs, recording the prompt it received."""
+    agent = FakeAgent(digest_output())
+    with patch("src.infrastructure.ai.ai_service.get_digest_agent", return_value=agent):
+        yield agent
+
+
+@pytest.fixture
+def quiz_agent() -> Iterator[FakeAgent]:
+    """The agent ``start_quiz`` and ``continue_quiz`` run."""
+    agent = FakeAgent("**Question 1/5:** What is the main topic?")
+    with patch("src.infrastructure.ai.ai_service.get_quiz_agent", return_value=agent):
+        yield agent

--- a/backend/tests/protocol_conformance.py
+++ b/backend/tests/protocol_conformance.py
@@ -9,6 +9,7 @@ prefix). When adding a repository or query adapter, add its pair here.
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from src.application.ai.protocols.ai_usage_repository import AIUsageRepositoryProtocol
 from src.application.identity.protocols.refresh_token_repository import (
     RefreshTokenRepositoryProtocol,
 )
@@ -16,9 +17,12 @@ from src.application.identity.protocols.token_service import TokenServiceProtoco
 from src.application.identity.protocols.user_repository import UserRepositoryProtocol
 from src.application.jobs.protocols.job_batch_repository import JobBatchRepositoryProtocol
 from src.application.jobs.queries.job_batch import JobBatchQueryProtocol
+from src.application.learning.protocols.ai_chat_service import AIChatServiceProtocol
 from src.application.learning.protocols.ai_chat_session_repository import (
     AIChatSessionRepositoryProtocol,
 )
+from src.application.learning.protocols.ai_flashcard_service import AIFlashcardServiceProtocol
+from src.application.learning.protocols.ai_quiz_service import AIQuizServiceProtocol
 from src.application.learning.protocols.flashcard_repository import FlashcardRepositoryProtocol
 from src.application.learning.queries.book_flashcards import BookFlashcardQueryProtocol
 from src.application.library.protocols.book_repository import (
@@ -30,6 +34,10 @@ from src.application.library.queries.book_details import BookDetailsQueryProtoco
 from src.application.library.queries.book_list import BookListQueryProtocol
 from src.application.notes.protocols.note_repository import NoteRepositoryProtocol
 from src.application.notes.queries.note_with_links import NoteQueryProtocol
+from src.application.reading.protocols.ai_digest_service import AIDigestServiceProtocol
+from src.application.reading.protocols.ai_text_summary_service import (
+    AITextSummaryServiceProtocol,
+)
 from src.application.reading.protocols.book_repository import (
     BookRepositoryProtocol as ReadingBookRepositoryProtocol,
 )
@@ -57,6 +65,8 @@ from src.application.reflection.protocols.book_reflection_repository import (
     BookReflectionRepositoryProtocol,
 )
 from src.application.tagging.protocols.tag_repository import TagRepositoryProtocol
+from src.infrastructure.ai.ai_service import AIService
+from src.infrastructure.ai.repositories.ai_usage_repository import AIUsageRepository
 from src.infrastructure.identity.repositories.refresh_token_repository import (
     RefreshTokenRepository,
 )
@@ -138,3 +148,14 @@ def repositories_satisfy_their_protocols(
     _reading_sessions_view: ReadingSessionQueryProtocol = ReadingSessionQuery(
         db, label_resolution_service, file_repository, text_extraction_service
     )
+
+
+def ai_service_satisfies_its_protocols(db: AsyncSession) -> None:
+    """``AIService`` implements five protocols and is wired through none of them."""
+    _usage: AIUsageRepositoryProtocol = AIUsageRepository(db=db)
+    service = AIService(usage_repository=AIUsageRepository(db=db))
+    _digest: AIDigestServiceProtocol = service
+    _quiz: AIQuizServiceProtocol = service
+    _chat: AIChatServiceProtocol = service
+    _flashcards: AIFlashcardServiceProtocol = service
+    _summary: AITextSummaryServiceProtocol = service

--- a/backend/tests/test_chapter_digest_generation.py
+++ b/backend/tests/test_chapter_digest_generation.py
@@ -1,0 +1,140 @@
+"""Tests for the chapter digest generation endpoint.
+
+Digest generation was the one AI feature that already capped its input
+(`content[:10000]`); these tests cover it going through the shared
+`truncate_chapter_content` helper instead, alongside quiz and chat.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.infrastructure.ai.ai_service import MAX_CHAPTER_CONTEXT_CHARS
+from src.models import Book, Chapter
+
+
+async def create_digest_chapter(db_session: AsyncSession, book: Book) -> Chapter:
+    """Create a chapter with xpoint data needed for content extraction."""
+    chapter = Chapter(
+        book_id=book.id,
+        name="Digest Test Chapter",
+        start_xpoint="/body/text/chapter[1]",
+        end_xpoint="/body/text/chapter[2]",
+    )
+    db_session.add(chapter)
+    await db_session.commit()
+    await db_session.refresh(chapter)
+    return chapter
+
+
+class _FakeDigestResult:
+    """Stands in for pydantic_ai's AgentRunResult, recording what it was run with."""
+
+    def __init__(self, prompt: str) -> None:
+        self.prompt = prompt
+        self.output = SimpleNamespace(
+            summary="A summary.",
+            keypoints=["A key point."],
+            questions_and_answers=[SimpleNamespace(question="Q?", answer="A.")],
+        )
+        self.response = SimpleNamespace(model_name="fake-model")
+
+    def usage(self) -> SimpleNamespace:
+        return SimpleNamespace(input_tokens=1, output_tokens=1)
+
+
+class _FakeDigestAgent:
+    def __init__(self) -> None:
+        self.received_prompts: list[str] = []
+
+    async def run(self, prompt: str) -> _FakeDigestResult:
+        self.received_prompts.append(prompt)
+        return _FakeDigestResult(prompt)
+
+
+class TestGenerateChapterDigest:
+    @patch("src.infrastructure.common.dependencies.is_ai_enabled", return_value=True)
+    @patch(
+        "src.application.semantic.services.embedding_enqueuer.EmbeddingEnqueuer.enqueue_for",
+        new_callable=AsyncMock,
+    )
+    @patch("src.infrastructure.ai.ai_service.get_digest_agent")
+    @patch(
+        "src.infrastructure.library.services.epub_text_extraction_service"
+        ".EpubTextExtractionService.extract_chapter_text"
+    )
+    @patch(
+        "src.infrastructure.library.repositories.file_repository.FileRepository.get_epub",
+        new_callable=AsyncMock,
+    )
+    async def test_generate_digest_caps_over_long_chapter_content(
+        self,
+        mock_get_epub: AsyncMock,
+        mock_extract: MagicMock,
+        mock_get_agent: MagicMock,
+        mock_enqueue: AsyncMock,
+        mock_ai_enabled: MagicMock,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        test_book: Book,
+    ) -> None:
+        test_book.ebook_file = "/path/to/test.epub"
+        test_book.file_type = "epub"
+        await db_session.commit()
+
+        chapter = await create_digest_chapter(db_session, test_book)
+
+        mock_get_epub.return_value = b"fake epub content"
+        mock_extract.return_value = "x" * (MAX_CHAPTER_CONTEXT_CHARS * 2)
+        fake_agent = _FakeDigestAgent()
+        mock_get_agent.return_value = fake_agent
+
+        response = await client.post(f"/api/v1/chapters/{chapter.id}/digest/generate")
+
+        assert response.status_code == 201
+        assert len(fake_agent.received_prompts) == 1
+        assert len(fake_agent.received_prompts[0]) == MAX_CHAPTER_CONTEXT_CHARS
+
+    @patch("src.infrastructure.common.dependencies.is_ai_enabled", return_value=True)
+    @patch(
+        "src.application.semantic.services.embedding_enqueuer.EmbeddingEnqueuer.enqueue_for",
+        new_callable=AsyncMock,
+    )
+    @patch("src.infrastructure.ai.ai_service.get_digest_agent")
+    @patch(
+        "src.infrastructure.library.services.epub_text_extraction_service"
+        ".EpubTextExtractionService.extract_chapter_text"
+    )
+    @patch(
+        "src.infrastructure.library.repositories.file_repository.FileRepository.get_epub",
+        new_callable=AsyncMock,
+    )
+    async def test_generate_digest_leaves_short_chapter_content_untouched(
+        self,
+        mock_get_epub: AsyncMock,
+        mock_extract: MagicMock,
+        mock_get_agent: MagicMock,
+        mock_enqueue: AsyncMock,
+        mock_ai_enabled: MagicMock,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        test_book: Book,
+    ) -> None:
+        test_book.ebook_file = "/path/to/test.epub"
+        test_book.file_type = "epub"
+        await db_session.commit()
+
+        chapter = await create_digest_chapter(db_session, test_book)
+
+        mock_get_epub.return_value = b"fake epub content"
+        short_content = "This chapter is short but long enough to pass the minimum-length check."
+        mock_extract.return_value = short_content
+        fake_agent = _FakeDigestAgent()
+        mock_get_agent.return_value = fake_agent
+
+        response = await client.post(f"/api/v1/chapters/{chapter.id}/digest/generate")
+
+        assert response.status_code == 201
+        assert fake_agent.received_prompts == [short_content]

--- a/backend/tests/test_chapter_digest_generation.py
+++ b/backend/tests/test_chapter_digest_generation.py
@@ -1,140 +1,26 @@
-"""Tests for the chapter digest generation endpoint.
+"""Tests for the chapter digest generation endpoint."""
 
-Digest generation was the one AI feature that already capped its input
-(`content[:10000]`); these tests cover it going through the shared
-`truncate_chapter_content` helper instead, alongside quiz and chat.
-"""
-
-from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock
 
 from httpx import AsyncClient
-from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.infrastructure.ai.ai_service import MAX_CHAPTER_CONTEXT_CHARS
-from src.models import Book, Chapter
-
-
-async def create_digest_chapter(db_session: AsyncSession, book: Book) -> Chapter:
-    """Create a chapter with xpoint data needed for content extraction."""
-    chapter = Chapter(
-        book_id=book.id,
-        name="Digest Test Chapter",
-        start_xpoint="/body/text/chapter[1]",
-        end_xpoint="/body/text/chapter[2]",
-    )
-    db_session.add(chapter)
-    await db_session.commit()
-    await db_session.refresh(chapter)
-    return chapter
-
-
-class _FakeDigestResult:
-    """Stands in for pydantic_ai's AgentRunResult, recording what it was run with."""
-
-    def __init__(self, prompt: str) -> None:
-        self.prompt = prompt
-        self.output = SimpleNamespace(
-            summary="A summary.",
-            keypoints=["A key point."],
-            questions_and_answers=[SimpleNamespace(question="Q?", answer="A.")],
-        )
-        self.response = SimpleNamespace(model_name="fake-model")
-
-    def usage(self) -> SimpleNamespace:
-        return SimpleNamespace(input_tokens=1, output_tokens=1)
-
-
-class _FakeDigestAgent:
-    def __init__(self) -> None:
-        self.received_prompts: list[str] = []
-
-    async def run(self, prompt: str) -> _FakeDigestResult:
-        self.received_prompts.append(prompt)
-        return _FakeDigestResult(prompt)
+from src.models import Chapter
+from tests.ai_helpers import FakeAgent
 
 
 class TestGenerateChapterDigest:
-    @patch("src.infrastructure.common.dependencies.is_ai_enabled", return_value=True)
-    @patch(
-        "src.application.semantic.services.embedding_enqueuer.EmbeddingEnqueuer.enqueue_for",
-        new_callable=AsyncMock,
-    )
-    @patch("src.infrastructure.ai.ai_service.get_digest_agent")
-    @patch(
-        "src.infrastructure.library.services.epub_text_extraction_service"
-        ".EpubTextExtractionService.extract_chapter_text"
-    )
-    @patch(
-        "src.infrastructure.library.repositories.file_repository.FileRepository.get_epub",
-        new_callable=AsyncMock,
-    )
-    async def test_generate_digest_caps_over_long_chapter_content(
+    async def test_caps_over_long_chapter_content(
         self,
-        mock_get_epub: AsyncMock,
-        mock_extract: MagicMock,
-        mock_get_agent: MagicMock,
-        mock_enqueue: AsyncMock,
-        mock_ai_enabled: MagicMock,
         client: AsyncClient,
-        db_session: AsyncSession,
-        test_book: Book,
+        ai_enabled: None,
+        epub_chapter: Chapter,
+        chapter_text: MagicMock,
+        digest_agent: FakeAgent,
     ) -> None:
-        test_book.ebook_file = "/path/to/test.epub"
-        test_book.file_type = "epub"
-        await db_session.commit()
+        chapter_text.return_value = "x" * (MAX_CHAPTER_CONTEXT_CHARS * 2)
 
-        chapter = await create_digest_chapter(db_session, test_book)
+        response = await client.post(f"/api/v1/chapters/{epub_chapter.id}/digest/generate")
 
-        mock_get_epub.return_value = b"fake epub content"
-        mock_extract.return_value = "x" * (MAX_CHAPTER_CONTEXT_CHARS * 2)
-        fake_agent = _FakeDigestAgent()
-        mock_get_agent.return_value = fake_agent
-
-        response = await client.post(f"/api/v1/chapters/{chapter.id}/digest/generate")
-
-        assert response.status_code == 201
-        assert len(fake_agent.received_prompts) == 1
-        assert len(fake_agent.received_prompts[0]) == MAX_CHAPTER_CONTEXT_CHARS
-
-    @patch("src.infrastructure.common.dependencies.is_ai_enabled", return_value=True)
-    @patch(
-        "src.application.semantic.services.embedding_enqueuer.EmbeddingEnqueuer.enqueue_for",
-        new_callable=AsyncMock,
-    )
-    @patch("src.infrastructure.ai.ai_service.get_digest_agent")
-    @patch(
-        "src.infrastructure.library.services.epub_text_extraction_service"
-        ".EpubTextExtractionService.extract_chapter_text"
-    )
-    @patch(
-        "src.infrastructure.library.repositories.file_repository.FileRepository.get_epub",
-        new_callable=AsyncMock,
-    )
-    async def test_generate_digest_leaves_short_chapter_content_untouched(
-        self,
-        mock_get_epub: AsyncMock,
-        mock_extract: MagicMock,
-        mock_get_agent: MagicMock,
-        mock_enqueue: AsyncMock,
-        mock_ai_enabled: MagicMock,
-        client: AsyncClient,
-        db_session: AsyncSession,
-        test_book: Book,
-    ) -> None:
-        test_book.ebook_file = "/path/to/test.epub"
-        test_book.file_type = "epub"
-        await db_session.commit()
-
-        chapter = await create_digest_chapter(db_session, test_book)
-
-        mock_get_epub.return_value = b"fake epub content"
-        short_content = "This chapter is short but long enough to pass the minimum-length check."
-        mock_extract.return_value = short_content
-        fake_agent = _FakeDigestAgent()
-        mock_get_agent.return_value = fake_agent
-
-        response = await client.post(f"/api/v1/chapters/{chapter.id}/digest/generate")
-
-        assert response.status_code == 201
-        assert fake_agent.received_prompts == [short_content]
+        assert response.status_code == 201, response.text
+        assert digest_agent.received_prompts == ["x" * MAX_CHAPTER_CONTEXT_CHARS]

--- a/backend/tests/test_chat_sessions.py
+++ b/backend/tests/test_chat_sessions.py
@@ -6,6 +6,7 @@ from httpx import AsyncClient
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from src.infrastructure.ai.ai_service import MAX_CHAPTER_CONTEXT_CHARS
 from src.models import AIChatSession as AIChatSessionModel
 from src.models import Book, Chapter
 
@@ -75,6 +76,48 @@ class TestCreateChatSession:
             )
         ).scalar_one()
         assert "The chapter is about testing." in str(session.message_history)
+
+    @patch("src.infrastructure.common.dependencies.is_ai_enabled", return_value=True)
+    @patch("src.infrastructure.ai.ai_service.AIService._respond", new_callable=AsyncMock)
+    @patch(
+        "src.infrastructure.library.services.epub_text_extraction_service"
+        ".EpubTextExtractionService.extract_chapter_text"
+    )
+    @patch(
+        "src.infrastructure.library.repositories.file_repository.FileRepository.get_epub",
+        new_callable=AsyncMock,
+    )
+    async def test_create_chat_session_caps_over_long_chapter_content(
+        self,
+        mock_get_epub: AsyncMock,
+        mock_extract: MagicMock,
+        mock_respond: AsyncMock,
+        mock_ai_enabled: MagicMock,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        test_book: Book,
+    ) -> None:
+        test_book.ebook_file = "/path/to/test.epub"
+        test_book.file_type = "epub"
+        await db_session.commit()
+
+        chapter = await create_chat_chapter(db_session, test_book)
+
+        mock_get_epub.return_value = b"fake epub content"
+        mock_extract.return_value = "x" * (MAX_CHAPTER_CONTEXT_CHARS * 2)
+
+        response = await client.post(f"/api/v1/chapters/{chapter.id}/chat-sessions")
+        assert response.status_code == 201
+        data = response.json()
+
+        session = (
+            await db_session.execute(
+                select(AIChatSessionModel).where(AIChatSessionModel.id == data["session_id"])
+            )
+        ).scalar_one()
+        seeded_content = str(session.message_history)
+        assert "x" * (MAX_CHAPTER_CONTEXT_CHARS + 1) not in seeded_content
+        assert "x" * MAX_CHAPTER_CONTEXT_CHARS in seeded_content
 
     @patch("src.infrastructure.common.dependencies.is_ai_enabled", return_value=True)
     async def test_create_chat_session_chapter_not_found(

--- a/backend/tests/test_chat_sessions.py
+++ b/backend/tests/test_chat_sessions.py
@@ -8,57 +8,37 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.infrastructure.ai.ai_service import MAX_CHAPTER_CONTEXT_CHARS
 from src.models import AIChatSession as AIChatSessionModel
-from src.models import Book, Chapter
+from src.models import Chapter
 
 CHAT_OPENER = "What do you want to chat about this chapter?"
 
 
-async def create_chat_chapter(db_session: AsyncSession, book: Book) -> Chapter:
-    """Create a chapter with xpoint data needed for content extraction."""
-    chapter = Chapter(
-        book_id=book.id,
-        name="Chat Test Chapter",
-        start_xpoint="/body/text/chapter[1]",
-        end_xpoint="/body/text/chapter[2]",
-    )
-    db_session.add(chapter)
-    await db_session.commit()
-    await db_session.refresh(chapter)
-    return chapter
+async def seeded_history(db_session: AsyncSession, session_id: int) -> str:
+    """The message history the endpoint stored, as one searchable string."""
+    session = (
+        await db_session.execute(
+            select(AIChatSessionModel).where(AIChatSessionModel.id == session_id)
+        )
+    ).scalar_one()
+    return str(session.message_history)
 
 
 class TestCreateChatSession:
-    @patch("src.infrastructure.common.dependencies.is_ai_enabled", return_value=True)
     @patch("src.infrastructure.ai.ai_service.AIService._respond", new_callable=AsyncMock)
-    @patch(
-        "src.infrastructure.library.services.epub_text_extraction_service"
-        ".EpubTextExtractionService.extract_chapter_text"
-    )
-    @patch(
-        "src.infrastructure.library.repositories.file_repository.FileRepository.get_epub",
-        new_callable=AsyncMock,
-    )
     async def test_create_chat_session_success(
         self,
-        mock_get_epub: AsyncMock,
-        mock_extract: MagicMock,
         mock_respond: AsyncMock,
-        mock_ai_enabled: MagicMock,
         client: AsyncClient,
+        ai_enabled: None,
         db_session: AsyncSession,
-        test_book: Book,
+        epub_chapter: Chapter,
+        chapter_text: MagicMock,
     ) -> None:
-        test_book.ebook_file = "/path/to/test.epub"
-        test_book.file_type = "epub"
-        await db_session.commit()
+        chapter_text.return_value = "The chapter is about testing."
 
-        chapter = await create_chat_chapter(db_session, test_book)
+        response = await client.post(f"/api/v1/chapters/{epub_chapter.id}/chat-sessions")
 
-        mock_get_epub.return_value = b"fake epub content"
-        mock_extract.return_value = "The chapter is about testing."
-
-        response = await client.post(f"/api/v1/chapters/{chapter.id}/chat-sessions")
-        assert response.status_code == 201
+        assert response.status_code == 201, response.text
         data = response.json()
         assert "session_id" in data
         assert data["message"] == CHAT_OPENER
@@ -70,67 +50,39 @@ class TestCreateChatSession:
 
         # The chapter content is seeded into the session history so the model can
         # refer to it on the first real message.
-        session = (
-            await db_session.execute(
-                select(AIChatSessionModel).where(AIChatSessionModel.id == data["session_id"])
-            )
-        ).scalar_one()
-        assert "The chapter is about testing." in str(session.message_history)
+        assert "The chapter is about testing." in await seeded_history(
+            db_session, data["session_id"]
+        )
 
-    @patch("src.infrastructure.common.dependencies.is_ai_enabled", return_value=True)
-    @patch("src.infrastructure.ai.ai_service.AIService._respond", new_callable=AsyncMock)
-    @patch(
-        "src.infrastructure.library.services.epub_text_extraction_service"
-        ".EpubTextExtractionService.extract_chapter_text"
-    )
-    @patch(
-        "src.infrastructure.library.repositories.file_repository.FileRepository.get_epub",
-        new_callable=AsyncMock,
-    )
     async def test_create_chat_session_caps_over_long_chapter_content(
         self,
-        mock_get_epub: AsyncMock,
-        mock_extract: MagicMock,
-        mock_respond: AsyncMock,
-        mock_ai_enabled: MagicMock,
         client: AsyncClient,
+        ai_enabled: None,
         db_session: AsyncSession,
-        test_book: Book,
+        epub_chapter: Chapter,
+        chapter_text: MagicMock,
     ) -> None:
-        test_book.ebook_file = "/path/to/test.epub"
-        test_book.file_type = "epub"
-        await db_session.commit()
+        """The seed is persisted and replayed on every turn, so an uncapped one
+        re-sends the whole book with each message the reader writes."""
+        chapter_text.return_value = "x" * (MAX_CHAPTER_CONTEXT_CHARS * 2)
 
-        chapter = await create_chat_chapter(db_session, test_book)
+        response = await client.post(f"/api/v1/chapters/{epub_chapter.id}/chat-sessions")
 
-        mock_get_epub.return_value = b"fake epub content"
-        mock_extract.return_value = "x" * (MAX_CHAPTER_CONTEXT_CHARS * 2)
+        assert response.status_code == 201, response.text
+        seeded = await seeded_history(db_session, response.json()["session_id"])
+        assert "x" * MAX_CHAPTER_CONTEXT_CHARS in seeded
+        assert "x" * (MAX_CHAPTER_CONTEXT_CHARS + 1) not in seeded
 
-        response = await client.post(f"/api/v1/chapters/{chapter.id}/chat-sessions")
-        assert response.status_code == 201
-        data = response.json()
-
-        session = (
-            await db_session.execute(
-                select(AIChatSessionModel).where(AIChatSessionModel.id == data["session_id"])
-            )
-        ).scalar_one()
-        seeded_content = str(session.message_history)
-        assert "x" * (MAX_CHAPTER_CONTEXT_CHARS + 1) not in seeded_content
-        assert "x" * MAX_CHAPTER_CONTEXT_CHARS in seeded_content
-
-    @patch("src.infrastructure.common.dependencies.is_ai_enabled", return_value=True)
     async def test_create_chat_session_chapter_not_found(
-        self, mock_ai_enabled: MagicMock, client: AsyncClient
+        self, client: AsyncClient, ai_enabled: None
     ) -> None:
         response = await client.post("/api/v1/chapters/99999/chat-sessions")
         assert response.status_code == 404
 
 
 class TestSendChatMessage:
-    @patch("src.infrastructure.common.dependencies.is_ai_enabled", return_value=True)
     async def test_send_message_session_not_found(
-        self, mock_ai_enabled: MagicMock, client: AsyncClient
+        self, client: AsyncClient, ai_enabled: None
     ) -> None:
         response = await client.post(
             "/api/v1/chat-sessions/99999/messages",
@@ -138,17 +90,13 @@ class TestSendChatMessage:
         )
         assert response.status_code == 404
 
-    @patch("src.infrastructure.common.dependencies.is_ai_enabled", return_value=True)
-    async def test_send_empty_message_rejected(
-        self, mock_ai_enabled: MagicMock, client: AsyncClient
-    ) -> None:
+    async def test_send_empty_message_rejected(self, client: AsyncClient, ai_enabled: None) -> None:
         response = await client.post(
             "/api/v1/chat-sessions/1/messages",
             json={"message": ""},
         )
         assert response.status_code == 422
 
-    @patch("src.infrastructure.common.dependencies.is_ai_enabled", return_value=True)
     @patch(
         "src.infrastructure.ai.ai_service.AIService.continue_chat",
         new_callable=AsyncMock,
@@ -156,8 +104,8 @@ class TestSendChatMessage:
     async def test_send_message_success(
         self,
         mock_continue_chat: AsyncMock,
-        mock_ai_enabled: MagicMock,
         client: AsyncClient,
+        ai_enabled: None,
         db_session: AsyncSession,
         test_chapter: Chapter,
     ) -> None:

--- a/backend/tests/test_quiz_sessions.py
+++ b/backend/tests/test_quiz_sessions.py
@@ -8,116 +8,57 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from src.infrastructure.ai.ai_service import MAX_CHAPTER_CONTEXT_CHARS
 from src.models import AIChatSession as AIChatSessionModel
 from src.models import Book, Chapter
-
-
-async def create_quiz_chapter(db_session: AsyncSession, book: Book) -> Chapter:
-    """Create a chapter with xpoint data needed for content extraction."""
-    chapter = Chapter(
-        book_id=book.id,
-        name="Quiz Test Chapter",
-        start_xpoint="/body/text/chapter[1]",
-        end_xpoint="/body/text/chapter[2]",
-    )
-    db_session.add(chapter)
-    await db_session.commit()
-    await db_session.refresh(chapter)
-    return chapter
+from tests.ai_helpers import FakeAgent
 
 
 class TestCreateQuizSession:
-    @patch("src.infrastructure.common.dependencies.is_ai_enabled", return_value=True)
-    @patch("src.infrastructure.ai.ai_service.AIService.start_quiz", new_callable=AsyncMock)
-    @patch(
-        "src.infrastructure.library.services.epub_text_extraction_service"
-        ".EpubTextExtractionService.extract_chapter_text"
-    )
-    @patch(
-        "src.infrastructure.library.repositories.file_repository.FileRepository.get_epub",
-        new_callable=AsyncMock,
-    )
     async def test_create_quiz_session_success(
         self,
-        mock_get_epub: AsyncMock,
-        mock_extract: MagicMock,
-        mock_start_quiz: AsyncMock,
-        mock_ai_enabled: MagicMock,
         client: AsyncClient,
-        db_session: AsyncSession,
-        test_book: Book,
+        ai_enabled: None,
+        epub_chapter: Chapter,
+        chapter_text: MagicMock,
+        quiz_agent: FakeAgent,
     ) -> None:
-        test_book.ebook_file = "/path/to/test.epub"
-        test_book.file_type = "epub"
-        await db_session.commit()
+        chapter_text.return_value = "Chapter content here"
 
-        chapter = await create_quiz_chapter(db_session, test_book)
+        response = await client.post(f"/api/v1/chapters/{epub_chapter.id}/quiz-sessions")
 
-        mock_get_epub.return_value = b"fake epub content"
-        mock_extract.return_value = "Chapter content here"
-
-        mock_start_quiz.return_value = (
-            "**Question 1/5:** What is the main topic?",
-            [{"some": "history"}],
-        )
-
-        response = await client.post(f"/api/v1/chapters/{chapter.id}/quiz-sessions")
-        assert response.status_code == 201
+        assert response.status_code == 201, response.text
         data = response.json()
         assert "session_id" in data
-        assert "message" in data
         assert "Question 1/5" in data["message"]
 
-    @patch("src.infrastructure.common.dependencies.is_ai_enabled", return_value=True)
-    @patch("src.infrastructure.ai.ai_service.get_quiz_agent")
-    @patch("src.infrastructure.ai.ai_service.AIService._respond", new_callable=AsyncMock)
-    @patch(
-        "src.infrastructure.library.services.epub_text_extraction_service"
-        ".EpubTextExtractionService.extract_chapter_text"
-    )
-    @patch(
-        "src.infrastructure.library.repositories.file_repository.FileRepository.get_epub",
-        new_callable=AsyncMock,
-    )
     async def test_create_quiz_session_caps_over_long_chapter_content(
         self,
-        mock_get_epub: AsyncMock,
-        mock_extract: MagicMock,
-        mock_respond: AsyncMock,
-        mock_get_agent: MagicMock,
-        mock_ai_enabled: MagicMock,
         client: AsyncClient,
-        db_session: AsyncSession,
-        test_book: Book,
+        ai_enabled: None,
+        epub_chapter: Chapter,
+        chapter_text: MagicMock,
+        quiz_agent: FakeAgent,
     ) -> None:
-        test_book.ebook_file = "/path/to/test.epub"
-        test_book.file_type = "epub"
-        await db_session.commit()
+        chapter_text.return_value = "x" * (MAX_CHAPTER_CONTEXT_CHARS * 2)
 
-        chapter = await create_quiz_chapter(db_session, test_book)
+        response = await client.post(f"/api/v1/chapters/{epub_chapter.id}/quiz-sessions")
 
-        mock_get_epub.return_value = b"fake epub content"
-        mock_extract.return_value = "x" * (MAX_CHAPTER_CONTEXT_CHARS * 2)
-        mock_respond.return_value = ("**Question 1/5:** ?", [{"some": "history"}])
+        assert response.status_code == 201, response.text
+        # The cap applies to the chapter content, not to the whole prompt, which
+        # also carries the fixed instruction text around it -- so assert on the
+        # content rather than on a prompt length that moves with the wording.
+        [prompt] = quiz_agent.received_prompts
+        assert "x" * MAX_CHAPTER_CONTEXT_CHARS in prompt
+        assert "x" * (MAX_CHAPTER_CONTEXT_CHARS + 1) not in prompt
 
-        response = await client.post(f"/api/v1/chapters/{chapter.id}/quiz-sessions")
-        assert response.status_code == 201
-
-        prompt = mock_respond.call_args.kwargs["prompt"]
-        # The cap applies to the chapter content itself, not the whole prompt
-        # (which also carries the fixed instruction text around it).
-        assert len(prompt) < MAX_CHAPTER_CONTEXT_CHARS + 250
-
-    @patch("src.infrastructure.common.dependencies.is_ai_enabled", return_value=True)
     async def test_create_quiz_session_chapter_not_found(
-        self, mock_ai_enabled: MagicMock, client: AsyncClient
+        self, client: AsyncClient, ai_enabled: None
     ) -> None:
         response = await client.post("/api/v1/chapters/99999/quiz-sessions")
         assert response.status_code == 404
 
 
 class TestSendQuizMessage:
-    @patch("src.infrastructure.common.dependencies.is_ai_enabled", return_value=True)
     async def test_send_message_session_not_found(
-        self, mock_ai_enabled: MagicMock, client: AsyncClient
+        self, client: AsyncClient, ai_enabled: None
     ) -> None:
         response = await client.post(
             "/api/v1/quiz-sessions/99999/messages",
@@ -125,17 +66,13 @@ class TestSendQuizMessage:
         )
         assert response.status_code == 404
 
-    @patch("src.infrastructure.common.dependencies.is_ai_enabled", return_value=True)
-    async def test_send_empty_message_rejected(
-        self, mock_ai_enabled: MagicMock, client: AsyncClient
-    ) -> None:
+    async def test_send_empty_message_rejected(self, client: AsyncClient, ai_enabled: None) -> None:
         response = await client.post(
             "/api/v1/quiz-sessions/1/messages",
             json={"message": ""},
         )
         assert response.status_code == 422
 
-    @patch("src.infrastructure.common.dependencies.is_ai_enabled", return_value=True)
     @patch(
         "src.infrastructure.ai.ai_service.AIService.continue_quiz",
         new_callable=AsyncMock,
@@ -143,16 +80,15 @@ class TestSendQuizMessage:
     async def test_send_message_success(
         self,
         mock_continue_quiz: AsyncMock,
-        mock_ai_enabled: MagicMock,
         client: AsyncClient,
+        ai_enabled: None,
         db_session: AsyncSession,
         test_book: Book,
+        epub_chapter: Chapter,
     ) -> None:
-        chapter = await create_quiz_chapter(db_session, test_book)
-
         ai_chat_session = AIChatSessionModel(
             user_id=1,
-            chapter_id=chapter.id,
+            chapter_id=epub_chapter.id,
             session_type="quiz",
             message_history=[{"some": "history"}],
         )
@@ -171,5 +107,4 @@ class TestSendQuizMessage:
         )
         assert response.status_code == 200
         data = response.json()
-        assert "message" in data
         assert "Question 2/5" in data["message"]

--- a/backend/tests/test_quiz_sessions.py
+++ b/backend/tests/test_quiz_sessions.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from src.infrastructure.ai.ai_service import MAX_CHAPTER_CONTEXT_CHARS
 from src.models import AIChatSession as AIChatSessionModel
 from src.models import Book, Chapter
 
@@ -64,6 +65,46 @@ class TestCreateQuizSession:
         assert "session_id" in data
         assert "message" in data
         assert "Question 1/5" in data["message"]
+
+    @patch("src.infrastructure.common.dependencies.is_ai_enabled", return_value=True)
+    @patch("src.infrastructure.ai.ai_service.get_quiz_agent")
+    @patch("src.infrastructure.ai.ai_service.AIService._respond", new_callable=AsyncMock)
+    @patch(
+        "src.infrastructure.library.services.epub_text_extraction_service"
+        ".EpubTextExtractionService.extract_chapter_text"
+    )
+    @patch(
+        "src.infrastructure.library.repositories.file_repository.FileRepository.get_epub",
+        new_callable=AsyncMock,
+    )
+    async def test_create_quiz_session_caps_over_long_chapter_content(
+        self,
+        mock_get_epub: AsyncMock,
+        mock_extract: MagicMock,
+        mock_respond: AsyncMock,
+        mock_get_agent: MagicMock,
+        mock_ai_enabled: MagicMock,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        test_book: Book,
+    ) -> None:
+        test_book.ebook_file = "/path/to/test.epub"
+        test_book.file_type = "epub"
+        await db_session.commit()
+
+        chapter = await create_quiz_chapter(db_session, test_book)
+
+        mock_get_epub.return_value = b"fake epub content"
+        mock_extract.return_value = "x" * (MAX_CHAPTER_CONTEXT_CHARS * 2)
+        mock_respond.return_value = ("**Question 1/5:** ?", [{"some": "history"}])
+
+        response = await client.post(f"/api/v1/chapters/{chapter.id}/quiz-sessions")
+        assert response.status_code == 201
+
+        prompt = mock_respond.call_args.kwargs["prompt"]
+        # The cap applies to the chapter content itself, not the whole prompt
+        # (which also carries the fixed instruction text around it).
+        assert len(prompt) < MAX_CHAPTER_CONTEXT_CHARS + 250
 
     @patch("src.infrastructure.common.dependencies.is_ai_enabled", return_value=True)
     async def test_create_quiz_session_chapter_not_found(

--- a/backend/tests/unit/infrastructure/ai/test_chapter_content_truncation.py
+++ b/backend/tests/unit/infrastructure/ai/test_chapter_content_truncation.py
@@ -1,0 +1,64 @@
+"""Tests for the chapter-content cap shared by digest, quiz and chat.
+
+Digest already capped its input; quiz and chat did not, so a chapter with no
+real chapter boundaries (the whole book parsed as one chapter) sent the
+entire book as context. `truncate_chapter_content` is the one place all
+three now go through.
+"""
+
+from collections.abc import Generator
+
+import pytest
+import structlog
+from structlog.typing import EventDict
+
+from src.infrastructure.ai.ai_service import (
+    MAX_CHAPTER_CONTEXT_CHARS,
+    truncate_chapter_content,
+)
+
+
+@pytest.fixture
+def captured_logs() -> Generator[list[EventDict], None, None]:
+    """Capture structlog events for the duration of one test."""
+    with structlog.testing.capture_logs() as entries:
+        yield entries
+
+
+class TestTruncateChapterContent:
+    def test_leaves_content_within_the_budget_untouched(
+        self, captured_logs: list[EventDict]
+    ) -> None:
+        content = "w" * MAX_CHAPTER_CONTEXT_CHARS
+
+        result = truncate_chapter_content(content, chapter_id=7)
+
+        assert result == content
+        assert captured_logs == []
+
+    def test_leaves_short_content_untouched(self, captured_logs: list[EventDict]) -> None:
+        result = truncate_chapter_content("short chapter", chapter_id=7)
+
+        assert result == "short chapter"
+        assert captured_logs == []
+
+    def test_truncates_over_budget_content_to_the_cap(self) -> None:
+        content = "x" * (MAX_CHAPTER_CONTEXT_CHARS * 2)
+
+        result = truncate_chapter_content(content, chapter_id=42)
+
+        assert len(result) == MAX_CHAPTER_CONTEXT_CHARS
+        assert result == content[:MAX_CHAPTER_CONTEXT_CHARS]
+
+    def test_logs_chapter_id_and_dropped_length_when_truncating(
+        self, captured_logs: list[EventDict]
+    ) -> None:
+        content = "x" * (MAX_CHAPTER_CONTEXT_CHARS + 250)
+
+        truncate_chapter_content(content, chapter_id=42)
+
+        assert len(captured_logs) == 1
+        event = captured_logs[0]
+        assert event["event"] == "chapter_content_truncated"
+        assert event["chapter_id"] == 42
+        assert event["dropped_chars"] == 250

--- a/backend/tests/unit/infrastructure/ai/test_chapter_content_truncation.py
+++ b/backend/tests/unit/infrastructure/ai/test_chapter_content_truncation.py
@@ -12,10 +12,22 @@ import pytest
 import structlog
 from structlog.typing import EventDict
 
+from src.application.ai.ai_usage_context import AIUsageContext
+from src.domain.common.value_objects.ids import UserId
 from src.infrastructure.ai.ai_service import (
     MAX_CHAPTER_CONTEXT_CHARS,
+    chapter_id_of,
     truncate_chapter_content,
 )
+
+
+def usage_context(entity_type: str, entity_id: int) -> AIUsageContext:
+    return AIUsageContext(
+        user_id=UserId(1),
+        task_type="digest",
+        entity_type=entity_type,
+        entity_id=entity_id,
+    )
 
 
 @pytest.fixture
@@ -62,3 +74,12 @@ class TestTruncateChapterContent:
         assert event["event"] == "chapter_content_truncated"
         assert event["chapter_id"] == 42
         assert event["dropped_chars"] == 250
+
+
+class TestChapterIdOf:
+    def test_reads_the_entity_id_of_a_chapter_context(self) -> None:
+        assert chapter_id_of(usage_context("chapter", 42)) == 42
+
+    def test_refuses_a_context_naming_something_else(self) -> None:
+        with pytest.raises(ValueError, match="chapter usage context"):
+            chapter_id_of(usage_context("highlight", 42))

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -628,7 +628,7 @@ wheels = [
 
 [[package]]
 name = "crossbill-backend"
-version = "0.24.1"
+version = "0.26.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary

- Digest already truncated its input to 10,000 characters; quiz and chat had no cap at all, so a chapter with no real chapter boundaries (the whole book parsed as one chapter, e.g. when an EPUB's nav data is missing) sent the entire book as context on every turn.
- Adds a shared `truncate_chapter_content` helper in `AIService` that head-truncates at the same 10,000-char figure and logs the chapter ID + dropped character count when it fires.
- Routes `generate_digest`, `start_quiz`, and `seed_chat_context` through it. `seed_chat_context` needed a new `chapter_id` parameter threaded from its one caller (`StartChatSessionUseCase`), since it never took a `usage_context` before (it doesn't call the model).

## Test plan

- [x] New unit test on the helper itself: under-cap/at-cap/over-cap boundaries, and log content (chapter_id + dropped_chars) when truncation fires.
- [x] New API-level tests for digest, quiz, and chat confirming truncation actually happens end-to-end (not just at the helper level).
- [x] Full backend suite passes (892 tests).
- [x] pyright clean, import-linter contracts hold, duplication check under threshold.
- [x] Proved the new tests can fail: temporarily disabled truncation, confirmed all 5 new tests failed, reverted.

Fixes #613

---
_Generated by [Claude Code](https://claude.ai/code)_