### PR TITLE
Fade every book tab in from one place

### DIFF
--- a/frontend/src/components/animations/FadeInOut.tsx
+++ b/frontend/src/components/animations/FadeInOut.tsx
@@ -1,13 +1,33 @@
 import { motion } from 'motion/react';
+import { useState } from 'react';
 
-export const FadeInOut = ({ children, ekey }: { children: React.ReactNode; ekey: React.Key }) => {
+const ENTER = { opacity: 0, y: 20 };
+
+interface FadeInOutProps {
+  children: React.ReactNode;
+  ekey: React.Key;
+  /**
+   * Set to false when an ancestor already fades this content in on first
+   * paint. The wrapper then only animates once `ekey` changes, so the two
+   * fades do not stack into a double opacity ramp and a doubled y offset.
+   */
+  animateOnMount?: boolean;
+}
+
+export const FadeInOut = ({ children, ekey, animateOnMount = true }: FadeInOutProps) => {
+  // `ekey` keys the inner motion.div, not this component, so this component
+  // survives key changes and can tell the first paint from a later swap.
+  const [renderedKey, setRenderedKey] = useState(ekey);
+  const [shouldAnimate, setShouldAnimate] = useState(animateOnMount);
+  if (renderedKey !== ekey) {
+    setRenderedKey(ekey);
+    setShouldAnimate(true);
+  }
+
   return (
     <motion.div
       key={ekey}
-      initial={{
-        opacity: 0,
-        y: 20,
-      }}
+      initial={shouldAnimate ? ENTER : false}
       animate={{ opacity: 1, y: 0 }}
       exit={{ opacity: 0, y: -10 }}
       transition={{ duration: 0.3 }}

--- a/frontend/src/components/features/flashcards/FlashcardChapterList.tsx
+++ b/frontend/src/components/features/flashcards/FlashcardChapterList.tsx
@@ -25,7 +25,6 @@ interface FlashcardChapterListProps {
   bookId: number;
   isLoading?: boolean;
   emptyState?: ReactNode;
-  animationKey?: string;
   onEditFlashcard: (flashcard: FlashcardWithContext) => void;
 }
 
@@ -34,7 +33,6 @@ export const FlashcardChapterList = ({
   bookId,
   isLoading,
   emptyState = <EmptyStateText>No flashcards found.</EmptyStateText>,
-  animationKey = 'flashcard-chapters',
   onEditFlashcard,
 }: FlashcardChapterListProps) => (
   <ChapterGroupedList
@@ -46,7 +44,6 @@ export const FlashcardChapterList = ({
     ariaLabel={(chapter) => chapter.listLabel ?? `Flashcards in ${chapter.name}`}
     isLoading={isLoading}
     emptyState={emptyState}
-    animationKey={animationKey}
     renderItem={(flashcard) => (
       <FlashcardListCard
         flashcard={flashcard}

--- a/frontend/src/pages/BookPage/BookPage.tsx
+++ b/frontend/src/pages/BookPage/BookPage.tsx
@@ -14,11 +14,14 @@ import { BookTitle } from '@/pages/BookPage/BookTitle/BookTitle.tsx';
 import { DesktopNavLinks } from '@/pages/BookPage/navigation/DesktopNavLinks.tsx';
 import { MobileBottomNav } from '@/pages/BookPage/navigation/MobileBottomNav.tsx';
 import { Alert, Box, useMediaQuery, useTheme } from '@mui/material';
-import { Outlet, useParams } from '@tanstack/react-router';
+import { Outlet, useLocation, useParams } from '@tanstack/react-router';
 import { useEffect, useState } from 'react';
 
 export const BookPage = () => {
   const { bookId } = useParams({ strict: false });
+  // Keys the tab fade below. Search params are excluded on purpose: filtering
+  // or searching within a tab must not replay the animation.
+  const pathname = useLocation({ select: (location) => location.pathname });
   const { data: book, isLoading, isError } = useGetBookDetails(Number(bookId));
 
   const theme = useTheme();
@@ -111,7 +114,9 @@ export const BookPage = () => {
                   <div ref={setLeftSidebarEl} />
                 </Box>
                 <Box component="main" sx={{ minWidth: 0 }}>
-                  <Outlet />
+                  <FadeInOut ekey={pathname} animateOnMount={false}>
+                    <Outlet />
+                  </FadeInOut>
                 </Box>
                 <Box ref={setRightSidebarEl} />
               </Box>
@@ -120,7 +125,9 @@ export const BookPage = () => {
             <Box sx={{ maxWidth: '800px', mx: 'auto' }}>
               <BookTitle book={book} />
               <Box component="main">
-                <Outlet />
+                <FadeInOut ekey={pathname} animateOnMount={false}>
+                  <Outlet />
+                </FadeInOut>
               </Box>
             </Box>
           )}

--- a/frontend/src/pages/BookPage/Flashcards/FlashcardsPage.tsx
+++ b/frontend/src/pages/BookPage/Flashcards/FlashcardsPage.tsx
@@ -215,7 +215,6 @@ export const FlashcardsPage = () => {
               chapters={flashcardChapters}
               bookId={book.id}
               emptyState={emptyState}
-              animationKey="flashcards"
               onEditFlashcard={setEditingFlashcard}
             />
           </Box>
@@ -239,7 +238,6 @@ export const FlashcardsPage = () => {
             chapters={flashcardChapters}
             bookId={book.id}
             emptyState={emptyState}
-            animationKey="flashcards"
             onEditFlashcard={setEditingFlashcard}
           />
           {fabContainerEl &&

--- a/frontend/src/pages/BookPage/Highlights/HighlightsList.tsx
+++ b/frontend/src/pages/BookPage/Highlights/HighlightsList.tsx
@@ -17,7 +17,6 @@ interface ChapterListProps {
   noteCountByHighlightId: Record<number, number>;
   isLoading?: boolean;
   emptyState?: ReactNode;
-  animationKey?: string;
   onOpenHighlight?: (highlightId: number) => void;
 }
 
@@ -27,7 +26,6 @@ export const HighlightsList = ({
   noteCountByHighlightId,
   isLoading,
   emptyState,
-  animationKey = 'chapters',
   onOpenHighlight,
 }: ChapterListProps) => (
   <ChapterGroupedList
@@ -39,7 +37,6 @@ export const HighlightsList = ({
     ariaLabel={(chapter) => `Highlights in ${chapter.name}`}
     isLoading={isLoading}
     emptyState={emptyState}
-    animationKey={animationKey}
     cardListSx={{ gap: 2.5 }}
     renderItem={(highlight) => (
       <HighlightCard

--- a/frontend/src/pages/BookPage/Highlights/HighlightsPage.tsx
+++ b/frontend/src/pages/BookPage/Highlights/HighlightsPage.tsx
@@ -246,7 +246,6 @@ export const HighlightsPage = () => {
               noteCountByHighlightId={noteCountByHighlightId}
               isLoading={bookSearch.isSearching}
               emptyState={emptyState}
-              animationKey="chapters-highlights"
               onOpenHighlight={highlightDialog.open}
             />
           </Box>
@@ -281,7 +280,6 @@ export const HighlightsPage = () => {
             noteCountByHighlightId={noteCountByHighlightId}
             isLoading={bookSearch.isSearching}
             emptyState={emptyState}
-            animationKey="chapters-highlights"
             onOpenHighlight={highlightDialog.open}
           />
 

--- a/frontend/src/pages/BookPage/ReadingSessions/ReadingSessionList.tsx
+++ b/frontend/src/pages/BookPage/ReadingSessions/ReadingSessionList.tsx
@@ -20,9 +20,11 @@ export const ReadingSessionList = ({
   onOpenHighlight,
 }: ReadingSessionListProps) => {
   return (
-    // The tab-level fade in `BookPage` covers the first paint; this one only
-    // replays the list when the page changes.
-    <FadeInOut ekey={animationKey} animateOnMount={false}>
+    // Paging refetches, and the page unmounts this list while it loads, so
+    // `animateOnMount={false}` would suppress the very fade it is meant to
+    // preserve. Animating on mount costs a slightly deeper fade on the one tab
+    // whose data is already cached.
+    <FadeInOut ekey={animationKey}>
       {sessions.length === 0 ? (
         <EmptyStateText variant="page">{emptyMessage}</EmptyStateText>
       ) : (

--- a/frontend/src/pages/BookPage/ReadingSessions/ReadingSessionList.tsx
+++ b/frontend/src/pages/BookPage/ReadingSessions/ReadingSessionList.tsx
@@ -20,7 +20,9 @@ export const ReadingSessionList = ({
   onOpenHighlight,
 }: ReadingSessionListProps) => {
   return (
-    <FadeInOut ekey={animationKey}>
+    // The tab-level fade in `BookPage` covers the first paint; this one only
+    // replays the list when the page changes.
+    <FadeInOut ekey={animationKey} animateOnMount={false}>
       {sessions.length === 0 ? (
         <EmptyStateText variant="page">{emptyMessage}</EmptyStateText>
       ) : (

--- a/frontend/src/pages/BookPage/common/ChapterGroupedList.tsx
+++ b/frontend/src/pages/BookPage/common/ChapterGroupedList.tsx
@@ -1,4 +1,3 @@
-import { FadeInOut } from '@/components/animations/FadeInOut.tsx';
 import { CardList } from '@/components/CardList.tsx';
 import { EmptyStateText } from '@/components/EmptyStateText.tsx';
 import { SectionTitle } from '@/components/typography/SectionTitle.tsx';
@@ -18,7 +17,6 @@ interface ChapterGroupedListProps<TChapter, TItem> {
   isLoading?: boolean;
   /** Shown in place of the list when there is no chapter to show. */
   emptyState?: ReactNode;
-  animationKey?: string;
   /** Extra styles merged onto each chapter's CardList. */
   cardListSx?: SxProps<Theme>;
   /** Rendered in place of the card list when a chapter has no items. */
@@ -26,10 +24,10 @@ interface ChapterGroupedListProps<TChapter, TItem> {
 }
 
 /**
- * Generic chapter-grouped list: an optional "Searching..." loading state, a
- * fade-in wrapper, an empty-state branch, then a `SectionTitle` + `CardList`
- * per chapter. Shared by the highlights and flashcards tabs, which differ only
- * in the item card and a couple of presentational knobs.
+ * Generic chapter-grouped list: an optional "Searching..." loading state, an
+ * empty-state branch, then a `SectionTitle` + `CardList` per chapter. Shared by
+ * the highlights and flashcards tabs, which differ only in the item card and a
+ * couple of presentational knobs.
  */
 export const ChapterGroupedList = <TChapter, TItem>({
   chapters,
@@ -41,7 +39,6 @@ export const ChapterGroupedList = <TChapter, TItem>({
   ariaLabel,
   isLoading,
   emptyState = <EmptyStateText>No chapters found.</EmptyStateText>,
-  animationKey = 'chapters',
   cardListSx,
   renderEmptyChapter,
 }: ChapterGroupedListProps<TChapter, TItem>) => {
@@ -61,32 +58,30 @@ export const ChapterGroupedList = <TChapter, TItem>({
   }
 
   return (
-    <FadeInOut ekey={animationKey}>
-      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
-        {chapters.length === 0
-          ? emptyState
-          : chapters.map((chapter) => {
-              const chapterId = getChapterId(chapter);
-              const chapterName = getChapterName(chapter);
-              const items = getItems(chapter);
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+      {chapters.length === 0
+        ? emptyState
+        : chapters.map((chapter) => {
+            const chapterId = getChapterId(chapter);
+            const chapterName = getChapterName(chapter);
+            const items = getItems(chapter);
 
-              return (
-                <Box key={chapterId} id={`chapter-${chapterId}`}>
-                  <SectionTitle showDivider>{chapterName}</SectionTitle>
+            return (
+              <Box key={chapterId} id={`chapter-${chapterId}`}>
+                <SectionTitle showDivider>{chapterName}</SectionTitle>
 
-                  {items.length === 0 && renderEmptyChapter ? (
-                    renderEmptyChapter()
-                  ) : (
-                    <CardList sx={cardListSx} aria-label={ariaLabel(chapter)}>
-                      {items.map((item) => (
-                        <li key={getItemKey(item)}>{renderItem(item)}</li>
-                      ))}
-                    </CardList>
-                  )}
-                </Box>
-              );
-            })}
-      </Box>
-    </FadeInOut>
+                {items.length === 0 && renderEmptyChapter ? (
+                  renderEmptyChapter()
+                ) : (
+                  <CardList sx={cardListSx} aria-label={ariaLabel(chapter)}>
+                    {items.map((item) => (
+                      <li key={getItemKey(item)}>{renderItem(item)}</li>
+                    ))}
+                  </CardList>
+                )}
+              </Box>
+            );
+          })}
+    </Box>
   );
 };


### PR DESCRIPTION
Fixes #665

The book page animated inconsistently: Highlights, Flashcards and Sessions faded their list in, because the list component happened to wrap itself in `FadeInOut`. Structure, Notes and Reflection animated nothing. `BookPage`'s existing fade is keyed by book id, so it only ran when you opened a different book, never on a tab switch.

## What changed

The fade now lives in one place. `BookPage.tsx` wraps `<Outlet />` in a `FadeInOut` keyed by pathname, in both the desktop and mobile branches, so every tab fades its whole content in — page title, search field and body — and re-fades when you switch tabs. The book title above stays put. Search params are excluded from the key on purpose: filtering within a tab must not replay the animation.

`FadeInOut` gained an `animateOnMount` prop so the tab wrapper does not stack with the book-level fade on first paint — without it the content would travel 40px and ramp opacity twice. It compares the rendered key against the incoming one during render rather than tracking mount in a ref or an effect, both of which the repo's `react-hooks` rules reject.

`ChapterGroupedList` lost its own `FadeInOut` and the `animationKey` prop that existed only to feed it, which removed that prop from `HighlightsList`, `FlashcardChapterList`, `HighlightsPage` and `FlashcardsPage` too. `ReadingSessionList` keeps its fade so paging through sessions still replays the list.

## Two consequences worth knowing

**Search results on Highlights and Flashcards no longer fade in.** `ChapterGroupedList` returned early while loading, so its old wrapper faded results in when a search resolved. A search changes only search params, so the tab wrapper does not cover it. Notes already popped its search results in with no animation, so this makes the three search-capable tabs agree rather than diverge.

**The Sessions list still animates on mount**, so on that one tab a warm cache gives a slightly deeper fade than elsewhere. The alternative was worse: `animateOnMount={false}` there suppressed the very fade it was meant to preserve, because paging refetches under a new query key and the page renders the list only once `data` is defined, so the list unmounts while an uncached page loads. Page 2 appeared instantly while the cached page 1 still faded. `placeholderData: keepPreviousData` on the sessions query would fix both, but that changes fetching behaviour beyond this ticket.

## Checks

`lint`, `format`, `type-check`, `knip` and `duplication-check` pass. Duplication is 1.0%, unchanged from `main`, so the threshold stays at 1.1. All 144 frontend tests across 21 files pass.

No test added: animation is not asserted anywhere in this repo, and the test tier here is user-visible route behaviour, which the existing route tests already cover for all six tabs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fupr32CuL6MNRw2rubiqyU