### PR TITLE
Replace "Preferences" with "Settings" in hamburger menu

### DIFF
--- a/frontend/src/components/layout/AppBar.tsx
+++ b/frontend/src/components/layout/AppBar.tsx
@@ -116,7 +116,7 @@ export function AppBar() {
               <ListItemIcon>
                 <SettingsIcon fontSize="small" />
               </ListItemIcon>
-              <ListItemText>Preferences</ListItemText>
+              <ListItemText>Settings</ListItemText>
             </MenuItem>
             <MenuItem onClick={handleLogout}>
               <ListItemIcon>

--- a/frontend/src/pages/SettingsPage/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage/SettingsPage.tsx
@@ -212,11 +212,8 @@ const PasswordForm = () => {
 export const SettingsPage = () => {
   return (
     <PageContainer maxWidth="sm">
-      <Typography variant="h1" sx={{ mb: 1, color: 'text.primary' }}>
+      <Typography variant="h1" sx={{ mb: 4, color: 'text.primary' }}>
         Settings
-      </Typography>
-      <Typography variant="body2" sx={{ mb: 4, color: 'text.secondary' }}>
-        Manage your account preferences
       </Typography>
 
       <EmailForm />


### PR DESCRIPTION
## Summary

- Hamburger menu item "Preferences" → "Settings" (`AppBar.tsx`)
- Removed the "Manage your account preferences" subtitle on the Settings page, since these are app settings, not account settings (`SettingsPage.tsx`)

## Test plan

- [x] `tsc --noEmit` and `eslint` clean on both files
- [x] No test assertions referenced the old text

Fixes #626

🤖 Generated with [Claude Code](https://claude.ai/code)