### PR TITLE
Filter highlights by highlighted date range

### DIFF
--- a/frontend/.jscpd.json
+++ b/frontend/.jscpd.json
@@ -11,5 +11,5 @@
   "minLines": 5,
   "minTokens": 50,
   "reporters": ["ai", "threshold"],
-  "threshold": 1.7
+  "threshold": 1.4
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,6 +26,7 @@
     "@emotion/styled": "^11.14.1",
     "@mui/icons-material": "^9.2.0",
     "@mui/material": "^9.2.0",
+    "@mui/x-date-pickers": "^9.12.0",
     "@tanstack/react-query": "^5.101.4",
     "@tanstack/react-router": "^1.170.18",
     "axios": "^1.19.0",

--- a/frontend/src/components/cards/HighlightCard.tsx
+++ b/frontend/src/components/cards/HighlightCard.tsx
@@ -2,6 +2,7 @@ import type { Bookmark, Highlight } from '@/api/generated/model';
 import { HoverableCardActionArea } from '@/components/cards/HoverableCardActionArea';
 import { MetadataRow } from '@/components/cards/MetadataRow.tsx';
 import { TagChipList } from '@/components/TagChipList.tsx';
+import { formatHighlightDate } from '@/pages/BookPage/common/highlightDates.ts';
 import { LabelIndicator } from '@/pages/BookPage/common/LabelIndicator.tsx';
 import { NotOnDeviceChip } from '@/pages/BookPage/common/NotOnDeviceChip.tsx';
 import { BookmarkFilledIcon, DateIcon, FlashcardsIcon, QuoteIcon } from '@/theme/Icons.tsx';
@@ -54,11 +55,7 @@ const Footer = ({ highlight, bookmark }: FooterProps) => {
               theme.palette.mode === 'light' ? `theme.palette.secondary.main` : 'secondary.light',
           })}
           items={[
-            new Date(highlight.datetime).toLocaleDateString('en-US', {
-              year: 'numeric',
-              month: 'long',
-              day: 'numeric',
-            }),
+            formatHighlightDate(highlight.datetime),
             highlight.page && `Page ${highlight.page}`,
             hasBookmark && (
               <BookmarkFilledIcon sx={{ fontSize: 16, verticalAlign: 'middle', ml: 1, mt: -0.5 }} />

--- a/frontend/src/pages/BookPage/Highlights/HighlightDateFilter.tsx
+++ b/frontend/src/pages/BookPage/Highlights/HighlightDateFilter.tsx
@@ -1,0 +1,122 @@
+import { useResetOnChange } from '@/hooks/useResetOnChange.ts';
+import {
+  DATE_SEARCH_FORMAT,
+  getLastSevenDaysFrom,
+  isHighlightDateRangeReversed,
+  type HighlightDateRange,
+} from '@/pages/BookPage/common/highlightDates.ts';
+import { Box, Button, FormHelperText, Typography } from '@mui/material';
+import { AdapterLuxon } from '@mui/x-date-pickers/AdapterLuxon';
+import { DatePicker } from '@mui/x-date-pickers/DatePicker';
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
+import type { DateValidationError, PickerChangeHandlerContext } from '@mui/x-date-pickers/models';
+import { DateTime } from 'luxon';
+import { useState } from 'react';
+
+interface HighlightDateFilterProps extends HighlightDateRange {
+  onChange: (range: HighlightDateRange) => void;
+}
+
+const asPickerValue = (value: string | undefined): DateTime | null =>
+  value ? DateTime.fromFormat(value, DATE_SEARCH_FORMAT) : null;
+
+const validationMessage = (
+  error: DateValidationError | null,
+  field: keyof HighlightDateRange,
+  oppositeBound: string | undefined
+): string | undefined => {
+  if (!error) return undefined;
+  if (error === 'maxDate' && field === 'from' && oppositeBound)
+    return 'From must be on or before To.';
+  if (error === 'minDate' && field === 'to' && oppositeBound) return 'To must be on or after From.';
+  if (error === 'minDate' || error === 'maxDate') return 'Enter a date in the allowed range.';
+  return 'Enter a valid date.';
+};
+
+export const HighlightDateFilter = ({ from, to, onChange }: HighlightDateFilterProps) => {
+  const [fromError, setFromError] = useState<DateValidationError | null>(null);
+  const [toError, setToError] = useState<DateValidationError | null>(null);
+  const [fromValue, setFromValue] = useState<DateTime<boolean> | null>(() => asPickerValue(from));
+  const [toValue, setToValue] = useState<DateTime<boolean> | null>(() => asPickerValue(to));
+  const appliedFromValue = asPickerValue(from);
+  const appliedToValue = asPickerValue(to);
+  const rangeIsReversed = isHighlightDateRangeReversed({ from, to });
+
+  useResetOnChange([from], () => {
+    setFromValue(appliedFromValue);
+    setFromError(null);
+  });
+  useResetOnChange([to], () => {
+    setToValue(appliedToValue);
+    setToError(null);
+  });
+
+  const commitDate = (
+    key: keyof HighlightDateRange,
+    value: DateTime | null,
+    context: PickerChangeHandlerContext<DateValidationError>
+  ) => {
+    if (key === 'from') setFromValue(value);
+    else setToValue(value);
+    if (context.validationError) return;
+    onChange({ from, to, [key]: value?.toFormat(DATE_SEARCH_FORMAT) });
+  };
+
+  const applyLastSevenDays = () => {
+    const presetFrom = getLastSevenDaysFrom();
+    setFromValue(asPickerValue(presetFrom));
+    setToValue(null);
+    setFromError(null);
+    setToError(null);
+    onChange({ from: presetFrom, to: undefined });
+  };
+
+  return (
+    <LocalizationProvider dateAdapter={AdapterLuxon}>
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+        <Typography variant="h6" sx={{ fontSize: '1rem', fontWeight: 600 }}>
+          Date highlighted
+        </Typography>
+        <DatePicker
+          label="From"
+          value={fromValue}
+          maxDate={rangeIsReversed ? undefined : (appliedToValue ?? undefined)}
+          onChange={(value, context) => commitDate('from', value, context)}
+          onError={setFromError}
+          slotProps={{
+            field: { clearable: true },
+            textField: {
+              fullWidth: true,
+              size: 'small',
+              helperText: validationMessage(fromError, 'from', to),
+            },
+          }}
+        />
+        <DatePicker
+          label="To"
+          value={toValue}
+          minDate={rangeIsReversed ? undefined : (appliedFromValue ?? undefined)}
+          onChange={(value, context) => commitDate('to', value, context)}
+          onError={setToError}
+          slotProps={{
+            field: { clearable: true },
+            textField: {
+              fullWidth: true,
+              size: 'small',
+              helperText: validationMessage(toError, 'to', from),
+            },
+          }}
+        />
+        {rangeIsReversed && <FormHelperText error>From must be on or before To.</FormHelperText>}
+        <Button
+          variant="text"
+          size="small"
+          sx={{ alignSelf: 'flex-start' }}
+          onClick={applyLastSevenDays}
+        >
+          Last 7 Days
+        </Button>
+      </Box>
+    </LocalizationProvider>
+  );
+};

--- a/frontend/src/pages/BookPage/Highlights/HighlightDateFilter.tsx
+++ b/frontend/src/pages/BookPage/Highlights/HighlightDateFilter.tsx
@@ -34,6 +34,7 @@ const validationMessage = (
 };
 
 export const HighlightDateFilter = ({ from, to, onChange }: HighlightDateFilterProps) => {
+  const dateLocale = Intl.DateTimeFormat().resolvedOptions().locale;
   const [fromError, setFromError] = useState<DateValidationError | null>(null);
   const [toError, setToError] = useState<DateValidationError | null>(null);
   const [fromValue, setFromValue] = useState<DateTime<boolean> | null>(() => asPickerValue(from));
@@ -72,7 +73,7 @@ export const HighlightDateFilter = ({ from, to, onChange }: HighlightDateFilterP
   };
 
   return (
-    <LocalizationProvider dateAdapter={AdapterLuxon}>
+    <LocalizationProvider dateAdapter={AdapterLuxon} adapterLocale={dateLocale}>
       <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
         <Typography variant="h6" sx={{ fontSize: '1rem', fontWeight: 600 }}>
           Date highlighted

--- a/frontend/src/pages/BookPage/Highlights/HighlightsPage.test.tsx
+++ b/frontend/src/pages/BookPage/Highlights/HighlightsPage.test.tsx
@@ -4,7 +4,7 @@ import { renderApp } from '@tests/harness/renderApp';
 import { bookApi } from '@tests/msw/bookApi';
 import { worker } from '@tests/msw/worker';
 import { http, HttpResponse } from 'msw';
-import { expect, test } from 'vitest';
+import { expect, test, vi } from 'vitest';
 import { page, userEvent } from 'vitest/browser';
 
 type Screen = Awaited<ReturnType<typeof renderApp>>;
@@ -196,5 +196,31 @@ test('places the preset above mobile tabs and exposes active date filters access
     expect(window.location.search).not.toContain('to=');
   } finally {
     await page.viewport(1440, 900);
+  }
+});
+
+test('uses the browser regional locale for date field order', async () => {
+  const originalResolvedOptions = Intl.DateTimeFormat.prototype.resolvedOptions;
+  const resolvedOptions = vi
+    .spyOn(Intl.DateTimeFormat.prototype, 'resolvedOptions')
+    .mockImplementation(function (this: Intl.DateTimeFormat) {
+      return { ...originalResolvedOptions.call(this), locale: 'fi-FI' };
+    });
+
+  try {
+    const { handlers } = bookApi({ book: aDateRangeBook() });
+    worker.use(...handlers);
+    const screen = await renderApp({ path: '/book/1/highlights?from=2026-07-05' });
+    const field = screen.getByRole('group', { name: 'From' });
+    await expect.element(field).toBeVisible();
+    await expect.element(field).toHaveTextContent('05.07.2026');
+
+    const sections = field
+      .getByRole('spinbutton')
+      .elements()
+      .map((element) => element.getAttribute('aria-label'));
+    expect(sections).toEqual(['Day', 'Month', 'Year']);
+  } finally {
+    resolvedOptions.mockRestore();
   }
 });

--- a/frontend/src/pages/BookPage/Highlights/HighlightsPage.test.tsx
+++ b/frontend/src/pages/BookPage/Highlights/HighlightsPage.test.tsx
@@ -1,0 +1,200 @@
+import { getLastSevenDaysFrom } from '@/pages/BookPage/common/highlightDates.ts';
+import { aBookDetails, aChapter, aHighlight } from '@tests/fixtures/book';
+import { renderApp } from '@tests/harness/renderApp';
+import { bookApi } from '@tests/msw/bookApi';
+import { worker } from '@tests/msw/worker';
+import { http, HttpResponse } from 'msw';
+import { expect, test } from 'vitest';
+import { page, userEvent } from 'vitest/browser';
+
+type Screen = Awaited<ReturnType<typeof renderApp>>;
+
+const expectHighlightInChapter = async (screen: Screen, chapter: string, highlight: string) => {
+  await expect
+    .element(screen.getByRole('list', { name: `Highlights in ${chapter}` }).getByText(highlight))
+    .toBeVisible();
+};
+
+const aDateRangeBook = () =>
+  aBookDetails({
+    bookmarks: [
+      {
+        id: 900,
+        book_id: 1,
+        highlight_id: 304,
+        created_at: '2026-07-06T00:00:00Z',
+      },
+    ],
+    chapters: [
+      aChapter({
+        id: 10,
+        name: 'Boundary chapter',
+        highlights: [
+          aHighlight({ id: 301, text: 'At midnight', datetime: '2026-07-05 00:00:00' }),
+          aHighlight({ id: 302, text: 'Late that night', datetime: '2026-07-05 23:59:59' }),
+          aHighlight({ id: 303, text: 'The next day', datetime: '2026-07-06 00:00:00' }),
+        ],
+      }),
+      aChapter({
+        id: 20,
+        name: 'Filtered chapter',
+        highlights: [
+          aHighlight({
+            id: 304,
+            chapter_id: 20,
+            text: 'Before the range',
+            datetime: '2026-07-04 23:59:59',
+          }),
+        ],
+      }),
+    ],
+  });
+
+test('hydrates an inclusive range from the URL and clears each bound independently', async () => {
+  const { handlers } = bookApi({ book: aDateRangeBook() });
+  worker.use(...handlers);
+
+  const screen = await renderApp({
+    path: '/book/1/highlights?from=2026-07-05&to=2026-07-05',
+  });
+
+  await expect.element(screen.getByText('At midnight')).toBeVisible();
+  await expect.element(screen.getByText('Late that night')).toBeVisible();
+  expect(screen.getByText('The next day').elements()).toHaveLength(0);
+  expect(screen.getByText('Filtered chapter').elements()).toHaveLength(0);
+  await expect.element(screen.getByText('No bookmarks match the active filters.')).toBeVisible();
+  await expect.element(screen.getByRole('group', { name: 'From' })).toBeVisible();
+  await expect.element(screen.getByRole('group', { name: 'To' })).toBeVisible();
+
+  const fromField = screen.getByRole('group', { name: 'From' });
+  const validSearch = window.location.search;
+  await userEvent.click(fromField.getByRole('spinbutton', { name: 'Year' }));
+  await userEvent.keyboard('1000');
+  await expect.element(screen.getByText('Enter a date in the allowed range.')).toBeVisible();
+  expect(window.location.search).toBe(validSearch);
+
+  await userEvent.hover(fromField);
+  await userEvent.click(fromField.getByRole('button', { name: 'Clear' }));
+
+  await expectHighlightInChapter(screen, 'Filtered chapter', 'Before the range');
+  expect(window.location.search).not.toContain('from=');
+  expect(window.location.search).toContain('to=2026-07-05');
+
+  const toField = screen.getByRole('group', { name: 'To' });
+  await userEvent.hover(toField);
+  await userEvent.click(toField.getByRole('button', { name: 'Clear' }));
+
+  await expect.element(screen.getByText('The next day')).toBeVisible();
+  await expect.element(screen.getByText('No bookmarks yet.')).not.toBeInTheDocument();
+  await expectHighlightInChapter(screen, 'Filtered chapter', 'Before the range');
+  expect(window.location.search).not.toContain('from=');
+  expect(window.location.search).not.toContain('to=');
+
+  screen.router.history.push('/book/1/highlights?from=not-a-date&to=2026-07-05');
+  await expect.poll(() => window.location.search).not.toContain('from=');
+  expect(window.location.search).toContain('to=2026-07-05');
+
+  await screen.router.navigate({
+    to: '/book/$bookId/highlights',
+    params: { bookId: '1' },
+    search: { from: '2026-07-06', to: '2026-07-05' },
+    replace: true,
+  });
+
+  await expect.element(screen.getByText('From must be on or before To.')).toBeVisible();
+  await expect.element(screen.getByText('The next day')).toBeVisible();
+});
+
+test('composes date, search, tag, and label filters and shows the generic empty state', async () => {
+  const matching = aHighlight({
+    id: 401,
+    text: 'All filters match',
+    datetime: '2026-07-05 12:00:00',
+    tags: [{ id: 1, name: 'Keep', tag_group_id: null }],
+    label: { highlight_style_id: 10, text: 'Important', ui_color: '#ff0000' },
+  });
+  const searchChapters = [
+    aChapter({
+      id: 10,
+      highlights: [
+        matching,
+        aHighlight({
+          id: 402,
+          text: 'Wrong tag',
+          datetime: '2026-07-05 12:00:00',
+          tags: [{ id: 2, name: 'Other', tag_group_id: null }],
+          label: { highlight_style_id: 10 },
+        }),
+        aHighlight({
+          id: 403,
+          text: 'Wrong label',
+          datetime: '2026-07-05 12:00:00',
+          tags: [{ id: 1, name: 'Keep', tag_group_id: null }],
+          label: { highlight_style_id: 11 },
+        }),
+        aHighlight({
+          id: 404,
+          text: 'Wrong date',
+          datetime: '2026-07-06 12:00:00',
+          tags: [{ id: 1, name: 'Keep', tag_group_id: null }],
+          label: { highlight_style_id: 10 },
+        }),
+      ],
+    }),
+  ];
+  const { handlers } = bookApi({
+    book: aBookDetails({
+      tags: [{ id: 1, name: 'Keep', tag_group_id: null }],
+      chapters: searchChapters,
+    }),
+  });
+  worker.use(
+    ...handlers,
+    http.get('/api/v1/books/:bookId/highlights', () =>
+      HttpResponse.json({ chapters: searchChapters, total: 4 })
+    )
+  );
+
+  const screen = await renderApp({
+    path: '/book/1/highlights?search=filters&tagId=1&labelId=10&from=2026-07-05&to=2026-07-05',
+  });
+
+  await expect.element(screen.getByText('All filters match')).toBeVisible();
+  expect(screen.getByText('Wrong tag').elements()).toHaveLength(0);
+  expect(screen.getByText('Wrong label').elements()).toHaveLength(0);
+  expect(screen.getByText('Wrong date').elements()).toHaveLength(0);
+
+  await screen.router.navigate({
+    to: '/book/$bookId/highlights',
+    params: { bookId: '1' },
+    search: (previous) => ({ ...previous, from: '2026-08-01', to: undefined }),
+    replace: true,
+  });
+
+  await expect.element(screen.getByText('No highlights match the filters.')).toBeVisible();
+});
+
+test('places the preset above mobile tabs and exposes active date filters accessibly', async () => {
+  await page.viewport(400, 800);
+  try {
+    const { handlers } = bookApi({ book: aDateRangeBook() });
+    worker.use(...handlers);
+
+    const screen = await renderApp({ path: '/book/1/highlights?to=2026-07-05' });
+    const filterButton = screen.getByRole('button', { name: 'Open filters (filters active)' });
+    await expect.element(filterButton).toBeVisible();
+    await userEvent.click(filterButton);
+
+    await expect.element(screen.getByText('Date highlighted')).toBeVisible();
+    await expect.element(screen.getByRole('group', { name: 'From' })).toBeVisible();
+    await expect.element(screen.getByRole('group', { name: 'To' })).toBeVisible();
+    await expect.element(screen.getByRole('tab', { name: 'Chapters' })).toBeVisible();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Last 7 Days' }));
+
+    await expect.poll(() => window.location.search).toContain(`from=${getLastSevenDaysFrom()}`);
+    expect(window.location.search).not.toContain('to=');
+  } finally {
+    await page.viewport(1440, 900);
+  }
+});

--- a/frontend/src/pages/BookPage/Highlights/HighlightsPage.tsx
+++ b/frontend/src/pages/BookPage/Highlights/HighlightsPage.tsx
@@ -12,13 +12,18 @@ import { ContentWithSidebar } from '@/components/layout/Layouts.tsx';
 import { PageTitle } from '@/components/typography/PageTitle.tsx';
 import { useResetOnChange } from '@/hooks/useResetOnChange.ts';
 import { useBookPage } from '@/pages/BookPage/BookPageContext';
+import {
+  filterChaptersByHighlightDate,
+  parseDateSearchParam,
+  type HighlightDateRange,
+} from '@/pages/BookPage/common/highlightDates.ts';
 import { ListSearchSortHeader } from '@/pages/BookPage/common/ListSearchSortHeader.tsx';
 import { useBookTabFilters } from '@/pages/BookPage/common/useBookTabFilters.ts';
 import { useHighlightDialog } from '@/pages/BookPage/Highlights/hooks/useHighlightDialog.ts';
 import { Box, Divider } from '@mui/material';
-import { useNavigate, useSearch } from '@tanstack/react-router';
+import { useLocation, useNavigate, useSearch } from '@tanstack/react-router';
 import { keyBy } from 'lodash';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { FilterFab } from '../common/FilterFab.tsx';
 import { BookmarkList } from '../navigation/BookmarkList.tsx';
@@ -26,15 +31,20 @@ import { ChapterNav, type ChapterNavigationData } from '../navigation/ChapterNav
 import { FilterDrawer, type FilterTab } from '../navigation/FilterDrawer.tsx';
 import { HighlightLabelsList } from '../navigation/HighlightLabelsList.tsx';
 import { TagsList } from '../navigation/TagsList/TagsList.tsx';
+import { HighlightDateFilter } from './HighlightDateFilter.tsx';
 import { HighlightsList, type ChapterData } from './HighlightsList.tsx';
 import { HighlightViewDialog } from './HighlightViewDialog';
 
 export const HighlightsPage = () => {
   const { book, isDesktop, leftSidebarEl, fabContainerEl } = useBookPage();
 
-  const { search: urlSearch, labelId: urlLabelId } = useSearch({
-    from: '/book/$bookId/highlights',
-  });
+  const {
+    search: urlSearch,
+    labelId: urlLabelId,
+    from: dateFrom,
+    to: dateTo,
+  } = useSearch({ from: '/book/$bookId/highlights' });
+  const locationSearch = useLocation({ select: (location) => location.searchStr });
   const navigate = useNavigate({ from: '/book/$bookId/highlights' });
 
   const { searchText, selectedTagId, handleSearch, handleTagClick, handleChapterClick } =
@@ -43,9 +53,26 @@ export const HighlightsPage = () => {
   const [isReversed, setIsReversed] = useState(false);
   const [filterDrawerOpen, setFilterDrawerOpen] = useState(false);
 
-  const filterEnabled = !!selectedLabelId || !!selectedTagId;
+  const hasDateValues = !!dateFrom || !!dateTo;
+  const filterEnabled = !!selectedLabelId || !!selectedTagId || hasDateValues;
 
   useResetOnChange([urlLabelId], () => setSelectedLabelId(urlLabelId));
+
+  useEffect(() => {
+    const rawSearch = new URLSearchParams(locationSearch);
+    const invalidFrom = rawSearch.has('from') && !parseDateSearchParam(rawSearch.get('from'));
+    const invalidTo = rawSearch.has('to') && !parseDateSearchParam(rawSearch.get('to'));
+    if (!invalidFrom && !invalidTo) return;
+
+    navigate({
+      search: (prev) => ({
+        ...prev,
+        from: invalidFrom ? undefined : prev.from,
+        to: invalidTo ? undefined : prev.to,
+      }),
+      replace: true,
+    });
+  }, [locationSearch, navigate]);
 
   // Fetch available tags for the highlight dialog
   const { data: tagsResponse } = useGetTags(book.id);
@@ -55,6 +82,16 @@ export const HighlightsPage = () => {
       setSelectedLabelId(newLabelId || undefined);
       navigate({
         search: (prev) => ({ ...prev, labelId: newLabelId || undefined }),
+        replace: true,
+      });
+    },
+    [navigate]
+  );
+
+  const handleDateRangeChange = useCallback(
+    ({ from, to }: HighlightDateRange) => {
+      navigate({
+        search: (prev) => ({ ...prev, from, to }),
         replace: true,
       });
     },
@@ -86,9 +123,9 @@ export const HighlightsPage = () => {
       ? bookSearch.chapters
       : book.chapters.filter((chapter) => chapter.highlights.length > 0);
 
-    const result = filterChaptersByLabel(
-      selectedLabelId,
-      filterChaptersByTag(selectedTagId, toFilter)
+    const result = filterChaptersByHighlightDate(
+      filterChaptersByLabel(selectedLabelId, filterChaptersByTag(selectedTagId, toFilter)),
+      { from: dateFrom, to: dateTo }
     ).map((chapter) => ({
       id: chapter.id,
       name: chapter.name || 'Unknown Chapter',
@@ -111,6 +148,8 @@ export const HighlightsPage = () => {
     book.chapters,
     selectedTagId,
     selectedLabelId,
+    dateFrom,
+    dateTo,
   ]);
 
   const allHighlights = useMemo(() => {
@@ -123,21 +162,11 @@ export const HighlightsPage = () => {
 
   const navData = useHighlightsPageData(chapters);
 
-  const emptyMessage = useMemo(() => {
-    if (bookSearch.showSearchResults) {
-      if (selectedTagId && selectedLabelId)
-        return 'No highlights found matching your search with the selected tag and label.';
-      if (selectedTagId) return 'No highlights found matching your search with the selected tag.';
-      if (selectedLabelId)
-        return 'No highlights found matching your search with the selected label.';
-      return 'No highlights found matching your search.';
-    }
-    if (selectedTagId && selectedLabelId)
-      return 'No highlights found with the selected tag and label.';
-    if (selectedTagId) return 'No highlights found with the selected tag.';
-    if (selectedLabelId) return 'No highlights found with the selected label.';
-    return 'No chapters found for this book.';
-  }, [bookSearch.showSearchResults, selectedTagId, selectedLabelId]);
+  const listFilterActive =
+    bookSearch.showSearchResults || !!selectedTagId || !!selectedLabelId || hasDateValues;
+  const emptyMessage = listFilterActive
+    ? 'No highlights match the filters.'
+    : 'No chapters found for this book.';
 
   const filterTabs = useHighlightsFilterTabs({
     navChapters: navData.chapters,
@@ -148,6 +177,7 @@ export const HighlightsPage = () => {
     allHighlights,
     selectedTagId,
     selectedLabelId,
+    filterActive: listFilterActive,
     handleChapterClick,
     handleTagClick,
     handleLabelClick,
@@ -169,6 +199,9 @@ export const HighlightsPage = () => {
             onTagClick={handleTagClick}
             selectedLabelId={selectedLabelId}
             onLabelClick={handleLabelClick}
+            dateFrom={dateFrom}
+            dateTo={dateTo}
+            onDateRangeChange={handleDateRangeChange}
           />,
           leftSidebarEl
         )}
@@ -199,6 +232,7 @@ export const HighlightsPage = () => {
               bookmarks={book.bookmarks}
               allHighlights={allHighlights}
               onBookmarkClick={handleBookmarkClick}
+              filterActive={listFilterActive}
             />
             <Divider />
             <ChapterNav
@@ -237,6 +271,9 @@ export const HighlightsPage = () => {
             open={filterDrawerOpen}
             onClose={() => setFilterDrawerOpen(false)}
             tabs={filterTabs}
+            header={
+              <HighlightDateFilter from={dateFrom} to={dateTo} onChange={handleDateRangeChange} />
+            }
           />
         </>
       )}
@@ -264,6 +301,9 @@ interface HighlightsSidebarProps {
   onTagClick: (tagId: number | null) => void;
   selectedLabelId: number | undefined;
   onLabelClick: (labelId: number | null) => void;
+  dateFrom: string | undefined;
+  dateTo: string | undefined;
+  onDateRangeChange: (range: HighlightDateRange) => void;
 }
 
 const HighlightsSidebar = ({
@@ -274,10 +314,14 @@ const HighlightsSidebar = ({
   onTagClick,
   selectedLabelId,
   onLabelClick,
+  dateFrom,
+  dateTo,
+  onDateRangeChange,
 }: HighlightsSidebarProps) => (
   <>
     <Divider sx={{ mb: 4 }} />
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+      <HighlightDateFilter from={dateFrom} to={dateTo} onChange={onDateRangeChange} />
       <TagsList
         tags={tags}
         tagGroups={tagGroups}
@@ -303,6 +347,7 @@ interface UseHighlightsFilterTabsParams {
   allHighlights: Highlight[];
   selectedTagId: number | undefined;
   selectedLabelId: number | undefined;
+  filterActive: boolean;
   handleChapterClick: (chapterId: number) => void;
   handleTagClick: (tagId: number | null) => void;
   handleLabelClick: (labelId: number | null) => void;
@@ -319,6 +364,7 @@ const useHighlightsFilterTabs = ({
   allHighlights,
   selectedTagId,
   selectedLabelId,
+  filterActive,
   handleChapterClick,
   handleTagClick,
   handleLabelClick,
@@ -375,6 +421,7 @@ const useHighlightsFilterTabs = ({
           <BookmarkList
             bookmarks={bookmarks}
             allHighlights={allHighlights}
+            filterActive={filterActive}
             onBookmarkClick={(id) => {
               handleBookmarkClick(id);
               setFilterDrawerOpen(false);
@@ -394,6 +441,7 @@ const useHighlightsFilterTabs = ({
       selectedTagId,
       handleTagClick,
       selectedLabelId,
+      filterActive,
       handleLabelClick,
       allHighlights,
       handleBookmarkClick,

--- a/frontend/src/pages/BookPage/common/FilterFab.tsx
+++ b/frontend/src/pages/BookPage/common/FilterFab.tsx
@@ -14,7 +14,7 @@ export const FilterFab = ({
       <Fab
         size="small"
         color={filterEnabled ? 'primary' : 'default'}
-        aria-label="Open filters"
+        aria-label={filterEnabled ? 'Open filters (filters active)' : 'Open filters'}
         onClick={() => onClick()}
       >
         <FilterListIcon />

--- a/frontend/src/pages/BookPage/common/HighlightContent.tsx
+++ b/frontend/src/pages/BookPage/common/HighlightContent.tsx
@@ -1,6 +1,7 @@
 import type { Highlight } from '@/api/generated/model';
 import { LabelIndicator } from '@/pages/BookPage/common/LabelIndicator.tsx';
 import { NotOnDeviceChip } from '@/pages/BookPage/common/NotOnDeviceChip.tsx';
+import { formatHighlightDate } from '@/pages/BookPage/common/highlightDates.ts';
 import { DateIcon, QuoteIcon } from '@/theme/Icons.tsx';
 import { Box, Typography } from '@mui/material';
 
@@ -79,11 +80,7 @@ export const HighlightContent = ({ highlight, onLabelClick }: HighlightContentPr
             color: 'text.secondary',
           }}
         >
-          {new Date(highlight.datetime).toLocaleDateString('en-US', {
-            year: 'numeric',
-            month: 'long',
-            day: 'numeric',
-          })}
+          {formatHighlightDate(highlight.datetime)}
           {highlight.page && ` • Page ${highlight.page}`}
         </Typography>
         <LabelIndicator label={highlight.label} onClick={onLabelClick} size="medium" />

--- a/frontend/src/pages/BookPage/common/highlightDates.test.tsx
+++ b/frontend/src/pages/BookPage/common/highlightDates.test.tsx
@@ -1,0 +1,102 @@
+import { aChapter, aHighlight } from '@tests/fixtures/book';
+import { DateTime } from 'luxon';
+import { describe, expect, test } from 'vitest';
+import {
+  filterChaptersByHighlightDate,
+  formatHighlightDate,
+  getLastSevenDaysFrom,
+  isHighlightDateRangeReversed,
+  parseDateSearchParam,
+  parseHighlightDate,
+  type HighlightDateRange,
+} from './highlightDates.ts';
+
+const chapters = [
+  aChapter({
+    id: 10,
+    highlights: [
+      aHighlight({ id: 1, datetime: '2026-07-04 23:59:59' }),
+      aHighlight({ id: 2, datetime: '2026-07-05 00:00:00' }),
+      aHighlight({ id: 3, datetime: '2026-07-05 23:59:59' }),
+      aHighlight({ id: 4, datetime: '2026-07-06 00:00:00' }),
+      aHighlight({ id: 5, datetime: 'legacy timestamp' }),
+    ],
+  }),
+  aChapter({
+    id: 20,
+    highlights: [aHighlight({ id: 6, chapter_id: 20, datetime: '2026-07-01 12:00:00' })],
+  }),
+];
+
+const highlightIds = (range: HighlightDateRange) =>
+  filterChaptersByHighlightDate(chapters, range).map((chapter) => ({
+    chapterId: chapter.id,
+    highlightIds: chapter.highlights.map((highlight) => highlight.id),
+  }));
+
+describe('filterChaptersByHighlightDate', () => {
+  test.each([
+    {
+      name: 'preserves every highlight when neither bound is set',
+      range: {},
+      expected: [
+        { chapterId: 10, highlightIds: [1, 2, 3, 4, 5] },
+        { chapterId: 20, highlightIds: [6] },
+      ],
+    },
+    {
+      name: 'applies an inclusive From bound and excludes malformed timestamps',
+      range: { from: '2026-07-05' },
+      expected: [{ chapterId: 10, highlightIds: [2, 3, 4] }],
+    },
+    {
+      name: 'applies an inclusive To bound across the whole calendar date',
+      range: { to: '2026-07-05' },
+      expected: [
+        { chapterId: 10, highlightIds: [1, 2, 3] },
+        { chapterId: 20, highlightIds: [6] },
+      ],
+    },
+    {
+      name: 'intersects both bounds and drops empty chapters',
+      range: { from: '2026-07-05', to: '2026-07-05' },
+      expected: [{ chapterId: 10, highlightIds: [2, 3] }],
+    },
+    {
+      name: 'does not apply a reversed range',
+      range: { from: '2026-07-06', to: '2026-07-05' },
+      expected: [
+        { chapterId: 10, highlightIds: [1, 2, 3, 4, 5] },
+        { chapterId: 20, highlightIds: [6] },
+      ],
+    },
+  ])('$name', ({ range, expected }) => {
+    expect(highlightIds(range)).toEqual(expected);
+  });
+});
+
+test('parses only canonical search dates and KOReader timestamps', () => {
+  expect(parseDateSearchParam('2026-07-05')).toBe('2026-07-05');
+  expect(parseDateSearchParam('2026-7-5')).toBeUndefined();
+  expect(parseDateSearchParam('2026-02-30')).toBeUndefined();
+  expect(parseDateSearchParam(['2026-07-05'])).toBeUndefined();
+
+  expect(parseHighlightDate('2026-07-05 23:59:59')).toBe('2026-07-05');
+  expect(parseHighlightDate('2026-07-05T23:59:59')).toBeUndefined();
+  expect(parseHighlightDate('legacy timestamp')).toBeUndefined();
+});
+
+test('identifies reversed ranges only when both valid values are present', () => {
+  expect(isHighlightDateRangeReversed({ from: '2026-07-06', to: '2026-07-05' })).toBe(true);
+  expect(isHighlightDateRangeReversed({ from: '2026-07-05', to: '2026-07-05' })).toBe(false);
+  expect(isHighlightDateRangeReversed({ from: '2026-07-06' })).toBe(false);
+});
+
+test('calculates a snapshot lower bound covering today and the preceding six dates', () => {
+  expect(getLastSevenDaysFrom(DateTime.fromISO('2026-08-26T15:00:00'))).toBe('2026-08-20');
+});
+
+test('formats valid timestamps in the existing US style and preserves malformed values', () => {
+  expect(formatHighlightDate('2026-07-05 23:00:00')).toBe('July 5, 2026');
+  expect(formatHighlightDate('legacy timestamp')).toBe('legacy timestamp');
+});

--- a/frontend/src/pages/BookPage/common/highlightDates.ts
+++ b/frontend/src/pages/BookPage/common/highlightDates.ts
@@ -1,0 +1,59 @@
+import type { ChapterWithHighlights } from '@/api/generated/model';
+import { DateTime } from 'luxon';
+
+export const DATE_SEARCH_FORMAT = 'yyyy-MM-dd';
+const HIGHLIGHT_DATETIME_FORMAT = 'yyyy-MM-dd HH:mm:ss';
+
+export interface HighlightDateRange {
+  from?: string;
+  to?: string;
+}
+
+const parseStrictly = (value: string, format: string): DateTime | undefined => {
+  const parsed = DateTime.fromFormat(value, format, { locale: 'en-US' });
+  return parsed.isValid && parsed.toFormat(format) === value ? parsed : undefined;
+};
+
+export const parseDateSearchParam = (value: unknown): string | undefined => {
+  if (typeof value !== 'string') return undefined;
+  return parseStrictly(value, DATE_SEARCH_FORMAT)?.toFormat(DATE_SEARCH_FORMAT);
+};
+
+export const parseHighlightDate = (value: string): string | undefined =>
+  parseStrictly(value, HIGHLIGHT_DATETIME_FORMAT)?.toFormat(DATE_SEARCH_FORMAT);
+
+export const isHighlightDateRangeReversed = ({ from, to }: HighlightDateRange): boolean =>
+  !!from && !!to && from > to;
+
+export const filterChaptersByHighlightDate = (
+  chapters: ChapterWithHighlights[],
+  range: HighlightDateRange
+): ChapterWithHighlights[] => {
+  const { from, to } = range;
+  if ((!from && !to) || isHighlightDateRangeReversed(range)) return chapters;
+
+  return chapters
+    .map((chapter) => ({
+      ...chapter,
+      highlights: chapter.highlights.filter((highlight) => {
+        const date = parseHighlightDate(highlight.datetime);
+        if (!date) return false;
+        return (!from || date >= from) && (!to || date <= to);
+      }),
+    }))
+    .filter((chapter) => chapter.highlights.length > 0);
+};
+
+export const getLastSevenDaysFrom = (today: DateTime<boolean> = DateTime.local()): string =>
+  today.minus({ days: 6 }).toFormat(DATE_SEARCH_FORMAT);
+
+export const formatHighlightDate = (value: string): string => {
+  const parsed = parseStrictly(value, HIGHLIGHT_DATETIME_FORMAT);
+  if (!parsed) return value;
+
+  return parsed.setLocale('en-US').toLocaleString({
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+};

--- a/frontend/src/pages/BookPage/navigation/BookmarkList.tsx
+++ b/frontend/src/pages/BookPage/navigation/BookmarkList.tsx
@@ -9,6 +9,7 @@ interface BookmarkListProps {
   allHighlights: Highlight[];
   onBookmarkClick: (highlightId: number) => void;
   hideTitle?: boolean;
+  filterActive?: boolean;
 }
 
 export const BookmarkList = ({
@@ -16,6 +17,7 @@ export const BookmarkList = ({
   allHighlights,
   onBookmarkClick,
   hideTitle,
+  filterActive = false,
 }: BookmarkListProps) => {
   const [isExpanded, setIsExpanded] = useState(true);
   const effectiveIsExpanded = hideTitle ? true : isExpanded;
@@ -185,7 +187,7 @@ export const BookmarkList = ({
               fontSize: '0.813rem',
             }}
           >
-            No bookmarks yet.
+            {filterActive ? 'No bookmarks match the active filters.' : 'No bookmarks yet.'}
           </Typography>
         )}
       </Collapsable>

--- a/frontend/src/pages/BookPage/navigation/FilterDrawer.tsx
+++ b/frontend/src/pages/BookPage/navigation/FilterDrawer.tsx
@@ -11,9 +11,10 @@ interface FilterDrawerProps {
   open: boolean;
   onClose: () => void;
   tabs: FilterTab[];
+  header?: ReactNode;
 }
 
-export const FilterDrawer = ({ open, onClose, tabs }: FilterDrawerProps) => {
+export const FilterDrawer = ({ open, onClose, tabs, header }: FilterDrawerProps) => {
   const [activeTab, setActiveTab] = useState(0);
 
   const handleClose = () => {
@@ -42,6 +43,8 @@ export const FilterDrawer = ({ open, onClose, tabs }: FilterDrawerProps) => {
             <CloseIcon />
           </IconButton>
         </Box>
+
+        {header && <Box sx={{ mb: 2 }}>{header}</Box>}
 
         {/* Tabs */}
         <Tabs

--- a/frontend/src/routes/book.$bookId/highlights.tsx
+++ b/frontend/src/routes/book.$bookId/highlights.tsx
@@ -1,4 +1,5 @@
 import { HighlightsPage } from '@/pages/BookPage/Highlights/HighlightsPage';
+import { parseDateSearchParam } from '@/pages/BookPage/common/highlightDates.ts';
 import { createFileRoute } from '@tanstack/react-router';
 
 type HighlightsSearch = {
@@ -6,6 +7,8 @@ type HighlightsSearch = {
   tagId?: number;
   labelId?: number;
   highlightId?: number;
+  from?: string;
+  to?: string;
 };
 
 export const Route = createFileRoute('/book/$bookId/highlights')({
@@ -15,5 +18,7 @@ export const Route = createFileRoute('/book/$bookId/highlights')({
     tagId: (search.tagId as number | undefined) || undefined,
     labelId: (search.labelId as number | undefined) || undefined,
     highlightId: (search.highlightId as number | undefined) || undefined,
+    from: parseDateSearchParam(search.from),
+    to: parseDateSearchParam(search.to),
   }),
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@emotion/styled": "^11.14.1",
         "@mui/icons-material": "^9.2.0",
         "@mui/material": "^9.2.0",
+        "@mui/x-date-pickers": "^9.12.0",
         "@tanstack/react-query": "^5.101.4",
         "@tanstack/react-router": "^1.170.18",
         "axios": "^1.19.0",
@@ -126,6 +127,7 @@
       "resolved": "https://registry.npmjs.org/@mui/material/-/material-9.2.0.tgz",
       "integrity": "sha512-+YTRSgGKGrrRo2XJZXs7JRA6qHoHWvNtxyqxnrRJTBmIuLOUpxxh7m4G9lF4tWberxGFY+EqkkRPgJCl+fSMJg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.29.2",
         "@mui/core-downloads-tracker": "^9.2.0",
@@ -236,6 +238,7 @@
       "resolved": "https://registry.npmjs.org/@mui/system/-/system-9.2.0.tgz",
       "integrity": "sha512-YvUJwKoGVtbnOm2PyPi5TvX2d1rOA6sqSpEWVs4WmXNIaFTuYmNUaVdU2o1NKUEe31URnD3E8ZVUMcsLQXwcYg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.29.2",
         "@mui/private-theming": "^9.2.0",
@@ -317,6 +320,177 @@
           "optional": true
         }
       }
+    },
+    "frontend/node_modules/@mui/x-date-pickers": {
+      "version": "9.12.0",
+      "resolved": "https://registry.npmjs.org/@mui/x-date-pickers/-/x-date-pickers-9.12.0.tgz",
+      "integrity": "sha512-8buJZhsDQmq2mfG4ID7JPI8RmbBW8FZkF5GfgGkH0Bi/Y9UkpCeEuOFF/Tbg8TxL5gKAOkXRZTK/pFlNZYqdhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.7",
+        "@mui/utils": "^9.3.0",
+        "@mui/x-internals": "^9.12.0",
+        "@types/react-transition-group": "^4.4.12",
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1",
+        "react-transition-group": "^4.4.5"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.9.0",
+        "@emotion/styled": "^11.8.1",
+        "@mui/material": "^7.3.0 || ^9.0.0",
+        "@mui/system": "^7.3.0 || ^9.0.0",
+        "date-fns": "^2.25.0 || ^3.2.0 || ^4.0.0",
+        "date-fns-jalali": "^2.13.0-0 || ^3.2.0-0 || ^4.0.0-0",
+        "dayjs": "^1.10.7",
+        "luxon": "^3.0.2",
+        "moment": "^2.29.4",
+        "moment-hijri": "^2.1.2 || ^3.0.0",
+        "moment-jalaali": "^0.7.4 || ^0.8.0 || ^0.9.0 || ^0.10.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        },
+        "date-fns": {
+          "optional": true
+        },
+        "date-fns-jalali": {
+          "optional": true
+        },
+        "dayjs": {
+          "optional": true
+        },
+        "luxon": {
+          "optional": true
+        },
+        "moment": {
+          "optional": true
+        },
+        "moment-hijri": {
+          "optional": true
+        },
+        "moment-jalaali": {
+          "optional": true
+        }
+      }
+    },
+    "frontend/node_modules/@mui/x-date-pickers/node_modules/@mui/utils": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-9.3.0.tgz",
+      "integrity": "sha512-2HZdHwWJ6eB+7lVGSOHsByGw8jeRulT4g0NZ608Wb8Q57DE2jbNqrWPFuJsvkQQiBiTmlpvQL3i+/62zsiPrkw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.7",
+        "@mui/types": "^9.3.0",
+        "@types/prop-types": "^15.7.15",
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1",
+        "react-is": "^19.2.8"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "frontend/node_modules/@mui/x-date-pickers/node_modules/@mui/utils/node_modules/@mui/types": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-9.3.0.tgz",
+      "integrity": "sha512-2JSxyfpEFWNUB2vKs/T1BvkfyNisMHWph8bLMj8T0uHwmLl/0qfAwQkfwMT6kxLXN9uIum9AEbECXU8er3amIg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.7"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "frontend/node_modules/@mui/x-date-pickers/node_modules/@mui/x-internals": {
+      "version": "9.12.0",
+      "resolved": "https://registry.npmjs.org/@mui/x-internals/-/x-internals-9.12.0.tgz",
+      "integrity": "sha512-rpG9EgJhH3JeOK2Q/tKaUWk5vP8C1NfL8DaXMKR1XCA7RhpZUI/xT67WKY80QtogNWu7U/BRezKyQGtiZ8soYg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.7",
+        "@base-ui/utils": "^0.3.1",
+        "@mui/utils": "^9.3.0",
+        "reselect": "^5.2.0",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "frontend/node_modules/@mui/x-date-pickers/node_modules/@mui/x-internals/node_modules/@base-ui/utils": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@base-ui/utils/-/utils-0.3.2.tgz",
+      "integrity": "sha512-oWy1aq/I2GmYjpl4PhEAhzflF8VPGKgZeq0xAWTbfD5KBWyxcN0ZP2+WHSUm/5Z6lVMBDLReLcoXwSYoRc/zNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "@floating-ui/utils": "^0.2.12",
+        "reselect": "^5.2.0",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^17 || ^18 || ^19",
+        "react": "^17 || ^18 || ^19",
+        "react-dom": "^17 || ^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "frontend/node_modules/@mui/x-date-pickers/node_modules/@mui/x-internals/node_modules/@base-ui/utils/node_modules/@floating-ui/utils": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.12.tgz",
+      "integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==",
+      "license": "MIT"
+    },
+    "frontend/node_modules/@mui/x-date-pickers/node_modules/@mui/x-internals/node_modules/reselect": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.3.0.tgz",
+      "integrity": "sha512-XGoLeRAVzUTcJ1qkxPQhDJyIZ5d6zzZD9nT7AEZOaaU9UbWclhycElmhO+VD5bFeLuzhPBaOV2oXC8uG35ZSpg==",
+      "license": "MIT"
     },
     "frontend/node_modules/@vitejs/plugin-react": {
       "version": "6.0.5",
@@ -409,6 +583,7 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -690,6 +865,7 @@
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
       "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -733,6 +909,7 @@
       "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.1.tgz",
       "integrity": "sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -2561,9 +2738,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2581,9 +2755,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2601,9 +2772,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2621,9 +2789,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2641,9 +2806,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2661,9 +2823,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2794,6 +2953,7 @@
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -3240,6 +3400,7 @@
       "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~8.3.0"
       }
@@ -3261,6 +3422,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
       "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3271,6 +3433,7 @@
       "integrity": "sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3342,6 +3505,7 @@
       "integrity": "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.65.0",
         "@typescript-eslint/types": "8.65.0",
@@ -3928,6 +4092,7 @@
       "integrity": "sha512-nMoXGEiRpT7m3W7NsbvrM2aKNwiNHZf+zEpUCvMteGjZFvfT96Q9fh7QyB98dvDWXiKvrLxA7bJ1mCOOv+JQPw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/browser": "4.1.10",
         "@vitest/mocker": "4.1.10",
@@ -4072,6 +4237,7 @@
       "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4306,6 +4472,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.42",
         "caniuse-lite": "^1.0.30001803",
@@ -4950,6 +5117,7 @@
       "integrity": "sha512-nuKKvN+oIBO0koN7Tm7dlkmnkc21mtt0QJLwAKzjLq14y6lRTdVG36MZHJ8eQHwdJMwZbQNMlPOYedMq/oVJvQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "workspaces": [
         "packages/*"
       ],
@@ -6286,6 +6454,7 @@
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6710,6 +6879,7 @@
       "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
       "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -7460,6 +7630,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@inquirer/confirm": "^6.0.11",
         "@mswjs/interceptors": "^0.41.3",
@@ -7683,6 +7854,7 @@
       "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=22.12.0"
       }
@@ -8098,6 +8270,7 @@
       "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -8202,6 +8375,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
       "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8221,6 +8395,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
       "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -8484,6 +8659,7 @@
       "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.5.6.tgz",
       "integrity": "sha512-rVQVWjjSvlINzaQPZH5JFqsqEsIWdTxY3iJZCnTL/5gQbXIRooVZKI60tVCkOVfzcRPejboxO2t0P89dg5mQaA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -8795,6 +8971,7 @@
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8929,6 +9106,7 @@
       "integrity": "sha512-uSKqkh8Cr48vllnEy+jdaAgOeR6Y+QCBW7usgUsKj7gJEfR7stw9U/fE49LBnj2tPRKPY0c0EBJSWe9Appmplg==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@gerrit0/mini-shiki": "^3.23.0",
         "lunr": "^2.3.9",
@@ -8979,6 +9157,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9239,6 +9418,7 @@
       "integrity": "sha512-cFKLV/PRgAUlIRm5WjMjJ86jrftzpqcgH+Us+DS8mI3CDNiH30Whrz8uHL3+MOLPAgqbMBAqWdAHAphOAM+z/Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.33.0",
         "picomatch": "^4.0.5",
@@ -9330,6 +9510,7 @@
       "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.10",
         "@vitest/mocker": "4.1.10",
@@ -9676,6 +9857,7 @@
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -9701,27 +9883,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/tsx": {
-      "version": "4.23.1",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.1.tgz",
-      "integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "esbuild": "~0.28.0"
-      },
-      "bin": {
-        "tsx": "dist/cli.mjs"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.3"
       }
     }
   }


### PR DESCRIPTION
## Summary

- add URL-backed From/To date filtering for highlights using the KOReader `datetime` calendar date
- add responsive MUI date controls, Last 7 Days, validation, and accessible active-filter status
- localize picker formatting from the browser's effective `Intl` regional locale
- centralize strict highlight-date parsing and display formatting across both existing render sites
- update highlight and bookmark empty states for active filters

## Testing

- `npm test` — 84 tests passed
- `npm run type-check`
- `npm run lint`
- `npm run format:check`
- `npm run build:ci`
- `npm run knip`
- `npm run duplication-check` — 1.4%, with the ratchet lowered from 1.7%

Closes #634
