### PR TITLE
Lock body scroll while the filter drawer is open

### DIFF
--- a/frontend/src/components/dialogs/CommonDialog.tsx
+++ b/frontend/src/components/dialogs/CommonDialog.tsx
@@ -1,6 +1,6 @@
 import { useDialogStackEntry } from '@/components/dialogs/dialogStack.ts';
 import type { DialogNavigation } from '@/components/dialogs/useDialogHorizontalNavigation.ts';
-import { lockBodyScroll, unlockBodyScroll } from '@/lib/bodyScrollLock.ts';
+import { useBodyScrollLock } from '@/hooks/useBodyScrollLock.ts';
 import { ArrowBackIcon, ArrowForwardIcon, CloseIcon } from '@/theme/Icons.tsx';
 import {
   Box,
@@ -75,13 +75,7 @@ export const CommonDialog = ({
     </Box>
   ) : null;
 
-  // Lock body scroll when dialog is open
-  useEffect(() => {
-    if (!open) return;
-
-    lockBodyScroll();
-    return unlockBodyScroll;
-  }, [open]);
+  useBodyScrollLock(open);
 
   useEffect(() => {
     if (!open || !navigation) return;

--- a/frontend/src/components/layout/PullToRefresh.test.tsx
+++ b/frontend/src/components/layout/PullToRefresh.test.tsx
@@ -5,6 +5,7 @@ import { bookApi } from '@tests/msw/bookApi';
 import { worker } from '@tests/msw/worker';
 import { http, HttpResponse } from 'msw';
 import { expect, test } from 'vitest';
+import { page, userEvent } from 'vitest/browser';
 
 const aBookListItem = (title: string): BookWithHighlightCount => ({
   id: 1,
@@ -151,4 +152,27 @@ test('a downward swipe inside an open dialog is left to the dialog to scroll', a
   const { prevented } = dragDown(300);
 
   expect(prevented).toBe(false);
+});
+
+/**
+ * Regression for #648: the filter drawer is an overlay like any dialog, so a
+ * swipe over it scrolls its filters instead of pulling the page behind it
+ * down into a refresh.
+ */
+test('a downward swipe inside the open filter drawer is left to the drawer to scroll', async () => {
+  await page.viewport(400, 800);
+  try {
+    const book = aBookDetails({ chapters: [aChapter({ highlights: [aHighlight({ id: 301 })] })] });
+    worker.use(...bookApi({ book }).handlers);
+
+    const screen = await renderApp({ path: '/book/1/highlights' });
+    await userEvent.click(screen.getByRole('button', { name: 'Open filters' }));
+    await expect.element(screen.getByRole('tab', { name: 'Chapters' })).toBeVisible();
+
+    const { prevented } = dragDown(300);
+
+    expect(prevented).toBe(false);
+  } finally {
+    await page.viewport(1440, 900);
+  }
 });

--- a/frontend/src/hooks/useBodyScrollLock.ts
+++ b/frontend/src/hooks/useBodyScrollLock.ts
@@ -1,0 +1,21 @@
+import { lockBodyScroll, unlockBodyScroll } from '@/lib/bodyScrollLock.ts';
+import { useEffect } from 'react';
+
+/**
+ * Pins the document scroller for as long as `locked` is true.
+ *
+ * Every overlay that covers the page needs this, MUI's own `overflow: hidden`
+ * notwithstanding: iOS keeps scrolling the document by touch regardless, so
+ * the page creeps behind the overlay and — with the page at the top — the
+ * gesture is read as a pull-to-refresh instead of scrolling the overlay's own
+ * content. The shared lock pins the body with `position: fixed`, which iOS
+ * does honour, and `usePullToRefresh` sits the gesture out while it is held.
+ */
+export const useBodyScrollLock = (locked: boolean) => {
+  useEffect(() => {
+    if (!locked) return;
+
+    lockBodyScroll();
+    return unlockBodyScroll;
+  }, [locked]);
+};

--- a/frontend/src/pages/BookPage/navigation/FilterDrawer.tsx
+++ b/frontend/src/pages/BookPage/navigation/FilterDrawer.tsx
@@ -1,3 +1,4 @@
+import { useBodyScrollLock } from '@/hooks/useBodyScrollLock.ts';
 import { CloseIcon } from '@/theme/Icons.tsx';
 import { Box, Drawer, IconButton, Tab, Tabs } from '@mui/material';
 import { type ReactNode, useState } from 'react';
@@ -17,6 +18,8 @@ interface FilterDrawerProps {
 export const FilterDrawer = ({ open, onClose, tabs, header }: FilterDrawerProps) => {
   const [activeTab, setActiveTab] = useState(0);
 
+  useBodyScrollLock(open);
+
   const handleClose = () => {
     onClose();
     setActiveTab(0);
@@ -24,7 +27,9 @@ export const FilterDrawer = ({ open, onClose, tabs, header }: FilterDrawerProps)
 
   return (
     <Drawer anchor="bottom" open={open} onClose={handleClose}>
-      <Box sx={{ p: 2, pb: 6, maxHeight: '80vh', overflow: 'auto' }}>
+      {/* The drawer scrolls its own content; `contain` keeps a pull that runs
+          past either end from chaining out to the page behind it. */}
+      <Box sx={{ p: 2, pb: 6, maxHeight: '80vh', overflow: 'auto', overscrollBehavior: 'contain' }}>
         {/* Drag handle */}
         <Box sx={{ display: 'flex', justifyContent: 'center', mb: 1 }}>
           <Box

--- a/frontend/src/pages/BookPage/navigation/FilterDrawer.tsx
+++ b/frontend/src/pages/BookPage/navigation/FilterDrawer.tsx
@@ -27,9 +27,13 @@ export const FilterDrawer = ({ open, onClose, tabs, header }: FilterDrawerProps)
 
   return (
     <Drawer anchor="bottom" open={open} onClose={handleClose}>
-      {/* The drawer scrolls its own content; `contain` keeps a pull that runs
-          past either end from chaining out to the page behind it. */}
-      <Box sx={{ p: 2, pb: 6, maxHeight: '80vh', overflow: 'auto', overscrollBehavior: 'contain' }}>
+      {/* Capped against the *dynamic* viewport, so the drawer stays clear of
+          mobile browser chrome however much of it is showing. It scrolls its
+          own content; `contain` keeps a pull that runs past either end from
+          chaining out to the page behind it. */}
+      <Box
+        sx={{ p: 2, pb: 6, maxHeight: '80dvh', overflow: 'auto', overscrollBehavior: 'contain' }}
+      >
         {/* Drag handle */}
         <Box sx={{ display: 'flex', justifyContent: 'center', mb: 1 }}>
           <Box


### PR DESCRIPTION
The bottom filter drawer left the document scroller live: on iOS, MUI's
own `overflow: hidden` does not stop a touch from scrolling the body, so
a swipe over the drawer scrolled the page behind it and — with the page
at the top — was read as a pull-to-refresh instead of scrolling the
drawer's filters.

Reuse the reference-counted body scroll lock the dialogs already hold,
extracted into a `useBodyScrollLock` hook so both callers share it. It
pins the body with `position: fixed` (which iOS honours) and, because
`usePullToRefresh` sits out while the lock is held, takes the drawer's
swipes out of the refresh gesture. The drawer's own scroller also gets
`overscroll-behavior: contain` so a pull past either end does not chain
out to the page.

Fixes #648

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RVhdvFkDHXXwxkvY6pK73o