### PR TITLE
Stop pull-to-refresh from swallowing scrolls inside dialogs

### DIFF
--- a/frontend/src/components/dialogs/CommonDialog.tsx
+++ b/frontend/src/components/dialogs/CommonDialog.tsx
@@ -1,5 +1,6 @@
 import { useDialogStackEntry } from '@/components/dialogs/dialogStack.ts';
 import type { DialogNavigation } from '@/components/dialogs/useDialogHorizontalNavigation.ts';
+import { lockBodyScroll, unlockBodyScroll } from '@/lib/bodyScrollLock.ts';
 import { ArrowBackIcon, ArrowForwardIcon, CloseIcon } from '@/theme/Icons.tsx';
 import {
   Box,
@@ -31,41 +32,6 @@ interface CommonDialogProps {
   isLoading?: boolean;
   headerElement?: ReactNode;
 }
-
-/**
- * Reference-counted body scroll lock, shared across every mounted
- * `CommonDialog`. Nested dialogs (a note opened on top of a highlight, say)
- * each mount/unmount their own lock effect; without a shared counter the
- * inner dialog's mount reads `window.scrollY` as 0 (the outer lock already
- * made the body `position: fixed`) and its unmount then clears the body
- * styles the still-open outer dialog needs. Only the first locker records
- * the scroll position and applies the styles; only the last unlocker
- * restores them.
- */
-let lockCount = 0;
-let lockedScrollY = 0;
-
-const lockBodyScroll = () => {
-  if (lockCount === 0) {
-    lockedScrollY = window.scrollY;
-    document.body.style.overflow = 'hidden';
-    document.body.style.position = 'fixed';
-    document.body.style.top = `-${lockedScrollY}px`;
-    document.body.style.width = '100%';
-  }
-  lockCount += 1;
-};
-
-const unlockBodyScroll = () => {
-  lockCount -= 1;
-  if (lockCount === 0) {
-    document.body.style.overflow = '';
-    document.body.style.position = '';
-    document.body.style.top = '';
-    document.body.style.width = '';
-    window.scrollTo(0, lockedScrollY);
-  }
-};
 
 /**
  * Common dialog component with standard structure:

--- a/frontend/src/components/layout/PullToRefresh.test.tsx
+++ b/frontend/src/components/layout/PullToRefresh.test.tsx
@@ -1,5 +1,7 @@
 import type { BookWithHighlightCount } from '@/api/generated/model';
+import { aBookDetails, aChapter, aHighlight } from '@tests/fixtures/book';
 import { renderApp } from '@tests/harness/renderApp';
+import { bookApi } from '@tests/msw/bookApi';
 import { worker } from '@tests/msw/worker';
 import { http, HttpResponse } from 'msw';
 import { expect, test } from 'vitest';
@@ -131,4 +133,22 @@ test('a sideways swipe is left to the horizontal scroller under it', async () =>
 
   expect(prevented).toBe(false);
   await expectNoRefresh(page);
+});
+
+/**
+ * An open dialog pins the body with `position: fixed`, which reads back as
+ * `window.scrollY === 0` — the very thing the gesture reads to tell it is at
+ * the top of the page. Unguarded, every downward swipe in a dialog was
+ * swallowed as a pull and the dialog's own content never scrolled.
+ */
+test('a downward swipe inside an open dialog is left to the dialog to scroll', async () => {
+  const book = aBookDetails({ chapters: [aChapter({ highlights: [aHighlight({ id: 301 })] })] });
+  worker.use(...bookApi({ book }).handlers);
+
+  const screen = await renderApp({ path: '/book/1/highlights?highlightId=301' });
+  await expect.element(screen.getByRole('dialog')).toBeVisible();
+
+  const { prevented } = dragDown(300);
+
+  expect(prevented).toBe(false);
 });

--- a/frontend/src/hooks/usePullToRefresh.ts
+++ b/frontend/src/hooks/usePullToRefresh.ts
@@ -1,3 +1,4 @@
+import { isBodyScrollLocked } from '@/lib/bodyScrollLock.ts';
 import { useEffect, useRef, useState } from 'react';
 
 /** Pull distance, in pixels, that arms the refresh. */
@@ -40,7 +41,9 @@ export const usePullToRefresh = (onRefresh: () => Promise<unknown>) => {
       setPullDistance(value);
     };
 
-    const isAtTop = () => window.scrollY <= 0;
+    // A locked body is `position: fixed`, so scrollY reads 0 whatever the
+    // page behind the dialog was scrolled to: sit the lock out entirely.
+    const isAtTop = () => !isBodyScrollLocked() && window.scrollY <= 0;
 
     const handleTouchStart = (event: TouchEvent) => {
       const isCandidate = event.touches.length === 1 && isAtTop();

--- a/frontend/src/lib/bodyScrollLock.ts
+++ b/frontend/src/lib/bodyScrollLock.ts
@@ -1,0 +1,37 @@
+/**
+ * Reference-counted body scroll lock, shared across every caller.
+ *
+ * Nested dialogs (a note opened on top of a highlight, say) each mount and
+ * unmount their own lock effect; without a shared counter the inner dialog's
+ * mount reads `window.scrollY` as 0 (the outer lock already made the body
+ * `position: fixed`) and its unmount then clears the body styles the
+ * still-open outer dialog needs. Only the first locker records the scroll
+ * position and applies the styles; only the last unlocker restores them.
+ */
+let lockCount = 0;
+let lockedScrollY = 0;
+
+export const lockBodyScroll = () => {
+  if (lockCount === 0) {
+    lockedScrollY = window.scrollY;
+    document.body.style.overflow = 'hidden';
+    document.body.style.position = 'fixed';
+    document.body.style.top = `-${lockedScrollY}px`;
+    document.body.style.width = '100%';
+  }
+  lockCount += 1;
+};
+
+export const unlockBodyScroll = () => {
+  lockCount -= 1;
+  if (lockCount === 0) {
+    document.body.style.overflow = '';
+    document.body.style.position = '';
+    document.body.style.top = '';
+    document.body.style.width = '';
+    window.scrollTo(0, lockedScrollY);
+  }
+};
+
+/** Whether the document scroller is pinned, and `window.scrollY` therefore 0. */
+export const isBodyScrollLocked = () => lockCount > 0;


### PR DESCRIPTION
## The bug

On a touch screen, a downward swipe inside an open `CommonDialog` scrolled nothing — quick swipes worst of all. The page body was unaffected.

## Root cause

`usePullToRefresh` arms itself on `window.scrollY <= 0` and registers its listeners on `window`, so it sees touches inside the dialog too. `CommonDialog`'s scroll lock pins the body with `position: fixed`, which collapses `window.scrollY` to 0 however far the page was actually scrolled — so the guard is unconditionally true while any dialog is open. A downward swipe then hits `event.preventDefault()` on a non-passive `touchmove`, cancelling the scroll `DialogContent` was about to do. `touchAction: 'pan-y'` cannot help; a JS `preventDefault` wins.

Two details match the report:

- **Only downward swipes.** The direction check is `Math.abs(deltaX) >= deltaY` (not `abs(deltaY)`), so an upward swipe always releases the gesture. Swiping *down* to get back up the dialog is the broken one.
- **Quick swipes especially.** A fast flick is near-pure vertical, so the first sample past the 10px slop reads as a pull. A slower drag drifts sideways enough to often trip the horizontal release instead.

The regression is pull-to-refresh (0be2fdd0, 8206df10), not the reference-counted scroll lock — `position: fixed` predates it.

## Fix

Move the reference-counted lock out of `CommonDialog` into `frontend/src/lib/bodyScrollLock.ts` and expose `isBodyScrollLocked()`, then have the gesture sit out a locked document:

```ts
const isAtTop = () => !isBodyScrollLocked() && window.scrollY <= 0;
```

A pinned document cannot scroll, so pull-to-refresh has nothing to do there — for any future locker, not only dialogs.

## Testing

A route-level test opens a real highlight dialog by URL and asserts the drag is not swallowed. It fails on the old code, passes on the new.

All frontend gates pass: 87 tests in 14 files, lint, format, type-check, knip, jscpd at 1.3%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TdZ1gDqS6g14213Zpt5MJo