### PR TITLE
Upgrade actions/cache from v4 to v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
           node-version: "24"
 
       - name: Cache npm dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: node_modules
           key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
@@ -65,7 +65,7 @@ jobs:
         run: echo "version=$(node -p "require('playwright/package.json').version")" >> "$GITHUB_OUTPUT"
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ steps.playwright.outputs.version }}
@@ -142,7 +142,7 @@ jobs:
           node-version: "24"
 
       - name: Cache npm dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: node_modules
           key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Cache npm dependencies
         if: matrix.component == 'frontend'
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: node_modules
           key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}


### PR DESCRIPTION
## Summary
Updates the `actions/cache` GitHub Action from v4 to v6 across CI and release workflows to benefit from the latest features, performance improvements, and security updates.

## Changes
- Updated `actions/cache` version from v4 to v6 in `.github/workflows/ci.yml`:
  - npm dependencies cache step
  - Playwright browsers cache step
  - Second npm dependencies cache step in a different job
- Updated `actions/cache` version from v4 to v6 in `.github/workflows/release.yml`:
  - npm dependencies cache step (conditional on frontend component)

## Notes
All cache configurations remain unchanged; only the action version is updated. The cache keys, paths, and restore-keys logic are preserved as-is.

https://claude.ai/code/session_01Hci1TBznwGMwXWzZdn5gdD