### PR TITLE
Lock the pull-to-refresh gesture to its direction

### DIFF
--- a/frontend/.jscpd.json
+++ b/frontend/.jscpd.json
@@ -11,5 +11,5 @@
   "minLines": 5,
   "minTokens": 50,
   "reporters": ["ai", "threshold"],
-  "threshold": 1.4
+  "threshold": 1.33
 }

--- a/frontend/src/components/layout/PullToRefresh.test.tsx
+++ b/frontend/src/components/layout/PullToRefresh.test.tsx
@@ -39,18 +39,36 @@ function booksApi(title: string) {
   return { handlers, state };
 }
 
-const touchAt = (clientY: number) =>
-  new Touch({ identifier: 1, target: document.body, clientX: 0, clientY });
+const touchAt = (clientX: number, clientY: number) =>
+  new Touch({ identifier: 1, target: document.body, clientX, clientY });
+
+const dispatch = (type: string, touches: Touch[]) => {
+  const event = new TouchEvent(type, { touches, cancelable: true, bubbles: true });
+  window.dispatchEvent(event);
+  return event;
+};
+
+/**
+ * One complete drag from the top of the page, in steps small enough that the
+ * gesture passes through the direction lock the way a real finger does.
+ * Returns whether the page swallowed the movement.
+ */
+const drag = ({ x = 0, y = 0 }: { x?: number; y?: number }) => {
+  const STEPS = 10;
+  dispatch('touchstart', [touchAt(0, 0)]);
+
+  let prevented = false;
+  for (let step = 1; step <= STEPS; step += 1) {
+    const move = dispatch('touchmove', [touchAt((x * step) / STEPS, (y * step) / STEPS)]);
+    prevented ||= move.defaultPrevented;
+  }
+
+  dispatch('touchend', []);
+  return { prevented };
+};
 
 /** One complete downward drag from the top of the page. */
-const dragDown = (distance: number) => {
-  const dispatch = (type: string, touches: Touch[]) =>
-    window.dispatchEvent(new TouchEvent(type, { touches, cancelable: true, bubbles: true }));
-
-  dispatch('touchstart', [touchAt(0)]);
-  dispatch('touchmove', [touchAt(distance)]);
-  dispatch('touchend', []);
-};
+const dragDown = (distance: number) => drag({ y: distance });
 
 test('pulling the page down past the threshold refetches the data on screen', async () => {
   const { handlers, state } = booksApi('The Pragmatic Reader');
@@ -78,6 +96,26 @@ test('a pull that stops short of the threshold refetches nothing', async () => {
 
   // A refresh fires its request off the touchend handler, so whatever this
   // drag was going to do has reached the handler well inside this window.
+  await new Promise((resolve) => setTimeout(resolve, 300));
+
+  expect(state.requests).toBe(1);
+  await expect.element(screen.getByText('The Pragmatic Reader')).toBeVisible();
+});
+
+test('a sideways swipe is left to the horizontal scroller under it', async () => {
+  const { handlers, state } = booksApi('The Pragmatic Reader');
+  worker.use(...handlers);
+
+  const screen = await renderApp({ path: '/' });
+  await expect.element(screen.getByText('The Pragmatic Reader')).toBeVisible();
+
+  state.title = 'The Refreshed Reader';
+  // A carousel drag: far enough sideways to be horizontal, with the vertical
+  // drift a finger leaves behind — and past the refresh threshold on its own.
+  const { prevented } = drag({ x: -240, y: 200 });
+
+  expect(prevented).toBe(false);
+
   await new Promise((resolve) => setTimeout(resolve, 300));
 
   expect(state.requests).toBe(1);

--- a/frontend/src/components/layout/PullToRefresh.test.tsx
+++ b/frontend/src/components/layout/PullToRefresh.test.tsx
@@ -70,54 +70,64 @@ const drag = ({ x = 0, y = 0 }: { x?: number; y?: number }) => {
 /** One complete downward drag from the top of the page. */
 const dragDown = (distance: number) => drag({ y: distance });
 
-test('pulling the page down past the threshold refetches the data on screen', async () => {
-  const { handlers, state } = booksApi('The Pragmatic Reader');
+const ORIGINAL_TITLE = 'The Pragmatic Reader';
+const REFRESHED_TITLE = 'The Refreshed Reader';
+
+/**
+ * The front page on screen showing the original title, with the API primed to
+ * answer the next request with the refreshed one — so a refetch shows up as a
+ * changed title rather than only as a request count.
+ */
+async function aFrontPageReadyToRefresh() {
+  const { handlers, state } = booksApi(ORIGINAL_TITLE);
   worker.use(...handlers);
 
   const screen = await renderApp({ path: '/' });
-  await expect.element(screen.getByText('The Pragmatic Reader')).toBeVisible();
+  await expect.element(screen.getByText(ORIGINAL_TITLE)).toBeVisible();
 
-  state.title = 'The Refreshed Reader';
-  dragDown(300);
+  state.title = REFRESHED_TITLE;
 
-  await expect.element(screen.getByText('The Refreshed Reader')).toBeVisible();
-});
+  return { screen, state };
+}
 
-test('a pull that stops short of the threshold refetches nothing', async () => {
-  const { handlers, state } = booksApi('The Pragmatic Reader');
-  worker.use(...handlers);
+type FrontPage = Awaited<ReturnType<typeof aFrontPageReadyToRefresh>>;
 
-  const screen = await renderApp({ path: '/' });
-  await expect.element(screen.getByText('The Pragmatic Reader')).toBeVisible();
-
-  state.title = 'The Refreshed Reader';
-  // 30px of pull once resistance is applied: under the 70px threshold.
-  dragDown(60);
-
-  // A refresh fires its request off the touchend handler, so whatever this
-  // drag was going to do has reached the handler well inside this window.
+/**
+ * Nothing refetched: still the one request, still the original title. A
+ * refresh fires its request off the touchend handler, so whatever the drag was
+ * going to do has reached the handler well inside this window.
+ */
+async function expectNoRefresh({ screen, state }: FrontPage) {
   await new Promise((resolve) => setTimeout(resolve, 300));
 
   expect(state.requests).toBe(1);
-  await expect.element(screen.getByText('The Pragmatic Reader')).toBeVisible();
+  await expect.element(screen.getByText(ORIGINAL_TITLE)).toBeVisible();
+}
+
+test('pulling the page down past the threshold refetches the data on screen', async () => {
+  const { screen } = await aFrontPageReadyToRefresh();
+
+  dragDown(300);
+
+  await expect.element(screen.getByText(REFRESHED_TITLE)).toBeVisible();
+});
+
+test('a pull that stops short of the threshold refetches nothing', async () => {
+  const page = await aFrontPageReadyToRefresh();
+
+  // 30px of pull once resistance is applied: under the 70px threshold.
+  dragDown(60);
+
+  await expectNoRefresh(page);
 });
 
 test('a sideways swipe is left to the horizontal scroller under it', async () => {
-  const { handlers, state } = booksApi('The Pragmatic Reader');
-  worker.use(...handlers);
+  const page = await aFrontPageReadyToRefresh();
 
-  const screen = await renderApp({ path: '/' });
-  await expect.element(screen.getByText('The Pragmatic Reader')).toBeVisible();
-
-  state.title = 'The Refreshed Reader';
   // A carousel drag: far enough sideways to be horizontal, with the vertical
   // drift a finger leaves behind — and past the refresh threshold on its own.
   const { prevented } = drag({ x: -240, y: 200 });
 
   expect(prevented).toBe(false);
-
-  await new Promise((resolve) => setTimeout(resolve, 300));
-
-  expect(state.requests).toBe(1);
-  await expect.element(screen.getByText('The Pragmatic Reader')).toBeVisible();
+  await expectNoRefresh(page);
 });

--- a/frontend/src/hooks/usePullToRefresh.ts
+++ b/frontend/src/hooks/usePullToRefresh.ts
@@ -7,6 +7,12 @@ const MAX_PULL_PX = 120;
 const RESISTANCE = 0.5;
 
 /**
+ * How far the finger travels before the gesture is read as vertical or
+ * horizontal. Below this, a touch has no direction yet and is left alone.
+ */
+const DIRECTION_LOCK_SLOP_PX = 10;
+
+/**
  * Pull-down-to-refresh gesture for the document scroller.
  *
  * iOS home-screen web apps have no browser chrome, so Safari's own
@@ -18,6 +24,8 @@ export const usePullToRefresh = (onRefresh: () => Promise<unknown>) => {
   const [isRefreshing, setIsRefreshing] = useState(false);
 
   const startYRef = useRef<number | null>(null);
+  const startXRef = useRef(0);
+  const isPullingRef = useRef(false);
   const pullRef = useRef(0);
   const refreshingRef = useRef(false);
   const onRefreshRef = useRef(onRefresh);
@@ -35,14 +43,31 @@ export const usePullToRefresh = (onRefresh: () => Promise<unknown>) => {
     const isAtTop = () => window.scrollY <= 0;
 
     const handleTouchStart = (event: TouchEvent) => {
-      startYRef.current = event.touches.length === 1 && isAtTop() ? event.touches[0].clientY : null;
+      const isCandidate = event.touches.length === 1 && isAtTop();
+      startYRef.current = isCandidate ? event.touches[0].clientY : null;
+      startXRef.current = isCandidate ? event.touches[0].clientX : 0;
+      isPullingRef.current = false;
     };
 
     const handleTouchMove = (event: TouchEvent) => {
       if (startYRef.current === null || refreshingRef.current || !isAtTop()) return;
 
-      const delta = event.touches[0].clientY - startYRef.current;
-      if (delta <= 0) {
+      const deltaY = event.touches[0].clientY - startYRef.current;
+
+      if (!isPullingRef.current) {
+        const deltaX = event.touches[0].clientX - startXRef.current;
+        // Until the gesture has a direction, leave it to the browser.
+        if (Math.max(Math.abs(deltaX), Math.abs(deltaY)) < DIRECTION_LOCK_SLOP_PX) return;
+        if (Math.abs(deltaX) >= deltaY) {
+          // Mostly sideways: release the touch for good, so a horizontal
+          // scroller such as a carousel keeps the whole gesture.
+          startYRef.current = null;
+          return;
+        }
+        isPullingRef.current = true;
+      }
+
+      if (deltaY <= 0) {
         // Pulled back up: release the gesture so the page scrolls normally.
         setPull(0);
         return;
@@ -51,12 +76,13 @@ export const usePullToRefresh = (onRefresh: () => Promise<unknown>) => {
       // Only a non-passive listener may call this, which is why the listeners
       // are registered by hand instead of through React's touch props.
       event.preventDefault();
-      setPull(Math.min(delta * RESISTANCE, MAX_PULL_PX));
+      setPull(Math.min(deltaY * RESISTANCE, MAX_PULL_PX));
     };
 
     const handleTouchEnd = () => {
       const shouldRefresh = pullRef.current >= PULL_THRESHOLD_PX;
       startYRef.current = null;
+      isPullingRef.current = false;
       setPull(0);
       if (!shouldRefresh) return;
 
@@ -70,6 +96,7 @@ export const usePullToRefresh = (onRefresh: () => Promise<unknown>) => {
 
     const handleTouchCancel = () => {
       startYRef.current = null;
+      isPullingRef.current = false;
       setPull(0);
     };
 


### PR DESCRIPTION
Follow-up to #629.

## The bug

Pull-to-refresh claimed any touch that started at `window.scrollY <= 0` and drifted downward at all — the only check in `touchmove` was `delta <= 0` on the vertical axis. A carousel swipe is mostly sideways but always leaves a few pixels of vertical drift, so `preventDefault()` fired and the native horizontal scroller never saw the rest of the gesture. On the mobile front page, where the page usually sits scrolled to the top, the carousels became hard to scroll: the page translated under the finger instead.

## The fix

`usePullToRefresh` now waits until the finger has travelled `DIRECTION_LOCK_SLOP_PX` (10px) on either axis, then decides once:

- `|deltaX| >= deltaY` → mostly sideways. Clear `startYRef` so the whole rest of the touch belongs to whatever scroller is under it.
- Otherwise → commit to the pull and behave as before.

Below the slop nothing is prevented, so the browser is free to lock the scroll axis itself. That window is safe: at `scrollY <= 0` with `overscroll-behavior-y: contain`, a downward drag scrolls nothing anyway.

Deciding once per touch is what makes a real drag feel right — a swipe that starts horizontal stays horizontal even as the finger curves downward.

## Test

A new case drags 240px left with 200px of downward drift — enough vertical travel to clear the refresh threshold on its own — and asserts both that no `touchmove` was `defaultPrevented` and that no refetch happened.

The drag helper now steps through a gesture in 10 increments instead of jumping the full distance in one `touchmove`, so tests pass through the direction lock the way a finger does.

All 86 frontend tests pass; typecheck and lint are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)