### PR TITLE
Normalise KOReader highlight timestamps to ISO in the backend

### DIFF
--- a/backend/alembic/versions/070_highlight_datetime_to_timestamp.py
+++ b/backend/alembic/versions/070_highlight_datetime_to_timestamp.py
@@ -1,0 +1,74 @@
+"""Store highlight device timestamps as timestamps, not KOReader strings
+
+``datetime`` and ``koreader_updated_at`` arrived as KOReader's own
+``yyyy-MM-dd HH:mm:ss`` text and were passed through unnormalised, so the web
+client needed a bespoke parser for them while every other timestamp the API
+sends is ISO (#664). They become ``TIMESTAMP WITHOUT TIME ZONE``: KOReader
+writes device-local wall time with no offset, and none is invented here.
+
+Existing rows are converted in place. Deduplication keys on ``content_hash``
+alone, so rewriting these columns cannot make a re-sync look like new
+highlights. A ``datetime`` that does not parse falls back to the row's
+``created_at`` -- the insert time of the sync that carried it, which is a real
+instant and always present -- because the column is NOT NULL; an unparseable
+``koreader_updated_at`` becomes NULL, which reads as "never edited on a
+device".
+
+Revision ID: 070
+Revises: 069
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "070"
+down_revision: str | Sequence[str] | None = "069"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+# Postgres' own ``timestamp`` cast accepts both the KOReader separator and the
+# ISO one, so the guard only has to reject text that is not a timestamp at all.
+_TIMESTAMP_TEXT = r"^\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}:\d{2}"
+
+UPGRADE_DATETIME = f"""
+ALTER TABLE highlights
+    ALTER COLUMN datetime TYPE TIMESTAMP WITHOUT TIME ZONE
+    USING CASE
+        WHEN datetime ~ '{_TIMESTAMP_TEXT}' THEN datetime::timestamp
+        ELSE created_at AT TIME ZONE 'UTC'
+    END
+"""
+
+UPGRADE_UPDATED_AT = f"""
+ALTER TABLE highlights
+    ALTER COLUMN koreader_updated_at TYPE TIMESTAMP WITHOUT TIME ZONE
+    USING CASE
+        WHEN koreader_updated_at ~ '{_TIMESTAMP_TEXT}' THEN koreader_updated_at::timestamp
+    END
+"""
+
+DOWNGRADE_DATETIME = """
+ALTER TABLE highlights
+    ALTER COLUMN datetime TYPE VARCHAR(50)
+    USING to_char(datetime, 'YYYY-MM-DD HH24:MI:SS')
+"""
+
+DOWNGRADE_UPDATED_AT = """
+ALTER TABLE highlights
+    ALTER COLUMN koreader_updated_at TYPE VARCHAR(50)
+    USING to_char(koreader_updated_at, 'YYYY-MM-DD HH24:MI:SS')
+"""
+
+
+def upgrade() -> None:
+    op.execute(sa.text(UPGRADE_DATETIME))
+    op.execute(sa.text(UPGRADE_UPDATED_AT))
+
+
+def downgrade() -> None:
+    op.execute(sa.text(DOWNGRADE_DATETIME))
+    op.execute(sa.text(DOWNGRADE_UPDATED_AT))

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -847,7 +847,7 @@
           "highlights"
         ],
         "summary": "Sync Highlights",
-        "description": "Sync highlights from KOReader.\n\nCreates or updates book record and adds highlights with automatic deduplication.\nDuplicates are identified by the combination of book, text, and datetime.\n\n``removed_ids`` carries the highlights the reader deleted on the device:\nthey are withheld from every device's pull and stay whole on the web.\n\nA highlight flagged ``is_new`` was created on the device after its last\npull, so a duplicate of a removed or deleted highlight is a deliberate\nre-highlight and brings that highlight back.\n\nArgs:\n    request: Highlight sync request containing book metadata and highlights\n\nReturns:\n    HighlightSyncResponse with sync statistics\n\nRaises:\n    HTTPException: If the sync fails due to server error",
+        "description": "Sync highlights from KOReader.\n\nCreates or updates book record and adds highlights with automatic deduplication.\nDuplicates are identified by book and highlighted text alone: a highlight's\ntimestamps say when the device made and edited it, and take no part in\ndeciding whether it is the same highlight.\n\n``removed_ids`` carries the highlights the reader deleted on the device:\nthey are withheld from every device's pull and stay whole on the web.\n\nA highlight flagged ``is_new`` was created on the device after its last\npull, so a duplicate of a removed or deleted highlight is a deliberate\nre-highlight and brings that highlight back.\n\nArgs:\n    request: Highlight sync request containing book metadata and highlights\n\nReturns:\n    HighlightSyncResponse with sync statistics\n\nRaises:\n    HTTPException: If the sync fails due to server error",
         "operationId": "upload_highlights",
         "deprecated": true,
         "security": [
@@ -929,7 +929,7 @@
           "highlights"
         ],
         "summary": "Sync Highlights",
-        "description": "Sync highlights from KOReader.\n\nCreates or updates book record and adds highlights with automatic deduplication.\nDuplicates are identified by the combination of book, text, and datetime.\n\n``removed_ids`` carries the highlights the reader deleted on the device:\nthey are withheld from every device's pull and stay whole on the web.\n\nA highlight flagged ``is_new`` was created on the device after its last\npull, so a duplicate of a removed or deleted highlight is a deliberate\nre-highlight and brings that highlight back.\n\nArgs:\n    request: Highlight sync request containing book metadata and highlights\n\nReturns:\n    HighlightSyncResponse with sync statistics\n\nRaises:\n    HTTPException: If the sync fails due to server error",
+        "description": "Sync highlights from KOReader.\n\nCreates or updates book record and adds highlights with automatic deduplication.\nDuplicates are identified by book and highlighted text alone: a highlight's\ntimestamps say when the device made and edited it, and take no part in\ndeciding whether it is the same highlight.\n\n``removed_ids`` carries the highlights the reader deleted on the device:\nthey are withheld from every device's pull and stay whole on the web.\n\nA highlight flagged ``is_new`` was created on the device after its last\npull, so a duplicate of a removed or deleted highlight is a deliberate\nre-highlight and brings that highlight back.\n\nArgs:\n    request: Highlight sync request containing book metadata and highlights\n\nReturns:\n    HighlightSyncResponse with sync statistics\n\nRaises:\n    HTTPException: If the sync fails due to server error",
         "operationId": "sync_highlights",
         "security": [
           {
@@ -6329,10 +6329,9 @@
           },
           "datetime": {
             "type": "string",
-            "maxLength": 50,
-            "minLength": 1,
+            "format": "date-time",
             "title": "Datetime",
-            "description": "KOReader datetime format"
+            "description": "When the highlight was made, on the device's own clock. Sent without a UTC offset because the e-reader does not know one; KOReader's 'YYYY-MM-DD HH:MM:SS' is accepted on the way in."
           },
           "id": {
             "type": "integer",
@@ -6461,10 +6460,9 @@
           },
           "datetime": {
             "type": "string",
-            "maxLength": 50,
-            "minLength": 1,
+            "format": "date-time",
             "title": "Datetime",
-            "description": "KOReader datetime format"
+            "description": "When the highlight was made, on the device's own clock. Sent without a UTC offset because the e-reader does not know one; KOReader's 'YYYY-MM-DD HH:MM:SS' is accepted on the way in."
           },
           "start_xpoint": {
             "anyOf": [
@@ -6530,14 +6528,14 @@
             "anyOf": [
               {
                 "type": "string",
-                "maxLength": 50
+                "format": "date-time"
               },
               {
                 "type": "null"
               }
             ],
             "title": "Datetime Updated",
-            "description": "KOReader datetime of the last edit on the device; absent until the highlight is first edited. The newest edit wins when devices disagree."
+            "description": "When the highlight was last edited on the device, on that device's own clock; absent until the highlight is first edited. The newest edit wins when devices disagree."
           },
           "is_new": {
             "type": "boolean",
@@ -6853,10 +6851,9 @@
           },
           "datetime": {
             "type": "string",
-            "maxLength": 50,
-            "minLength": 1,
+            "format": "date-time",
             "title": "Datetime",
-            "description": "KOReader datetime format"
+            "description": "When the highlight was made, on the device's own clock. Sent without a UTC offset because the e-reader does not know one; KOReader's 'YYYY-MM-DD HH:MM:SS' is accepted on the way in."
           },
           "id": {
             "type": "integer",
@@ -6995,6 +6992,7 @@
           },
           "datetime": {
             "type": "string",
+            "format": "date-time",
             "title": "Datetime"
           },
           "cover_file": {

--- a/backend/src/application/common/queries/highlight_row.py
+++ b/backend/src/application/common/queries/highlight_row.py
@@ -34,7 +34,7 @@ class HighlightRow:
     chapter_number: int | None
     text: str
     page: int | None
-    datetime: str
+    datetime: dt
     label: HighlightLabelView | None
     removed_from_devices: bool
     tags: tuple[TagRef, ...]

--- a/backend/src/application/learning/queries/book_flashcards.py
+++ b/backend/src/application/learning/queries/book_flashcards.py
@@ -24,7 +24,7 @@ class FlashcardHighlightView:
     chapter_number: int | None
     text: str
     page: int | None
-    datetime: str
+    datetime: dt
     label: HighlightLabelView | None
     tags: tuple[TagRef, ...]
     created_at: dt

--- a/backend/src/application/reading/commands/highlights/highlight_upload_use_case.py
+++ b/backend/src/application/reading/commands/highlights/highlight_upload_use_case.py
@@ -6,6 +6,7 @@ No Pydantic dependencies - works with domain entities only.
 """
 
 from dataclasses import dataclass
+from datetime import datetime as dt
 
 import structlog
 
@@ -52,8 +53,8 @@ class HighlightUploadData:
     page: int | None = None
     color: str | None = None
     drawer: str | None = None
-    datetime: str | None = None
-    datetime_updated: str | None = None
+    datetime: dt | None = None
+    datetime_updated: dt | None = None
     koreader_note: str | None = None
     # Set by the device for a highlight it created after its last pull; tells a
     # deliberate re-highlight from a stale echo of one already removed or deleted.
@@ -229,7 +230,7 @@ class HighlightUploadUseCase:
                 page=data.page,
                 position=position,
                 highlight_style_id=highlight_style.id,
-                datetime_str=data.datetime,
+                device_datetime=data.datetime,
                 koreader_updated_at=data.datetime_updated,
                 koreader_note=data.koreader_note,
                 origin_device_id=device_id,
@@ -420,8 +421,9 @@ class HighlightUploadUseCase:
         ``datetime_updated`` (its creation ``datetime`` until it is first
         edited) is compared against the one stored, and the incoming edit is
         applied only if it is strictly newer. Equal timestamps keep the
-        server's copy. The strings are KOReader's "%Y-%m-%d %H:%M:%S", which
-        orders correctly as text, so no parsing is needed. A stored highlight
+        server's copy. Both sides are offsetless device wall clocks, so the
+        comparison is only as good as the devices' agreement about the time --
+        the same approximation KOReader itself lives with. A stored highlight
         that has never received a device edit accepts the first one whatever
         its time: there is nothing to protect, and rows uploaded before notes
         were kept carry a server-side ``datetime`` that a device edit made

--- a/backend/src/application/reading/protocols/highlight_repository.py
+++ b/backend/src/application/reading/protocols/highlight_repository.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from datetime import datetime as dt
 from typing import Protocol
 
 from src.domain.common.value_objects import ContentHash, XPointRange
@@ -27,7 +28,7 @@ class DeviceEdit:
     highlight_id: HighlightId
     koreader_note: str | None
     highlight_style_id: HighlightStyleId | None
-    koreader_updated_at: str
+    koreader_updated_at: dt
 
 
 class HighlightRepositoryProtocol(Protocol):

--- a/backend/src/application/reading/queries/ereader_highlights.py
+++ b/backend/src/application/reading/queries/ereader_highlights.py
@@ -5,6 +5,7 @@ never be fed back into a command. See ``docs/adr/0001-read-models-and-query-serv
 """
 
 from dataclasses import dataclass
+from datetime import datetime as dt
 from typing import Protocol
 
 from src.domain.common.value_objects.ids import BookId, UserId
@@ -26,8 +27,8 @@ class EreaderHighlightView:
     text: str
     start_xpoint: str | None
     end_xpoint: str | None
-    datetime: str
-    datetime_updated: str | None
+    datetime: dt
+    datetime_updated: dt | None
     page: int | None
     chapter_number: int | None
     chapter_name: str | None

--- a/backend/src/application/reading/queries/reading_sessions.py
+++ b/backend/src/application/reading/queries/reading_sessions.py
@@ -25,7 +25,7 @@ class SessionHighlightView:
     chapter_id: int | None
     text: str
     page: int | None
-    datetime: str
+    datetime: dt
     label: HighlightLabelView | None
     removed_from_devices: bool
     created_at: dt

--- a/backend/src/application/semantic/queries/content_search.py
+++ b/backend/src/application/semantic/queries/content_search.py
@@ -19,6 +19,7 @@ never be fed back into a command. See ``docs/adr/0001-read-models-and-query-serv
 
 from collections.abc import Awaitable, Callable, Sequence
 from dataclasses import dataclass
+from datetime import datetime as dt
 from typing import Protocol
 
 from src.application.semantic.content_type import ContentType
@@ -48,7 +49,7 @@ class HighlightSearchView:
     chapter_number: int | None
     text: str
     page: int | None
-    datetime: str
+    datetime: dt
     cover_file: str | None
     cover_blurhash: str | None
 

--- a/backend/src/domain/reading/entities/highlight.py
+++ b/backend/src/domain/reading/entities/highlight.py
@@ -25,6 +25,16 @@ from src.domain.common.value_objects import (
 from src.domain.common.value_objects.position import Position
 
 
+def device_clock_now() -> dt_module.datetime:
+    """Server time as an offsetless wall clock.
+
+    Stands in for a device timestamp when the e-reader sends none, so the
+    substitute has the same shape as the real thing: a wall-clock reading with
+    no zone attached.
+    """
+    return dt_module.datetime.now(UTC).replace(tzinfo=None)
+
+
 @dataclass
 class Highlight(AggregateRoot[HighlightId]):
     """
@@ -59,8 +69,10 @@ class Highlight(AggregateRoot[HighlightId]):
     highlight_style_id: HighlightStyleId | None = None
 
     # Metadata
-    datetime: str = ""  # KOReader datetime string
-    koreader_updated_at: str | None = None  # KOReader datetime of the last edit on the device
+    # Device-local wall clock with no offset: the e-reader does not send one, so
+    # none is invented here. Ordering across timezones is approximate.
+    datetime: dt_module.datetime = field(default_factory=device_clock_now)
+    koreader_updated_at: dt_module.datetime | None = None  # Last edit on the device
     koreader_note: str | None = None  # Note written on the e-reader; not the Notes module
     origin_device_id: str | None = None  # Device the highlight was uploaded from
     created_at: dt_module.datetime = field(default_factory=lambda: dt_module.datetime.now(UTC))
@@ -181,8 +193,8 @@ class Highlight(AggregateRoot[HighlightId]):
         page: int | None = None,
         position: Position | None = None,
         highlight_style_id: HighlightStyleId | None = None,
-        datetime_str: str | None = None,
-        koreader_updated_at: str | None = None,
+        device_datetime: dt_module.datetime | None = None,
+        koreader_updated_at: dt_module.datetime | None = None,
         koreader_note: str | None = None,
         origin_device_id: str | None = None,
     ) -> Highlight:
@@ -197,7 +209,7 @@ class Highlight(AggregateRoot[HighlightId]):
             xpoints: Optional XPoint range for precise position
             page: Optional page number
             position: Optional Position for document-order location
-            datetime_str: Device-side creation time (KOReader format); server time when absent
+            device_datetime: Device-side creation time; server time when absent
             koreader_updated_at: Device-side time of the last edit; None until first edited
             koreader_note: Note attached to the highlight on the e-reader
             origin_device_id: Device the upload batch came from
@@ -210,8 +222,8 @@ class Highlight(AggregateRoot[HighlightId]):
         """
         highlight_text = text
         now = dt_module.datetime.now(UTC)
-        if not datetime_str:
-            datetime_str = now.strftime("%Y-%m-%d %H:%M:%S")
+        if device_datetime is None:
+            device_datetime = device_clock_now()
 
         return cls(
             id=HighlightId.generate(),  # Generate new ID
@@ -223,7 +235,7 @@ class Highlight(AggregateRoot[HighlightId]):
             page=page,
             position=position,
             highlight_style_id=highlight_style_id,
-            datetime=datetime_str,
+            datetime=device_datetime,
             koreader_updated_at=koreader_updated_at,
             koreader_note=koreader_note,
             origin_device_id=origin_device_id,
@@ -240,7 +252,7 @@ class Highlight(AggregateRoot[HighlightId]):
         user_id: UserId,
         book_id: BookId,
         text: str,
-        datetime_str: str,
+        device_datetime: dt_module.datetime,
         created_at: dt_module.datetime,
         updated_at: dt_module.datetime,
         chapter_id: ChapterId | None = None,
@@ -250,7 +262,7 @@ class Highlight(AggregateRoot[HighlightId]):
         highlight_style_id: HighlightStyleId | None = None,
         deleted_at: dt_module.datetime | None = None,
         removed_from_devices_at: dt_module.datetime | None = None,
-        koreader_updated_at: str | None = None,
+        koreader_updated_at: dt_module.datetime | None = None,
         koreader_note: str | None = None,
         origin_device_id: str | None = None,
     ) -> Highlight:
@@ -269,7 +281,7 @@ class Highlight(AggregateRoot[HighlightId]):
             page=page,
             position=position,
             highlight_style_id=highlight_style_id,
-            datetime=datetime_str,
+            datetime=device_datetime,
             koreader_updated_at=koreader_updated_at,
             koreader_note=koreader_note,
             origin_device_id=origin_device_id,

--- a/backend/src/infrastructure/reading/mappers/highlight_mapper.py
+++ b/backend/src/infrastructure/reading/mappers/highlight_mapper.py
@@ -48,7 +48,7 @@ class HighlightMapper:
             user_id=UserId(orm_model.user_id),
             book_id=BookId(orm_model.book_id),
             text=orm_model.text,
-            datetime_str=orm_model.datetime,
+            device_datetime=orm_model.datetime,
             created_at=orm_model.created_at,
             updated_at=orm_model.updated_at,
             chapter_id=ChapterId(orm_model.chapter_id) if orm_model.chapter_id else None,
@@ -87,14 +87,11 @@ class HighlightMapper:
             start_xpoint = domain_entity.xpoints.start.to_string()
             end_xpoint = domain_entity.xpoints.end.to_string()
 
-        # Use datetime string from entity (already formatted)
-        datetime_str = domain_entity.datetime
-
         # Update existing ORM model or create new one
         if orm_model is None:
             orm_model = HighlightORM(
                 id=orm_id(domain_entity.id),
-                datetime=datetime_str,
+                datetime=domain_entity.datetime,
                 created_at=domain_entity.created_at,
             )
         orm_model.user_id = domain_entity.user_id.value

--- a/backend/src/infrastructure/reading/orm/highlight_model.py
+++ b/backend/src/infrastructure/reading/orm/highlight_model.py
@@ -48,10 +48,11 @@ class Highlight(Base):
     highlight_style_id: Mapped[int | None] = mapped_column(
         ForeignKey("highlight_styles.id", ondelete="SET NULL"), index=True, nullable=True
     )
-    datetime: Mapped[str] = mapped_column(String(50), nullable=False)  # KOReader datetime string
-    koreader_updated_at: Mapped[str | None] = mapped_column(
-        String(50), nullable=True
-    )  # KOReader datetime string of the last edit on the device
+    # The e-reader's own wall clock, with no offset to attach it to an instant.
+    datetime: Mapped[dt] = mapped_column(DateTime(timezone=False), nullable=False)
+    koreader_updated_at: Mapped[dt | None] = mapped_column(
+        DateTime(timezone=False), nullable=True
+    )  # Device-side time of the last edit on the device
     koreader_note: Mapped[str | None] = mapped_column(Text, nullable=True)
     origin_device_id: Mapped[str | None] = mapped_column(String(100), nullable=True)
     content_hash: Mapped[str] = mapped_column(

--- a/backend/src/infrastructure/reading/routers/highlights.py
+++ b/backend/src/infrastructure/reading/routers/highlights.py
@@ -84,7 +84,9 @@ async def sync_highlights(
     Sync highlights from KOReader.
 
     Creates or updates book record and adds highlights with automatic deduplication.
-    Duplicates are identified by the combination of book, text, and datetime.
+    Duplicates are identified by book and highlighted text alone: a highlight's
+    timestamps say when the device made and edited it, and take no part in
+    deciding whether it is the same highlight.
 
     ``removed_ids`` carries the highlights the reader deleted on the device:
     they are withheld from every device's pull and stay whole on the web.

--- a/backend/src/infrastructure/reading/schemas/ereader_highlight_schemas.py
+++ b/backend/src/infrastructure/reading/schemas/ereader_highlight_schemas.py
@@ -1,6 +1,14 @@
 """Pydantic schemas for the ereader highlight-pull API."""
 
-from pydantic import BaseModel
+from datetime import datetime as dt
+from typing import Final
+
+from pydantic import BaseModel, field_serializer
+
+# KOReader's own timestamp format. The plugin writes what we send here straight
+# into a device annotation, so this response keeps the device's shape while the
+# web API serves the same instants as ISO.
+KOREADER_DATETIME_FORMAT: Final = "%Y-%m-%d %H:%M:%S"
 
 
 class EreaderHighlightItem(BaseModel):
@@ -16,8 +24,8 @@ class EreaderHighlightItem(BaseModel):
     text: str
     start_xpoint: str | None
     end_xpoint: str | None
-    datetime: str
-    datetime_updated: str | None
+    datetime: dt
+    datetime_updated: dt | None
     page: int | None
     chapter_number: int | None
     chapter_name: str | None
@@ -26,3 +34,13 @@ class EreaderHighlightItem(BaseModel):
     note: str | None
     origin_device_id: str | None
     placeable: bool
+
+    @field_serializer("datetime")
+    def _created_as_koreader_datetime(self, value: dt) -> str:
+        """Render the creation time the way KOReader writes it."""
+        return value.strftime(KOREADER_DATETIME_FORMAT)
+
+    @field_serializer("datetime_updated")
+    def _edited_as_koreader_datetime(self, value: dt | None) -> str | None:
+        """Render the last device edit the way KOReader writes it, if there is one."""
+        return value.strftime(KOREADER_DATETIME_FORMAT) if value is not None else None

--- a/backend/src/infrastructure/reading/schemas/highlight_schemas.py
+++ b/backend/src/infrastructure/reading/schemas/highlight_schemas.py
@@ -1,9 +1,10 @@
 """Pydantic schemas for Highlight API request/response validation."""
 
+from datetime import UTC
 from datetime import datetime as dt
 from typing import TYPE_CHECKING, Annotated, Any, Literal
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import AfterValidator, BaseModel, Field, model_validator
 
 from src.infrastructure.common.schemas.position_schemas import PositionResponse
 from src.infrastructure.reading.schemas.bookmark_schemas import Bookmark
@@ -20,6 +21,21 @@ if TYPE_CHECKING:
 # This will be moved after the class definitions
 
 
+def _drop_offset(value: dt) -> dt:
+    """Reduce a device timestamp to the offsetless wall clock we store.
+
+    KOReader sends device-local time with no offset, so there is nothing to
+    drop for the plugin. A client that does send one is converted to UTC rather
+    than having its offset quietly ignored.
+    """
+    if value.tzinfo is None:
+        return value
+    return value.astimezone(UTC).replace(tzinfo=None)
+
+
+DeviceDatetime = Annotated[dt, AfterValidator(_drop_offset)]
+
+
 class HighlightBase(BaseModel):
     """Base schema for Highlight."""
 
@@ -27,7 +43,14 @@ class HighlightBase(BaseModel):
     chapter: str | None = Field(None, max_length=500, description="Chapter name")
     chapter_number: int | None = Field(None, ge=1, description="Chapter order number from TOC")
     page: int | None = Field(None, ge=0, description="Page number")
-    datetime: str = Field(..., min_length=1, max_length=50, description="KOReader datetime format")
+    datetime: DeviceDatetime = Field(
+        ...,
+        description=(
+            "When the highlight was made, on the device's own clock. Sent without a "
+            "UTC offset because the e-reader does not know one; KOReader's "
+            "'YYYY-MM-DD HH:MM:SS' is accepted on the way in."
+        ),
+    )
 
 
 class HighlightCreate(HighlightBase):
@@ -42,12 +65,12 @@ class HighlightCreate(HighlightBase):
         None, description="Highlight drawer/style from KOReader (e.g. 'lighten', 'strikethrough')"
     )
     note: str | None = Field(None, description="Note attached to the highlight in KOReader")
-    datetime_updated: str | None = Field(
+    datetime_updated: DeviceDatetime | None = Field(
         None,
-        max_length=50,
         description=(
-            "KOReader datetime of the last edit on the device; absent until the "
-            "highlight is first edited. The newest edit wins when devices disagree."
+            "When the highlight was last edited on the device, on that device's own "
+            "clock; absent until the highlight is first edited. The newest edit wins "
+            "when devices disagree."
         ),
     )
     is_new: bool = Field(

--- a/backend/src/infrastructure/semantic/schemas/semantic_schemas.py
+++ b/backend/src/infrastructure/semantic/schemas/semantic_schemas.py
@@ -1,5 +1,7 @@
 """Pydantic schemas for semantic-search API responses."""
 
+from datetime import datetime as dt
+
 from pydantic import BaseModel, ConfigDict
 
 from src.infrastructure.jobs.schemas.job_batch_schemas import JobBatchResponse
@@ -54,7 +56,7 @@ class HighlightSearchItem(BaseModel):
     chapter_number: int | None
     text: str
     page: int | None
-    datetime: str
+    datetime: dt
     cover_file: str | None
     cover_blurhash: str | None
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -47,6 +47,9 @@ from src.infrastructure.common.client_version import (
 from src.infrastructure.identity.dependencies import get_current_user
 from src.infrastructure.library.repositories import file_repository
 from src.infrastructure.library.schemas import EreaderBookMetadata
+from src.infrastructure.reading.schemas.ereader_highlight_schemas import (
+    KOREADER_DATETIME_FORMAT,
+)
 from src.main import app
 from src.models import (
     Book,
@@ -150,6 +153,17 @@ async def create_test_chapter(
     return chapter
 
 
+def device_datetime(value: str) -> dt:
+    """Parse a KOReader timestamp, the way the sync boundary does.
+
+    Tests read better writing the device's own format, but the column and every
+    layer above it now hold a real datetime.
+
+    Naive on purpose: the device sends no offset, so there is none to parse.
+    """
+    return dt.strptime(value, KOREADER_DATETIME_FORMAT)  # noqa: DTZ007
+
+
 async def create_test_highlight(
     db_session: AsyncSession,
     book: Book,
@@ -180,7 +194,7 @@ async def create_test_highlight(
         page=page,
         start_xpoint=start_xpoint,
         end_xpoint=end_xpoint,
-        datetime=datetime_str,
+        datetime=device_datetime(datetime_str),
         content_hash=content_hash,
         deleted_at=deleted_at,
         removed_from_devices_at=removed_from_devices_at,

--- a/backend/tests/test_embedding_repository.py
+++ b/backend/tests/test_embedding_repository.py
@@ -12,6 +12,7 @@ from src.application.semantic.protocols.embedding_repository import EmbeddingWri
 from src.infrastructure.semantic.orm.embedding_model import Embedding as EmbeddingORM
 from src.infrastructure.semantic.repositories.embedding_repository import EmbeddingRepository
 from src.models import Book, Chapter, ChapterDigest, Highlight, Note
+from tests.conftest import device_datetime
 
 VECTOR = [0.1, 0.2, 0.3]
 OTHER_VECTOR = [0.9, 0.8, 0.7]
@@ -56,7 +57,7 @@ async def _referenced_content(db_session: AsyncSession) -> None:  # pyright: ign
                 user_id=1,
                 book_id=7,
                 text="highlight five",
-                datetime="2024-01-15 14:30:22",
+                datetime=device_datetime("2024-01-15 14:30:22"),
                 content_hash="f" * 64,
             ),
             Chapter(id=3, book_id=7, name="Chapter three"),

--- a/backend/tests/test_highlights.py
+++ b/backend/tests/test_highlights.py
@@ -16,6 +16,7 @@ from tests.conftest import (
     create_test_book,
     create_test_chapter,
     create_test_highlight,
+    device_datetime,
 )
 
 
@@ -251,11 +252,66 @@ class TestHighlightsUpload:
             select(models.Highlight).order_by(models.Highlight.datetime)
         )
         highlights = result.scalars().all()
-        assert [h.datetime for h in highlights] == ["2019-06-01 08:15:30", "2019-06-01 08:16:00"]
+        assert [h.datetime for h in highlights] == [
+            device_datetime("2019-06-01 08:15:30"),
+            device_datetime("2019-06-01 08:16:00"),
+        ]
         assert highlights[0].koreader_note == "Read this again before chapter 3"
         assert highlights[1].koreader_note is None
         # The device id is per batch, so every highlight in it carries the same one.
         assert [h.origin_device_id for h in highlights] == ["Kobo Clara", "Kobo Clara"]
+
+    async def test_the_web_gets_iso_while_the_device_gets_its_own_format(
+        self,
+        client: AsyncClient,
+        plugin_client: AsyncClient,
+        db_session: AsyncSession,
+        test_user: models.User,
+    ) -> None:
+        """One stored instant, rendered for each reader of it.
+
+        The web API serves highlight timestamps in the same ISO shape as every
+        other timestamp it sends, so the client needs no bespoke parser. The
+        plugin pull keeps KOReader's own format, because the plugin writes what
+        it receives straight into a device annotation.
+        """
+        client_book_id = "test-client-book-timestamp-shapes"
+        book = await create_test_book(
+            db_session=db_session,
+            user_id=test_user.id,
+            title="Timestamp Shapes",
+            client_book_id=client_book_id,
+        )
+        await create_test_chapter(
+            db_session=db_session, book=book, name="Chapter One", chapter_number=1
+        )
+
+        pushed = await plugin_client.post(
+            "/api/v1/highlights/sync",
+            json={
+                "client_book_id": client_book_id,
+                "highlights": [
+                    {
+                        "text": "Read on a device that knows no offset",
+                        "chapter_number": 1,
+                        "datetime": "2019-06-01 08:15:30",
+                        "start_xpoint": "/body/DocFragment[1]/body/p[1]/text().0",
+                        "end_xpoint": "/body/DocFragment[1]/body/p[1]/text().20",
+                    }
+                ],
+            },
+        )
+        assert pushed.status_code == status.HTTP_200_OK
+        assert pushed.json()["highlights_created"] == 1
+
+        web = await client.get(f"/api/v1/books/{book.id}")
+        assert web.status_code == status.HTTP_200_OK
+        on_the_web = [h for c in web.json()["chapters"] for h in c["highlights"]]
+        assert [h["datetime"] for h in on_the_web] == ["2019-06-01T08:15:30"]
+
+        pull = await plugin_client.get(f"/api/v1/ereader/books/{client_book_id}/highlights")
+        assert pull.status_code == status.HTTP_200_OK
+        assert [item["datetime"] for item in pull.json()["items"]] == ["2019-06-01 08:15:30"]
 
     async def test_upload_without_device_id_stores_none(
         self,
@@ -308,7 +364,7 @@ class TestHighlightsUpload:
         )
 
         assert stored.koreader_note == "edited note"
-        assert stored.koreader_updated_at == "2019-06-02 09:00:00"
+        assert stored.koreader_updated_at == device_datetime("2019-06-02 09:00:00")
 
     async def test_reupload_ignores_an_older_note_edit(
         self,
@@ -329,7 +385,7 @@ class TestHighlightsUpload:
         )
 
         assert stored.koreader_note == "newer note"
-        assert stored.koreader_updated_at == "2019-06-05 10:00:00"
+        assert stored.koreader_updated_at == device_datetime("2019-06-05 10:00:00")
 
     async def test_first_edit_is_accepted_even_when_older_than_the_stored_datetime(
         self,
@@ -357,7 +413,7 @@ class TestHighlightsUpload:
         )
 
         assert stored.koreader_note == "written in June"
-        assert stored.koreader_updated_at == "2025-06-01 09:00:00"
+        assert stored.koreader_updated_at == device_datetime("2025-06-01 09:00:00")
 
     async def test_reupload_with_the_same_edit_time_keeps_the_stored_note(
         self,
@@ -408,7 +464,7 @@ class TestHighlightsUpload:
         )
 
         assert stored.koreader_note == "note from the newer copy"
-        assert stored.koreader_updated_at == "2019-06-02 08:15:30"
+        assert stored.koreader_updated_at == device_datetime("2019-06-02 08:15:30")
 
     async def test_reupload_applies_a_newer_style_change(
         self,
@@ -1325,7 +1381,7 @@ class TestHighlightUploadRemovals:
 
         await db_session.refresh(stored)
         assert stored.koreader_note == "keep this"
-        assert stored.koreader_updated_at == "2025-01-01 00:00:00"
+        assert stored.koreader_updated_at == device_datetime("2025-01-01 00:00:00")
 
     async def test_a_negative_removed_id_is_rejected(
         self, plugin_client: AsyncClient, synced_book: tuple[models.Book, dict[str, int]]

--- a/backend/tests/test_semantic_search_api.py
+++ b/backend/tests/test_semantic_search_api.py
@@ -202,7 +202,7 @@ class TestRenderableFields:
         assert item["chapter_name"] == "Test Chapter"
         assert item["text"] == "the text"
         assert item["page"] == highlight.page
-        assert item["datetime"] == highlight.datetime
+        assert item["datetime"] == highlight.datetime.isoformat()
 
     async def test_note_item_carries_title_body_and_every_book(
         self,

--- a/backend/tests/unit/infrastructure/learning/queries/test_book_flashcard_query.py
+++ b/backend/tests/unit/infrastructure/learning/queries/test_book_flashcard_query.py
@@ -9,7 +9,7 @@ from src.application.reading.services.label_resolution_service import LabelResol
 from src.domain.common.value_objects.ids import BookId, UserId
 from src.infrastructure.learning.queries.book_flashcard_query import BookFlashcardQuery
 from src.models import Book, Flashcard, Highlight, HighlightStyle, Note, Tag, User
-from tests.conftest import create_test_book, create_test_highlight
+from tests.conftest import create_test_book, create_test_highlight, device_datetime
 from tests.unit.infrastructure.conftest import AddChapter
 
 DEFAULT_USER_ID = 1
@@ -159,7 +159,7 @@ async def test_highlight_carries_its_chapter_and_tags(
         highlight.id,
         "Highlighted text",
         42,
-        "2024-01-15 14:30:22",
+        device_datetime("2024-01-15 14:30:22"),
     )
     assert (embedded.chapter_id, embedded.chapter_name, embedded.chapter_number) == (
         chapter.id,

--- a/backend/tests/unit/infrastructure/semantic/content/test_content_source.py
+++ b/backend/tests/unit/infrastructure/semantic/content/test_content_source.py
@@ -12,6 +12,7 @@ from src.infrastructure.semantic.content.content_source import (
     ContentSource,
 )
 from src.models import Book, Chapter, ChapterDigest, Embedding, Highlight, Note
+from tests.conftest import device_datetime
 
 USER_ID = 1
 
@@ -46,7 +47,7 @@ async def _add_highlight(
         user_id=USER_ID,
         book_id=book.id,
         text=text,
-        datetime="2024-01-15 14:30:22",
+        datetime=device_datetime("2024-01-15 14:30:22"),
         content_hash=_expected_hash(text)[:64],
         deleted_at=datetime.now(UTC) if deleted else None,
     )

--- a/backend/tests/unit/infrastructure/semantic/queries/test_semantic_search_query.py
+++ b/backend/tests/unit/infrastructure/semantic/queries/test_semantic_search_query.py
@@ -7,6 +7,7 @@ from src.application.semantic.content_type import ContentType
 from src.infrastructure.notes.orm.associations import note_books
 from src.infrastructure.semantic.queries.semantic_search_query import SemanticSearchQuery
 from src.models import Book, Embedding, Highlight, Note, User
+from tests.conftest import device_datetime
 
 USER_ID = 1
 OTHER_USER_ID = 2
@@ -45,7 +46,7 @@ async def _add_source(
                 user_id=user_id,
                 book_id=book.id,
                 text=f"highlight {content_id}",
-                datetime="2024-01-15 14:30:22",
+                datetime=device_datetime("2024-01-15 14:30:22"),
                 content_hash="c" * 64,
             )
         )

--- a/frontend/src/api/generated/highlights/highlights.ts
+++ b/frontend/src/api/generated/highlights/highlights.ts
@@ -51,7 +51,9 @@ const withQueryKey = <T extends object, K>(query: T, queryKey: K): T & { queryKe
  * Sync highlights from KOReader.
  *
  * Creates or updates book record and adds highlights with automatic deduplication.
- * Duplicates are identified by the combination of book, text, and datetime.
+ * Duplicates are identified by book and highlighted text alone: a highlight's
+ * timestamps say when the device made and edited it, and take no part in
+ * deciding whether it is the same highlight.
  *
  * ``removed_ids`` carries the highlights the reader deleted on the device:
  * they are withheld from every device's pull and stay whole on the web.
@@ -151,7 +153,9 @@ export const useUploadHighlights = <TError = HTTPValidationError, TContext = unk
  * Sync highlights from KOReader.
  *
  * Creates or updates book record and adds highlights with automatic deduplication.
- * Duplicates are identified by the combination of book, text, and datetime.
+ * Duplicates are identified by book and highlighted text alone: a highlight's
+ * timestamps say when the device made and edited it, and take no part in
+ * deciding whether it is the same highlight.
  *
  * ``removed_ids`` carries the highlights the reader deleted on the device:
  * they are withheld from every device's pull and stay whole on the web.

--- a/frontend/src/api/generated/model/highlight.ts
+++ b/frontend/src/api/generated/model/highlight.ts
@@ -23,11 +23,7 @@ export interface Highlight {
   chapter_number?: number | null;
   /** Page number */
   page?: number | null;
-  /**
-   * KOReader datetime format
-   * @minLength 1
-   * @maxLength 50
-   */
+  /** When the highlight was made, on the device's own clock. Sent without a UTC offset because the e-reader does not know one; KOReader's 'YYYY-MM-DD HH:MM:SS' is accepted on the way in. */
   datetime: string;
   id: number;
   book_id: number;

--- a/frontend/src/api/generated/model/highlightCreate.ts
+++ b/frontend/src/api/generated/model/highlightCreate.ts
@@ -20,11 +20,7 @@ export interface HighlightCreate {
   chapter_number?: number | null;
   /** Page number */
   page?: number | null;
-  /**
-   * KOReader datetime format
-   * @minLength 1
-   * @maxLength 50
-   */
+  /** When the highlight was made, on the device's own clock. Sent without a UTC offset because the e-reader does not know one; KOReader's 'YYYY-MM-DD HH:MM:SS' is accepted on the way in. */
   datetime: string;
   /** Highlight start position in XML document */
   start_xpoint?: string | null;
@@ -36,7 +32,7 @@ export interface HighlightCreate {
   drawer?: string | null;
   /** Note attached to the highlight in KOReader */
   note?: string | null;
-  /** KOReader datetime of the last edit on the device; absent until the highlight is first edited. The newest edit wins when devices disagree. */
+  /** When the highlight was last edited on the device, on that device's own clock; absent until the highlight is first edited. The newest edit wins when devices disagree. */
   datetime_updated?: string | null;
   /** True when the device created this highlight after its last pull, so the server can tell a deliberate re-highlight from a stale echo. A flagged push of a text removed from devices or deleted on the web brings that highlight back; an unflagged one is skipped, as it always was. */
   is_new?: boolean;

--- a/frontend/src/api/generated/model/highlightResponseBase.ts
+++ b/frontend/src/api/generated/model/highlightResponseBase.ts
@@ -24,11 +24,7 @@ export interface HighlightResponseBase {
   chapter_number?: number | null;
   /** Page number */
   page?: number | null;
-  /**
-   * KOReader datetime format
-   * @minLength 1
-   * @maxLength 50
-   */
+  /** When the highlight was made, on the device's own clock. Sent without a UTC offset because the e-reader does not know one; KOReader's 'YYYY-MM-DD HH:MM:SS' is accepted on the way in. */
   datetime: string;
   id: number;
   book_id: number;

--- a/frontend/src/components/cards/HighlightCard.tsx
+++ b/frontend/src/components/cards/HighlightCard.tsx
@@ -2,7 +2,6 @@ import type { Bookmark, Highlight } from '@/api/generated/model';
 import { HoverableCardActionArea } from '@/components/cards/HoverableCardActionArea';
 import { MetadataRow } from '@/components/cards/MetadataRow.tsx';
 import { TagChipList } from '@/components/TagChipList.tsx';
-import { formatHighlightDate } from '@/pages/BookPage/common/highlightDates.ts';
 import { LabelIndicator } from '@/pages/BookPage/common/LabelIndicator.tsx';
 import { NotOnDeviceChip } from '@/pages/BookPage/common/NotOnDeviceChip.tsx';
 import {
@@ -14,6 +13,7 @@ import {
 } from '@/theme/Icons.tsx';
 import { ICON_SIZE } from '@/theme/iconSizes.ts';
 import { countLabel } from '@/utils/counts.ts';
+import { formatDate } from '@/utils/date.ts';
 import type { SvgIconComponent } from '@mui/icons-material';
 import { Box, Typography } from '@mui/material';
 
@@ -73,7 +73,7 @@ const Footer = ({ highlight, bookmark, noteCount }: FooterProps) => {
         <MetadataRow
           variant="caption"
           items={[
-            formatHighlightDate(highlight.datetime),
+            formatDate(highlight.datetime),
             highlight.page && `Page ${highlight.page}`,
             hasBookmark && (
               <BookmarkFilledIcon

--- a/frontend/src/pages/BookPage/Highlights/HighlightsPage.test.tsx
+++ b/frontend/src/pages/BookPage/Highlights/HighlightsPage.test.tsx
@@ -31,9 +31,9 @@ const aDateRangeBook = () =>
         id: 10,
         name: 'Boundary chapter',
         highlights: [
-          aHighlight({ id: 301, text: 'At midnight', datetime: '2026-07-05 00:00:00' }),
-          aHighlight({ id: 302, text: 'Late that night', datetime: '2026-07-05 23:59:59' }),
-          aHighlight({ id: 303, text: 'The next day', datetime: '2026-07-06 00:00:00' }),
+          aHighlight({ id: 301, text: 'At midnight', datetime: '2026-07-05T00:00:00' }),
+          aHighlight({ id: 302, text: 'Late that night', datetime: '2026-07-05T23:59:59' }),
+          aHighlight({ id: 303, text: 'The next day', datetime: '2026-07-06T00:00:00' }),
         ],
       }),
       aChapter({
@@ -44,7 +44,7 @@ const aDateRangeBook = () =>
             id: 304,
             chapter_id: 20,
             text: 'Before the range',
-            datetime: '2026-07-04 23:59:59',
+            datetime: '2026-07-04T23:59:59',
           }),
         ],
       }),
@@ -110,7 +110,7 @@ test('composes date, search, tag, and label filters and shows the generic empty 
   const matching = aHighlight({
     id: 401,
     text: 'All filters match',
-    datetime: '2026-07-05 12:00:00',
+    datetime: '2026-07-05T12:00:00',
     tags: [{ id: 1, name: 'Keep', tag_group_id: null }],
     label: { highlight_style_id: 10, text: 'Important', ui_color: '#ff0000' },
   });
@@ -122,21 +122,21 @@ test('composes date, search, tag, and label filters and shows the generic empty 
         aHighlight({
           id: 402,
           text: 'Wrong tag',
-          datetime: '2026-07-05 12:00:00',
+          datetime: '2026-07-05T12:00:00',
           tags: [{ id: 2, name: 'Other', tag_group_id: null }],
           label: { highlight_style_id: 10 },
         }),
         aHighlight({
           id: 403,
           text: 'Wrong label',
-          datetime: '2026-07-05 12:00:00',
+          datetime: '2026-07-05T12:00:00',
           tags: [{ id: 1, name: 'Keep', tag_group_id: null }],
           label: { highlight_style_id: 11 },
         }),
         aHighlight({
           id: 404,
           text: 'Wrong date',
-          datetime: '2026-07-06 12:00:00',
+          datetime: '2026-07-06T12:00:00',
           tags: [{ id: 1, name: 'Keep', tag_group_id: null }],
           label: { highlight_style_id: 10 },
         }),

--- a/frontend/src/pages/BookPage/common/HighlightContent.tsx
+++ b/frontend/src/pages/BookPage/common/HighlightContent.tsx
@@ -1,9 +1,9 @@
 import type { Highlight } from '@/api/generated/model';
 import { LabelIndicator } from '@/pages/BookPage/common/LabelIndicator.tsx';
 import { NotOnDeviceChip } from '@/pages/BookPage/common/NotOnDeviceChip.tsx';
-import { formatHighlightDate } from '@/pages/BookPage/common/highlightDates.ts';
 import { DateIcon, HighlightsIcon } from '@/theme/Icons.tsx';
 import { ICON_SIZE } from '@/theme/iconSizes.ts';
+import { formatDate } from '@/utils/date.ts';
 import { Box, Typography } from '@mui/material';
 
 interface HighlightContentProps {
@@ -81,7 +81,7 @@ export const HighlightContent = ({ highlight, onLabelClick }: HighlightContentPr
             color: 'text.secondary',
           }}
         >
-          {formatHighlightDate(highlight.datetime)}
+          {formatDate(highlight.datetime)}
           {highlight.page && ` • Page ${highlight.page}`}
         </Typography>
         <LabelIndicator label={highlight.label} onClick={onLabelClick} size="medium" />

--- a/frontend/src/pages/BookPage/common/highlightDates.test.tsx
+++ b/frontend/src/pages/BookPage/common/highlightDates.test.tsx
@@ -1,14 +1,11 @@
-import { formatDate } from '@/utils/date.ts';
 import { aChapter, aHighlight } from '@tests/fixtures/book';
 import { DateTime } from 'luxon';
 import { describe, expect, test } from 'vitest';
 import {
   filterChaptersByHighlightDate,
-  formatHighlightDate,
   getLastSevenDaysFrom,
   isHighlightDateRangeReversed,
   parseDateSearchParam,
-  parseHighlightDate,
   type HighlightDateRange,
 } from './highlightDates.ts';
 
@@ -16,16 +13,16 @@ const chapters = [
   aChapter({
     id: 10,
     highlights: [
-      aHighlight({ id: 1, datetime: '2026-07-04 23:59:59' }),
-      aHighlight({ id: 2, datetime: '2026-07-05 00:00:00' }),
-      aHighlight({ id: 3, datetime: '2026-07-05 23:59:59' }),
-      aHighlight({ id: 4, datetime: '2026-07-06 00:00:00' }),
+      aHighlight({ id: 1, datetime: '2026-07-04T23:59:59' }),
+      aHighlight({ id: 2, datetime: '2026-07-05T00:00:00' }),
+      aHighlight({ id: 3, datetime: '2026-07-05T23:59:59' }),
+      aHighlight({ id: 4, datetime: '2026-07-06T00:00:00' }),
       aHighlight({ id: 5, datetime: 'legacy timestamp' }),
     ],
   }),
   aChapter({
     id: 20,
-    highlights: [aHighlight({ id: 6, chapter_id: 20, datetime: '2026-07-01 12:00:00' })],
+    highlights: [aHighlight({ id: 6, chapter_id: 20, datetime: '2026-07-01T12:00:00' })],
   }),
 ];
 
@@ -76,15 +73,12 @@ describe('filterChaptersByHighlightDate', () => {
   });
 });
 
-test('parses only canonical search dates and KOReader timestamps', () => {
+test('parses only canonical search dates', () => {
   expect(parseDateSearchParam('2026-07-05')).toBe('2026-07-05');
   expect(parseDateSearchParam('2026-7-5')).toBeUndefined();
   expect(parseDateSearchParam('2026-02-30')).toBeUndefined();
+  expect(parseDateSearchParam('2026-07-05T23:59:59')).toBeUndefined();
   expect(parseDateSearchParam(['2026-07-05'])).toBeUndefined();
-
-  expect(parseHighlightDate('2026-07-05 23:59:59')).toBe('2026-07-05');
-  expect(parseHighlightDate('2026-07-05T23:59:59')).toBeUndefined();
-  expect(parseHighlightDate('legacy timestamp')).toBeUndefined();
 });
 
 test('identifies reversed ranges only when both valid values are present', () => {
@@ -95,11 +89,4 @@ test('identifies reversed ranges only when both valid values are present', () =>
 
 test('calculates a snapshot lower bound covering today and the preceding six dates', () => {
   expect(getLastSevenDaysFrom(DateTime.fromISO('2026-08-26T15:00:00'))).toBe('2026-08-20');
-});
-
-test('renders a highlight timestamp exactly as every other date, and preserves malformed values', () => {
-  // The rule, not one locale's spelling of it: a highlight's date and a
-  // session's date are the same string for the same day.
-  expect(formatHighlightDate('2026-07-05 23:00:00')).toBe(formatDate('2026-07-05T23:00:00'));
-  expect(formatHighlightDate('legacy timestamp')).toBe('legacy timestamp');
 });

--- a/frontend/src/pages/BookPage/common/highlightDates.ts
+++ b/frontend/src/pages/BookPage/common/highlightDates.ts
@@ -1,9 +1,7 @@
 import type { ChapterWithHighlights } from '@/api/generated/model';
-import { formatDateTime } from '@/utils/date.ts';
 import { DateTime } from 'luxon';
 
 export const DATE_SEARCH_FORMAT = 'yyyy-MM-dd';
-const HIGHLIGHT_DATETIME_FORMAT = 'yyyy-MM-dd HH:mm:ss';
 
 export interface HighlightDateRange {
   from?: string;
@@ -11,24 +9,19 @@ export interface HighlightDateRange {
 }
 
 /**
- * The locale pin is about digits, not date order. These formats are numeric,
- * but luxon parses and re-renders in the ambient locale's numbering system, so
- * for a reader on `ar-EG` the round-trip below comes back in Arabic-Indic
- * digits and rejects a perfectly good timestamp, and on `hi-IN-u-nu-deva` the
- * parse fails outright.
+ * The calendar day an ISO timestamp falls on, as `yyyy-MM-dd`.
+ *
+ * `toISODate` is ISO output rather than a locale rendering, so it stays in
+ * ASCII digits whatever numbering system the reader's locale uses.
  */
-const parseStrictly = (value: string, format: string): DateTime | undefined => {
-  const parsed = DateTime.fromFormat(value, format, { locale: 'en-US' });
-  return parsed.isValid && parsed.toFormat(format) === value ? parsed : undefined;
-};
+const isoDay = (value: string): string | undefined =>
+  DateTime.fromISO(value).toISODate() ?? undefined;
 
 export const parseDateSearchParam = (value: unknown): string | undefined => {
   if (typeof value !== 'string') return undefined;
-  return parseStrictly(value, DATE_SEARCH_FORMAT)?.toFormat(DATE_SEARCH_FORMAT);
+  const day = isoDay(value);
+  return day === value ? day : undefined;
 };
-
-export const parseHighlightDate = (value: string): string | undefined =>
-  parseStrictly(value, HIGHLIGHT_DATETIME_FORMAT)?.toFormat(DATE_SEARCH_FORMAT);
 
 export const isHighlightDateRangeReversed = ({ from, to }: HighlightDateRange): boolean =>
   !!from && !!to && from > to;
@@ -44,7 +37,7 @@ export const filterChaptersByHighlightDate = (
     .map((chapter) => ({
       ...chapter,
       highlights: chapter.highlights.filter((highlight) => {
-        const date = parseHighlightDate(highlight.datetime);
+        const date = isoDay(highlight.datetime);
         if (!date) return false;
         return (!from || date >= from) && (!to || date <= to);
       }),
@@ -54,16 +47,3 @@ export const filterChaptersByHighlightDate = (
 
 export const getLastSevenDaysFrom = (today: DateTime<boolean> = DateTime.local()): string =>
   today.minus({ days: 6 }).toFormat(DATE_SEARCH_FORMAT);
-
-/**
- * `highlight.datetime` is KOReader's own `yyyy-MM-dd HH:mm:ss` string, passed
- * through rather than normalised to ISO like every other timestamp the API
- * sends. Rendering goes through the app's one formatter, in the browser's
- * locale.
- */
-export const formatHighlightDate = (value: string): string => {
-  const parsed = parseStrictly(value, HIGHLIGHT_DATETIME_FORMAT);
-  if (!parsed) return value;
-
-  return formatDateTime(parsed);
-};

--- a/frontend/src/utils/date.ts
+++ b/frontend/src/utils/date.ts
@@ -2,8 +2,7 @@ import { DateTime } from 'luxon';
 
 /**
  * The browser's own locale — the one source for every date the app renders,
- * including the date pickers. Backend timestamps are *parsed* against a fixed
- * `en-US` format, which is a separate concern from how they are shown.
+ * including the date pickers.
  */
 export const browserLocale = (): string => Intl.DateTimeFormat().resolvedOptions().locale;
 
@@ -11,7 +10,7 @@ export const browserLocale = (): string => Intl.DateTimeFormat().resolvedOptions
  * The app's one rendered date format: `DATE_MED` in the browser's locale, so a
  * session header and the highlights beneath it never disagree.
  */
-export const formatDateTime = (dateTime: DateTime): string =>
+const formatDateTime = (dateTime: DateTime): string =>
   dateTime.setLocale(browserLocale()).toLocaleString(DateTime.DATE_MED);
 
 /**

--- a/frontend/tests/fixtures/book.ts
+++ b/frontend/tests/fixtures/book.ts
@@ -8,7 +8,7 @@ export const aHighlight = (overrides: Partial<Highlight> = {}): Highlight => ({
   chapter_number: 1,
   page: 42,
   text: 'The map is not the territory.',
-  datetime: '2026-01-01 00:00:00',
+  datetime: '2026-01-01T00:00:00',
   tags: [],
   flashcards: [],
   created_at: '2026-01-01T00:00:00Z',

--- a/frontend/tests/fixtures/semantic.ts
+++ b/frontend/tests/fixtures/semantic.ts
@@ -37,7 +37,7 @@ export const aHighlightHit = (
   chapter_number: 1,
   text: 'The map is not the territory.',
   page: 42,
-  datetime: '2026-01-01 00:00:00',
+  datetime: '2026-01-01T00:00:00',
   cover_file: null,
   cover_blurhash: null,
   ...overrides,


### PR DESCRIPTION
Fixes #664

## What

`Highlight.datetime` and `koreader_updated_at` were stored and served as KOReader's own `yyyy-MM-dd HH:mm:ss` text, while every other timestamp the API sends is ISO. They are now `TIMESTAMP WITHOUT TIME ZONE` from the column up through the domain entity, the read models and the web schemas.

KOReader writes device-local wall time with no offset, so none is invented here — the issue's option 1. Ordering across timezones stays as approximate as it already was. Attributing a real timezone remains a separate question about what the plugin should send.

## The two contracts, side by side

| Surface | Before | After |
|---|---|---|
| Web API (`GET /books/{id}`, search, flashcards, sessions) | `2019-06-01 08:15:30` | `2019-06-01T08:15:30` |
| Plugin pull (`GET /ereader/books/{id}/highlights`) | `2019-06-01 08:15:30` | `2019-06-01 08:15:30` |
| Plugin push (`POST /highlights/sync`) | KOReader format | KOReader format **or** ISO |

The plugin pull is unchanged byte for byte, so **the `koreader-plugin` minimum stays where it is**. That is deliberate rather than convenient: `highlight_importer.lua` writes `source.datetime` straight into a KOReader annotation, and its `fingerprint` compares `datetime_updated` against what the server sent — serving ISO there would write ISO into device metadata and make every pull look changed. The format now lives on `EreaderHighlightItem` as a field serializer, so there is one place that knows it.

The push accepts both shapes: normalisation belongs at the boundary, and Pydantic parses the device format and ISO alike, so a future plugin that sends ISO needs no server change.

## Two things the type change makes honest

- **The device-edit comparison was string ordering.** `_sync_device_edits_of_duplicates` compared `koreader_updated_at` as text, which the KOReader format happens to support. Left alone, mixing a stored ISO string with an incoming device string would have silently inverted the comparison (`' '` sorts below `'T'`) and dropped every device edit. It now compares datetimes.
- **The sync docstring was wrong about deduplication.** It claimed duplicates are identified by book, text and datetime. `content_hash` is computed from text alone, and the unique constraint is `(user_id, book_id, content_hash)`. That is also the answer to the issue's migration worry: rewriting these columns cannot make a re-sync from an unchanged device look like new highlights, because the dedupe key never touched them.

## Migration

`070_highlight_datetime_to_timestamp` converts both columns in place. A `datetime` that does not parse falls back to the row's `created_at` — the insert time of the sync that carried it, a real instant and always present — because the column is NOT NULL. An unparseable `koreader_updated_at` becomes NULL, which already reads as "never edited on a device". Both directions are reversible.

## Frontend

`formatHighlightDate`, `parseHighlightDate` and `parseStrictly` are gone; highlight dates go through `formatDate` like every other date.

This removes the locale pin those helpers needed. Luxon re-renders in the ambient locale's numbering system, so the strict round-trip rejected valid timestamps on `ar-EG` and failed to parse at all on `hi-IN-u-nu-deva` — a reader on either would have seen every highlight date fall back to the raw string. `DateTime.fromISO` and `toISODate` are locale-independent, so `parseDateSearchParam` keeps its strictness without one. Date filtering now compares calendar days rather than the leading characters of a device format.

## Testing

`test_the_web_gets_iso_while_the_device_gets_its_own_format` pushes one highlight in KOReader's format and asserts both readings of it: ISO on the book-details response, KOReader format on the plugin pull. Verified it fails when the pull's serializer is changed to emit ISO.

Full suite green: 921 backend, 144 frontend. `make lint`, `lint-imports`, `knip`, both duplication checks and `format:check` all pass. `openapi.json` regenerated.