### PR TITLE
Fix lint on readingStages: derive the stage type from the progression

### DIFF
--- a/frontend/src/pages/BookPage/Reflection/readingStages.ts
+++ b/frontend/src/pages/BookPage/Reflection/readingStages.ts
@@ -6,9 +6,7 @@ export const READING_STAGE_PROGRESSION = [
   'reflected',
 ] as const;
 
-const READING_STAGES = [...READING_STAGE_PROGRESSION, 'did_not_finish'] as const;
-
-export type ReadingStageValue = (typeof READING_STAGES)[number];
+export type ReadingStageValue = (typeof READING_STAGE_PROGRESSION)[number] | 'did_not_finish';
 
 export const READING_STAGE_LABELS: Record<ReadingStageValue, string> = {
   to_read: 'To read',


### PR DESCRIPTION
Fixes the `lint` failure on `main` from #639:

```
frontend/src/pages/BookPage/Reflection/readingStages.ts
  9:7  error  'READING_STAGES' is assigned a value but only used as a type  @typescript-eslint/no-unused-vars
```

## Why it slipped through

`READING_STAGES` existed only to back `ReadingStageValue`, and two checks pull in opposite directions on that:

- **exported** → knip fails: an export no other file imports.
- **not exported** → eslint fails: a value used only as a type.

In #639 I ran eslint before making it module-local for knip, and re-ran only knip and type-check afterwards. My fault, not a flaky check.

## The fix

Drop the array; build the type from the progression plus the exit stage.

```ts
export type ReadingStageValue = (typeof READING_STAGE_PROGRESSION)[number] | 'did_not_finish';
```

`READING_STAGE_LABELS` still has to cover all six keys, so the type stays exhaustive. This also reads closer to what the domain actually says: one of the progression, or the exit from it.

## Note for #632

#638 suggested that ticket build its filter control from a `READING_STAGES` array. That array no longer exists — #632 should add it back, exported, at the point where its control imports it. Both checks pass once something outside this module uses it.

Verified after the final edit this time: eslint, tsc, knip, prettier, and the 72 frontend tests all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gt5L7QzdBTSPjyWkRZS2Q4
