### PR TITLE
Make the Railway deploy branch-aware and quiet about the environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,9 @@ release-nightly: ## Build and push nightly Docker image to Docker Hub
 # (plain `railway redeploy` reuses the cached digest, so it won't pull a new build).
 # Requires RAILWAY_API_TOKEN (railway.com -> Account -> Tokens; NOT RAILWAY_TOKEN).
 # No `railway login` needed — the script talks to the API directly.
-deploy: ## Build+push nightly image and deploy it to Railway
+# Deploys whatever branch is checked out, tagging the image after it; the moving
+# :nightly tag is only refreshed on main.
+deploy: ## Build+push an image of the current branch and deploy it to Railway
 	set -a; [ -f .env.deploy ] && . ./.env.deploy; set +a; ./scripts/railway-deploy.sh
 
 empty-s3-bucket: ## Remove all objects from the local S3 bucket

--- a/scripts/build-for-docker-hub.sh
+++ b/scripts/build-for-docker-hub.sh
@@ -1,7 +1,12 @@
 #!/bin/bash
-# Usage: ./build-for-docker-hub.sh
-# Builds and pushes nightly release to Docker Hub with a unique tag.
+# Usage: ./build-for-docker-hub.sh [UNIQUE_TAG]
+# Builds and pushes a nightly image to Docker Hub under a unique tag.
 # Stable releases should be done by CI.
+#
+# The moving :nightly tag is refreshed only for builds of main, so that
+# deploying a feature branch (see railway-deploy.sh) cannot repoint the tag
+# other people pull. MOVE_NIGHTLY=1/0 overrides; when unset it is inferred from
+# the checked-out branch, so callers on a detached HEAD must set it explicitly.
 #
 # Requires `docker buildx` (BuildKit). Bundled with Docker Engine 23+ on Linux.
 # On macOS with the Homebrew docker CLI (no Docker Desktop):
@@ -15,14 +20,25 @@ set -e # Exit on error
 # Optional first arg pins the unique tag (so callers can deploy that exact image).
 UNIQUE_TAG="${1:-nightly-$(date +%Y%m%d%H%M%S)}"
 
-echo "Building and pushing nightly release (${UNIQUE_TAG})..."
+BRANCH="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)"
+MOVE_NIGHTLY="${MOVE_NIGHTLY:-$([ "$BRANCH" = "main" ] && echo 1 || echo 0)}"
+
+TAGS=(-t "tumetsu/crossbill:${UNIQUE_TAG}")
+if [ "$MOVE_NIGHTLY" = "1" ]; then
+  TAGS+=(-t tumetsu/crossbill:nightly)
+fi
+
+echo "Building and pushing ${UNIQUE_TAG}..."
 
 docker buildx build \
   --platform linux/amd64 \
-  -t tumetsu/crossbill:nightly \
-  -t "tumetsu/crossbill:${UNIQUE_TAG}" \
+  "${TAGS[@]}" \
   -f ./Dockerfile \
   --push \
   .
 
-echo "Pushed tags: nightly, ${UNIQUE_TAG}"
+if [ "$MOVE_NIGHTLY" = "1" ]; then
+  echo "Pushed tags: nightly, ${UNIQUE_TAG}"
+else
+  echo "Pushed tag: ${UNIQUE_TAG}"
+fi

--- a/scripts/railway-deploy.sh
+++ b/scripts/railway-deploy.sh
@@ -16,6 +16,15 @@
 #                         Resource IDs (not kept in-repo). Find them once with
 #                         `railway status --json` and export alongside the token.
 #   - docker buildx, jq, curl
+#
+# Optional:
+#   - DEPLOY_REF            Ref being deployed; defaults to the checked-out
+#                           branch. Set it when HEAD is detached (CI), since it
+#                           names the image tag and decides whether the moving
+#                           :nightly tag moves.
+#   - RAILWAY_DEPLOY_DEBUG  Dump raw API responses on error. Off by default: the
+#                           responses carry project and service names, and this
+#                           also runs in CI logs.
 set -euo pipefail
 
 : "${RAILWAY_API_TOKEN:?Set RAILWAY_API_TOKEN (railway.com -> Account -> Tokens; NOT RAILWAY_TOKEN)}"
@@ -25,11 +34,25 @@ ENVIRONMENT_ID="${RAILWAY_ENVIRONMENT_ID:?Set RAILWAY_ENVIRONMENT_ID (find it wi
 API="https://backboard.railway.com/graphql/v2"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
-TAG="nightly-$(date +%Y%m%d%H%M%S)"
+# Any ref can be deployed, so the tag records which one: a bare timestamp cannot
+# tell a main deploy from a branch one, and the tag is what Railway shows as live.
+REF_NAME="${DEPLOY_REF:-$(git rev-parse --abbrev-ref HEAD)}"
+SHORT_SHA="$(git rev-parse --short HEAD)"
+# Docker tags allow [A-Za-z0-9_.-] only and must not start with . or -, so refs
+# like `feat/thing` need slugging.
+REF_SLUG="$(printf '%s' "$REF_NAME" | tr '[:upper:]' '[:lower:]' |
+  sed -e 's#[^a-z0-9._-]#-#g' -e 's#^[^a-z0-9_]*##' | cut -c1-40)"
+[ -n "$REF_SLUG" ] || REF_SLUG="ref"
+# The timestamp stays: redeploying the same commit must still produce an image
+# reference Railway has not seen, or it serves the cached digest.
+TAG="${REF_SLUG}-${SHORT_SHA}-$(date +%Y%m%d%H%M%S)"
 IMAGE="tumetsu/crossbill:${TAG}"
 
-# 1. Build & push the pinned tag (also refreshes the moving :nightly tag).
-"${SCRIPT_DIR}/build-for-docker-hub.sh" "$TAG"
+echo "Deploying ${REF_NAME} (${SHORT_SHA}) as ${IMAGE}"
+
+# 1. Build & push the pinned tag (:nightly moves only for main; see the build script).
+MOVE_NIGHTLY="$([ "$REF_NAME" = "main" ] && echo 1 || echo 0)" \
+  "${SCRIPT_DIR}/build-for-docker-hub.sh" "$TAG"
 
 gql() {
   # $1 = full JSON request body; echoes the response, fails on a GraphQL error.
@@ -39,7 +62,10 @@ gql() {
     -H "Content-Type: application/json" \
     --data "$1")"
   if echo "$resp" | jq -e '.errors' >/dev/null 2>&1; then
-    echo "Railway API error: $resp" >&2
+    # Only the GraphQL messages: the full body can name the project, service and
+    # domain, and this runs somewhere the log outlives the deploy.
+    echo "Railway API error: $(echo "$resp" | jq -c '[.errors[].message]' 2>/dev/null || echo '[unparseable response]')" >&2
+    if [ -n "${RAILWAY_DEPLOY_DEBUG:-}" ]; then echo "$resp" >&2; fi
     exit 1
   fi
   printf '%s' "$resp"


### PR DESCRIPTION
Any ref can now be deployed, not just main, so the image tag records which
one: <ref-slug>-<short-sha>-<timestamp> instead of a bare timestamp, which
could not tell a main deploy from a branch one. DEPLOY_REF names the ref
when HEAD is detached.

The moving :nightly tag now only moves for main — a branch deploy must not
repoint the tag other people pull.

API errors no longer dump the raw GraphQL response, which carries project
and service names; only the error messages are printed, with the body behind
RAILWAY_DEPLOY_DEBUG. This runs where logs can outlive the deploy.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017xE4P6K77Q9pW65bCpM7k2