### PR TITLE
Pull-to-refresh for the iOS home-screen app

### DIFF
--- a/frontend/src/components/layout/PullToRefresh.test.tsx
+++ b/frontend/src/components/layout/PullToRefresh.test.tsx
@@ -1,0 +1,85 @@
+import type { BookWithHighlightCount } from '@/api/generated/model';
+import { renderApp } from '@tests/harness/renderApp';
+import { worker } from '@tests/msw/worker';
+import { http, HttpResponse } from 'msw';
+import { expect, test } from 'vitest';
+
+const aBookListItem = (title: string): BookWithHighlightCount => ({
+  id: 1,
+  title,
+  author: 'Ada Lovelace',
+  isbn: null,
+  cover_file: null,
+  cover_blurhash: null,
+  highlight_count: 0,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+});
+
+/**
+ * The books list, whose single title can be changed between requests, so a
+ * refetch is visible on screen rather than only in a request count.
+ */
+function booksApi(title: string) {
+  const state = { title, requests: 0 };
+
+  const handlers = [
+    http.get('/api/v1/books/', () => {
+      state.requests += 1;
+      return HttpResponse.json({
+        items: [aBookListItem(state.title)],
+        total: 1,
+        offset: 0,
+        limit: 32,
+      });
+    }),
+    http.get('/api/v1/books/recently-viewed', () => HttpResponse.json({ items: [] })),
+  ];
+
+  return { handlers, state };
+}
+
+const touchAt = (clientY: number) =>
+  new Touch({ identifier: 1, target: document.body, clientX: 0, clientY });
+
+/** One complete downward drag from the top of the page. */
+const dragDown = (distance: number) => {
+  const dispatch = (type: string, touches: Touch[]) =>
+    window.dispatchEvent(new TouchEvent(type, { touches, cancelable: true, bubbles: true }));
+
+  dispatch('touchstart', [touchAt(0)]);
+  dispatch('touchmove', [touchAt(distance)]);
+  dispatch('touchend', []);
+};
+
+test('pulling the page down past the threshold refetches the data on screen', async () => {
+  const { handlers, state } = booksApi('The Pragmatic Reader');
+  worker.use(...handlers);
+
+  const screen = await renderApp({ path: '/' });
+  await expect.element(screen.getByText('The Pragmatic Reader')).toBeVisible();
+
+  state.title = 'The Refreshed Reader';
+  dragDown(300);
+
+  await expect.element(screen.getByText('The Refreshed Reader')).toBeVisible();
+});
+
+test('a pull that stops short of the threshold refetches nothing', async () => {
+  const { handlers, state } = booksApi('The Pragmatic Reader');
+  worker.use(...handlers);
+
+  const screen = await renderApp({ path: '/' });
+  await expect.element(screen.getByText('The Pragmatic Reader')).toBeVisible();
+
+  state.title = 'The Refreshed Reader';
+  // 30px of pull once resistance is applied: under the 70px threshold.
+  dragDown(60);
+
+  // A refresh fires its request off the touchend handler, so whatever this
+  // drag was going to do has reached the handler well inside this window.
+  await new Promise((resolve) => setTimeout(resolve, 300));
+
+  expect(state.requests).toBe(1);
+  await expect.element(screen.getByText('The Pragmatic Reader')).toBeVisible();
+});

--- a/frontend/src/components/layout/PullToRefresh.tsx
+++ b/frontend/src/components/layout/PullToRefresh.tsx
@@ -1,0 +1,50 @@
+import { PULL_THRESHOLD_PX, usePullToRefresh } from '@/hooks/usePullToRefresh';
+import { useCacheEvents } from '@/lib/cacheEvents';
+import { Box, CircularProgress } from '@mui/material';
+import { type ReactNode } from 'react';
+
+/** How far the content rests below its normal position while refreshing. */
+const REFRESH_OFFSET_PX = 56;
+
+/**
+ * Wraps the app in a pull-down-to-refresh gesture that revalidates server
+ * state, restoring on the iOS home-screen app what Safari's own chrome
+ * provides in the browser.
+ */
+export function PullToRefresh({ children }: { children: ReactNode }) {
+  const { refreshRequested } = useCacheEvents();
+  const { pullDistance, isRefreshing } = usePullToRefresh(refreshRequested);
+
+  const offset = isRefreshing ? REFRESH_OFFSET_PX : pullDistance;
+
+  return (
+    <Box
+      sx={{
+        position: 'relative',
+        transform: offset > 0 ? `translateY(${offset}px)` : 'none',
+        transition: pullDistance > 0 ? 'none' : 'transform 0.2s ease-out',
+      }}
+    >
+      {offset > 0 && (
+        <Box
+          sx={{
+            position: 'absolute',
+            top: -44,
+            left: 0,
+            right: 0,
+            display: 'flex',
+            justifyContent: 'center',
+          }}
+        >
+          <CircularProgress
+            size={28}
+            aria-label="Refreshing"
+            variant={isRefreshing ? 'indeterminate' : 'determinate'}
+            value={Math.min(pullDistance / PULL_THRESHOLD_PX, 1) * 100}
+          />
+        </Box>
+      )}
+      {children}
+    </Box>
+  );
+}

--- a/frontend/src/hooks/usePullToRefresh.ts
+++ b/frontend/src/hooks/usePullToRefresh.ts
@@ -1,0 +1,90 @@
+import { useEffect, useRef, useState } from 'react';
+
+/** Pull distance, in pixels, that arms the refresh. */
+export const PULL_THRESHOLD_PX = 70;
+
+const MAX_PULL_PX = 120;
+const RESISTANCE = 0.5;
+
+/**
+ * Pull-down-to-refresh gesture for the document scroller.
+ *
+ * iOS home-screen web apps have no browser chrome, so Safari's own
+ * pull-to-refresh is unavailable there and the gesture has to be rebuilt from
+ * touch events.
+ */
+export const usePullToRefresh = (onRefresh: () => Promise<unknown>) => {
+  const [pullDistance, setPullDistance] = useState(0);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+
+  const startYRef = useRef<number | null>(null);
+  const pullRef = useRef(0);
+  const refreshingRef = useRef(false);
+  const onRefreshRef = useRef(onRefresh);
+
+  useEffect(() => {
+    onRefreshRef.current = onRefresh;
+  });
+
+  useEffect(() => {
+    const setPull = (value: number) => {
+      pullRef.current = value;
+      setPullDistance(value);
+    };
+
+    const isAtTop = () => window.scrollY <= 0;
+
+    const handleTouchStart = (event: TouchEvent) => {
+      startYRef.current = event.touches.length === 1 && isAtTop() ? event.touches[0].clientY : null;
+    };
+
+    const handleTouchMove = (event: TouchEvent) => {
+      if (startYRef.current === null || refreshingRef.current || !isAtTop()) return;
+
+      const delta = event.touches[0].clientY - startYRef.current;
+      if (delta <= 0) {
+        // Pulled back up: release the gesture so the page scrolls normally.
+        setPull(0);
+        return;
+      }
+
+      // Only a non-passive listener may call this, which is why the listeners
+      // are registered by hand instead of through React's touch props.
+      event.preventDefault();
+      setPull(Math.min(delta * RESISTANCE, MAX_PULL_PX));
+    };
+
+    const handleTouchEnd = () => {
+      const shouldRefresh = pullRef.current >= PULL_THRESHOLD_PX;
+      startYRef.current = null;
+      setPull(0);
+      if (!shouldRefresh) return;
+
+      refreshingRef.current = true;
+      setIsRefreshing(true);
+      void onRefreshRef.current().finally(() => {
+        refreshingRef.current = false;
+        setIsRefreshing(false);
+      });
+    };
+
+    const handleTouchCancel = () => {
+      startYRef.current = null;
+      setPull(0);
+    };
+
+    window.addEventListener('touchstart', handleTouchStart, { passive: true });
+    window.addEventListener('touchmove', handleTouchMove, { passive: false });
+    window.addEventListener('touchend', handleTouchEnd, { passive: true });
+    window.addEventListener('touchcancel', handleTouchCancel, { passive: true });
+
+    return () => {
+      window.removeEventListener('touchstart', handleTouchStart);
+      window.removeEventListener('touchmove', handleTouchMove);
+      window.removeEventListener('touchend', handleTouchEnd);
+      window.removeEventListener('touchcancel', handleTouchCancel);
+    };
+  }, []);
+
+  return { pullDistance, isRefreshing };
+};

--- a/frontend/src/lib/cacheEvents.ts
+++ b/frontend/src/lib/cacheEvents.ts
@@ -124,6 +124,15 @@ export const useCacheEvents = () => {
        */
       embeddingBackfillChanged: () => invalidate(getGetActiveBackfillQueryKey()),
 
+      /**
+       * The user asked for a full refresh, by pulling the page down.
+       *
+       * The one event that names no key at all: nothing specific changed, the
+       * whole cache is simply suspect. The promise settles once the active
+       * refetches do, so the caller can keep a spinner up until then.
+       */
+      refreshRequested: () => queryClient.invalidateQueries(),
+
       /** A highlight label was renamed or recoloured. Book details embeds labels. */
       highlightLabelsChanged: (bookId: number) =>
         invalidate(getGetBookDetailsQueryKey(bookId), getGetBookHighlightLabelsQueryKey(bookId)),

--- a/frontend/src/lib/queryClient.ts
+++ b/frontend/src/lib/queryClient.ts
@@ -5,6 +5,10 @@ export const queryClient = new QueryClient({
     queries: {
       staleTime: 1000 * 60 * 5, // 5 minutes
       retry: 1,
+      // A home-screen PWA is resumed, not reloaded, so a focus refetch is the
+      // only thing that revalidates on reopening. Plain `true` defers to
+      // staleTime and would skip it for the first five minutes.
+      refetchOnWindowFocus: 'always',
     },
   },
 });

--- a/frontend/src/routes/__root.tsx
+++ b/frontend/src/routes/__root.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable react-refresh/only-export-components */
 import { AppBar } from '@/components/layout/AppBar';
+import { PullToRefresh } from '@/components/layout/PullToRefresh';
 import { Box, CircularProgress } from '@mui/material';
 import { Navigate, Outlet, createRootRoute, useLocation } from '@tanstack/react-router';
 import { AuthProvider, useAuth } from '../context/AuthContext';
@@ -39,10 +40,10 @@ function AuthenticatedRoutes() {
   }
 
   return (
-    <Box>
+    <PullToRefresh>
       {!isPublicPage && <AppBar />}
       <Outlet />
-    </Box>
+    </PullToRefresh>
   );
 }
 

--- a/frontend/src/theme/theme.ts
+++ b/frontend/src/theme/theme.ts
@@ -223,6 +223,15 @@ export const theme = createTheme({
     '0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1)',
   ],
   components: {
+    MuiCssBaseline: {
+      styleOverrides: {
+        // Kills the iOS rubber-band bounce, so a downward drag at the top of
+        // the page belongs to the pull-to-refresh gesture alone.
+        'html, body': {
+          overscrollBehaviorY: 'contain',
+        },
+      },
+    },
     MuiButton: {
       styleOverrides: {
         root: {


### PR DESCRIPTION
## Why

Safari's pull-to-refresh lives in browser chrome, which a `display: standalone`
web app does not have. On the iPhone home-screen app the gesture is simply
missing, so refreshing meant leaving the app.

## What

**Refetch on resume** (`71d0a2cc`) — `refetchOnWindowFocus: 'always'`. A
home-screen PWA is resumed rather than reloaded, and the default `true` defers
to the 5-minute `staleTime`, so reopening the app showed stale data.

**The gesture** (`b720fa58`):

- `usePullToRefresh` — document-level touch listeners, registered by hand
  because `preventDefault()` needs a non-passive `touchmove` listener. 70px
  threshold, 0.5 resistance, 120px cap.
- `PullToRefresh` — wraps the root route; translates the page under the finger
  and holds it 56px down with a spinner until the refresh settles.
- `refreshRequested` in `cacheEvents.ts` — the one event that names no query
  key: nothing specific changed, the whole cache is suspect.
- `overscroll-behavior-y: contain` on html/body, so iOS's rubber-band bounce
  does not compete with the gesture.

## Tests

Two route-level cases in `PullToRefresh.test.tsx`: a 300px drag swaps the book
title on screen, a 60px drag leaves the request count at 1. Both were confirmed
to fail with the threshold broken.

Tried by hand on the iOS home-screen app and in Chrome Android device emulation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TdZ1gDqS6g14213Zpt5MJo