### PR TITLE
Fix broken KOReader plugin link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ cp .env.example .env
 docker compose up
 ```
 
-Then install the Koreader [plugin on your e-reader](clients/koreader-plugin/crossbill.koplugin/README.md).
+Then install the Koreader [plugin on your e-reader](https://github.com/Crossbill-App/koreader-plugin).
 
 ### Background Worker
 


### PR DESCRIPTION
## Summary

- The "Then install the Koreader plugin on your e-reader" link in the Installation section pointed at `clients/koreader-plugin/crossbill.koplugin/README.md`, a path that doesn't exist in this repo.
- The plugin lives in its own [`Crossbill-App/koreader-plugin`](https://github.com/Crossbill-App/koreader-plugin) repo, which the "Components" section above already links to correctly — this second reference just never got updated when the plugin was split out into that repo.
- Points it at the same URL instead.

## Test plan

- [x] Confirmed no `clients/` directory exists anywhere in this repo.
- [x] Checked for other stale references to the old path — none found.

---
_Generated by [Claude Code](https://claude.ai/code/session_013JzHc91F72CXnQ6VDzrWK1)_