### PR TITLE
Add note and reading-session counts to the book stats strip

### DIFF
--- a/frontend/src/pages/BookPage/BookPage.test.tsx
+++ b/frontend/src/pages/BookPage/BookPage.test.tsx
@@ -1,4 +1,5 @@
-import { aBookDetails, aChapter } from '@tests/fixtures/book';
+import { aBookDetails, aChapter, aHighlight } from '@tests/fixtures/book';
+import { aNote } from '@tests/fixtures/notes';
 import { renderApp } from '@tests/harness/renderApp';
 import { bookApi } from '@tests/msw/bookApi';
 import { worker } from '@tests/msw/worker';
@@ -34,4 +35,36 @@ test('a book can be marked as not finished, and the chip keeps saying so', async
 
   await expect.element(screen.getByRole('button', { name: 'Did not finish' })).toBeVisible();
   expect(state.book.reading_stage).toBe('did_not_finish');
+});
+
+test('the stats strip counts highlights, notes, flashcards and reading sessions', async () => {
+  const { handlers } = bookApi({
+    book: aBookDetails({
+      chapters: [aChapter({ highlights: [aHighlight({ id: 300 }), aHighlight({ id: 301 })] })],
+    }),
+    notes: [aNote({ id: 1 }), aNote({ id: 2, kind: null })],
+    sessionTotal: 8,
+  });
+  worker.use(...handlers);
+
+  const screen = await renderApp({ path: '/book/1' });
+
+  await expect.element(screen.getByText('2 highlights')).toBeVisible();
+  await expect.element(screen.getByText('2 notes')).toBeVisible();
+  await expect.element(screen.getByText('0 flashcards')).toBeVisible();
+  await expect.element(screen.getByText('8 sessions')).toBeVisible();
+});
+
+// Gists are auto-generated per chapter and the Notes tab hides them by
+// default, so counting them here would show a total the tab never matches.
+test('the note count leaves out gists', async () => {
+  const { handlers } = bookApi({
+    book: aBookDetails(),
+    notes: [aNote({ id: 1 }), aNote({ id: 2, kind: 'gist' }), aNote({ id: 3, kind: 'gist' })],
+  });
+  worker.use(...handlers);
+
+  const screen = await renderApp({ path: '/book/1' });
+
+  await expect.element(screen.getByText('1 notes')).toBeVisible();
 });

--- a/frontend/src/pages/BookPage/BookTitle/BookStatsStrip.tsx
+++ b/frontend/src/pages/BookPage/BookTitle/BookStatsStrip.tsx
@@ -1,5 +1,7 @@
 import type { BookDetails } from '@/api/generated/model';
+import { useGetNotesForBook } from '@/api/generated/notes/notes.ts';
 import { useGetBookReadingSessions } from '@/api/generated/reading-sessions/reading-sessions';
+import { DEFAULT_NOTE_KINDS, noteKindOf } from '@/pages/BookPage/Notes/noteKinds';
 import { formatDate } from '@/utils/date';
 import { Box, Typography } from '@mui/material';
 
@@ -9,12 +11,18 @@ interface BookStatsStripProps {
 
 export const BookStatsStrip = ({ book }: BookStatsStripProps) => {
   const { data: sessionsData } = useGetBookReadingSessions(book.id, { limit: 1 });
+  const { data: notesData } = useGetNotesForBook(book.id);
 
   // Count highlights across all chapters
   const highlightCount = book.chapters.reduce((sum, chapter) => sum + chapter.highlights.length, 0);
 
   // Count flashcards
   const flashcardCount = book.book_flashcards?.length ?? 0;
+
+  // Gists are excluded so this matches what the Notes tab lists by default.
+  const noteCount = (notesData?.items ?? []).filter((note) =>
+    DEFAULT_NOTE_KINDS.includes(noteKindOf(note.kind))
+  ).length;
 
   // Last read date from latest session
   const latestSession = sessionsData?.items[0];
@@ -23,7 +31,9 @@ export const BookStatsStrip = ({ book }: BookStatsStripProps) => {
   const items = [
     book.page_count ? `${book.page_count} pages` : null,
     `${highlightCount} highlights`,
+    `${noteCount} notes`,
     `${flashcardCount} flashcards`,
+    `${sessionsData?.total ?? 0} sessions`,
     `Added ${formatDate(book.created_at)}`,
     lastReadDate ? `Last read ${lastReadDate}` : null,
   ].filter(Boolean);

--- a/frontend/tests/msw/bookApi.ts
+++ b/frontend/tests/msw/bookApi.ts
@@ -10,6 +10,7 @@ import { aBookDetails } from '../fixtures/book';
 interface BookApiState {
   book: BookDetails;
   notes: NoteWithLinks[];
+  sessionTotal: number;
 }
 
 /**
@@ -21,6 +22,7 @@ export function bookApi(initial: Partial<BookApiState> = {}) {
   const state: BookApiState = {
     book: initial.book ?? aBookDetails(),
     notes: initial.notes ?? [],
+    sessionTotal: initial.sessionTotal ?? 0,
   };
 
   const findNote = (noteId: string | readonly string[] | undefined) =>
@@ -31,7 +33,7 @@ export function bookApi(initial: Partial<BookApiState> = {}) {
     http.get('/api/v1/books/:bookId/notes', () => HttpResponse.json({ items: state.notes })),
     http.get('/api/v1/books/:bookId/digest', () => HttpResponse.json({ items: [] })),
     http.get('/api/v1/books/:bookId/reading_sessions', () =>
-      HttpResponse.json({ items: [], total: 0, offset: 0, limit: 1 })
+      HttpResponse.json({ items: [], total: state.sessionTotal, offset: 0, limit: 1 })
     ),
     http.get('/api/v1/jobs/books/:bookId/digest', () => HttpResponse.json(null)),
     http.get('/api/v1/books/:bookId/tags', () => HttpResponse.json({ items: [] })),


### PR DESCRIPTION
Fixes #652

## What

The stats line in the book page header listed highlights and flashcards but not notes, so there was no way to see a book's note count without opening the Notes tab. The ticket also asked about a session count, so that is in too.

The strip now reads:

```
320 pages · 17 highlights · 12 notes · 0 flashcards · 8 sessions · Added Mar 25, 2026 · Last read Apr 18, 2026
```

## Notes on the two counts

- **Notes** come from the existing `GET /books/:id/notes` endpoint, filtered by `DEFAULT_NOTE_KINDS`. Gists are excluded: they are generated per chapter and the Notes tab hides them by default, so counting them would show a total the tab never matches.
- **Sessions** use `total` from the reading-sessions response the strip already fetches for the "Last read" date, so this costs no extra request.

## How to verify

- Full frontend suite passes (95 tests), including two new route-level tests in `BookPage.test.tsx` covering the counts and the gist exclusion.
- `type-check`, `lint`, `format:check`, `knip` and `duplication-check` all pass.
- Rendered in the browser test and checked the screenshot — the strip still fits on one line with the two extra items.

## Not done

The strip does not pluralise, so a book with one note reads "1 notes" — pre-existing behaviour ("1 highlights" too). Left alone to keep the change to the ticket's scope; happy to add a pluralise helper across the whole strip if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ft2M6DWiK3dVYSDCGzt5Mv