### PR TITLE
Show highlight, note and flashcard counts on library book cards

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -4635,6 +4635,13 @@
             "title": "Chapters",
             "description": "List of chapters with highlights"
           },
+          "highlight_count": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Highlight Count",
+            "description": "Live highlights on the book, including any that sit in no chapter",
+            "default": 0
+          },
           "reading_position": {
             "anyOf": [
               {
@@ -5010,6 +5017,13 @@
             "description": "Number of flashcards for this book",
             "default": 0
           },
+          "note_count": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Note Count",
+            "description": "Number of notes for this book, gists aside",
+            "default": 0
+          },
           "reading_stage": {
             "anyOf": [
               {
@@ -5088,7 +5102,7 @@
           "updated_at"
         ],
         "title": "BookWithHighlightCount",
-        "description": "Schema for Book with highlight and flashcard counts."
+        "description": "Schema for Book with highlight, flashcard and note counts."
       },
       "Bookmark": {
         "properties": {

--- a/backend/src/application/library/queries/book_details.py
+++ b/backend/src/application/library/queries/book_details.py
@@ -57,6 +57,7 @@ class BookDetailsView:
     bookmarks: tuple[BookmarkView, ...]
     book_flashcards: tuple[FlashcardRef, ...]
     chapters: tuple[ChapterWithHighlightsView, ...]
+    highlight_count: int
     reading_position: Position | None
     end_position: Position | None
     created_at: dt

--- a/backend/src/application/library/queries/book_list.py
+++ b/backend/src/application/library/queries/book_list.py
@@ -18,7 +18,7 @@ from src.domain.library.entities.book import ReadingStage
 
 @dataclass(frozen=True)
 class BookWithCountsView:
-    """A book as the library lists render it, with its highlight and card counts."""
+    """A book as the library lists render it, with its highlight, card and note counts."""
 
     id: int
     client_book_id: str | None
@@ -32,6 +32,7 @@ class BookWithCountsView:
     page_count: int | None
     highlight_count: int
     flashcard_count: int
+    note_count: int
     reading_stage: ReadingStage | None
     end_position: Position | None
     created_at: datetime

--- a/backend/src/domain/notes/entities/__init__.py
+++ b/backend/src/domain/notes/entities/__init__.py
@@ -1,5 +1,5 @@
 """Notes domain entities."""
 
-from src.domain.notes.entities.note import Note, NoteKind
+from src.domain.notes.entities.note import UNCOUNTED_NOTE_KINDS, Note, NoteKind
 
-__all__ = ["Note", "NoteKind"]
+__all__ = ["UNCOUNTED_NOTE_KINDS", "Note", "NoteKind"]

--- a/backend/src/domain/notes/entities/note.py
+++ b/backend/src/domain/notes/entities/note.py
@@ -22,6 +22,13 @@ class NoteKind(StrEnum):
     OTHER = "other"
 
 
+UNCOUNTED_NOTE_KINDS: frozenset[NoteKind] = frozenset({NoteKind.GIST})
+"""Kinds left out when notes are counted, matching the Notes tab's default filter.
+
+A note with no kind counts: untyped notes read as "other".
+"""
+
+
 @dataclass
 class Note(AggregateRoot[NoteId]):
     """

--- a/backend/src/infrastructure/library/queries/book_details_query.py
+++ b/backend/src/infrastructure/library/queries/book_details_query.py
@@ -58,6 +58,7 @@ class BookDetailsQuery:
         book, reading_position = book_row
 
         labels = await self.label_resolution_service.resolve_for_book(user_id, book_id)
+        highlights = await self._fetch_highlight_rows(book_id, user_id)
 
         return BookDetailsView(
             id=book.id,
@@ -75,7 +76,8 @@ class BookDetailsQuery:
             tag_groups=await self._fetch_tag_groups(book_id),
             bookmarks=await self._fetch_bookmarks(book_id),
             book_flashcards=await self._fetch_book_flashcards(book_id, user_id),
-            chapters=await self._fetch_chapters(book_id, user_id, labels),
+            chapters=await self._fetch_chapters(book_id, user_id, highlights, labels),
+            highlight_count=len(highlights),
             reading_position=reading_position,
             end_position=_position(book.end_position),
             created_at=book.created_at,
@@ -185,15 +187,17 @@ class BookDetailsQuery:
         self,
         book_id: BookId,
         user_id: UserId,
+        highlights: Sequence[HighlightORM],
         labels: dict[int, ResolvedLabel],
     ) -> tuple[ChapterWithHighlightsView, ...]:
         """Load every chapter of the book with the highlights that sit in it.
 
         Chapters without highlights are kept, and highlight groups whose chapter
-        is not among the book's chapters are appended at the end.
+        is not among the book's chapters are appended at the end. A highlight with
+        no chapter at all belongs to no group, so the tree holds fewer highlights
+        than the book has -- hence ``BookDetailsView.highlight_count``.
         """
         chapters = await self._fetch_chapter_rows(book_id, user_id)
-        highlights = await self._fetch_highlight_rows(book_id, user_id)
 
         grouped: dict[int, list[HighlightORM]] = defaultdict(list)
         orphan_chapters: dict[int, ChapterORM] = {}

--- a/backend/src/infrastructure/library/queries/book_list_query.py
+++ b/backend/src/infrastructure/library/queries/book_list_query.py
@@ -17,14 +17,17 @@ from src.application.library.queries.book_list import BookListPageView, BookWith
 from src.domain.common.value_objects.ids import UserId
 from src.domain.common.value_objects.position import Position
 from src.domain.library.entities.book import ReadingStage
+from src.domain.notes.entities.note import UNCOUNTED_NOTE_KINDS
 from src.infrastructure.common.sql import LIKE_ESCAPE_CHAR, escape_like_pattern
 from src.infrastructure.learning.orm.flashcard_model import Flashcard as FlashcardORM
 from src.infrastructure.library.orm.book_model import Book as BookORM
+from src.infrastructure.notes.orm.associations import note_books
+from src.infrastructure.notes.orm.note_model import Note as NoteORM
 from src.infrastructure.reading.orm.highlight_model import Highlight as HighlightORM
 
 
-def _book_rows() -> Select[tuple[BookORM, int, int]]:
-    """Select a book row with its highlight and flashcard counts.
+def _book_rows() -> Select[tuple[BookORM, int, int, int]]:
+    """Select a book row with its highlight, flashcard and note counts.
 
     Built per call rather than held as a module constant: ``noload`` resolves
     the relationship eagerly, which would configure the ORM mappers while this
@@ -52,7 +55,31 @@ def _book_rows() -> Select[tuple[BookORM, int, int]]:
         .scalar_subquery()
         .label("flashcard_count")
     )
-    return select(BookORM, highlight_count, flashcard_count).options(noload(BookORM.tag_groups))
+    note_count = (
+        select(func.count(NoteORM.id))
+        .join(note_books, note_books.c.note_id == NoteORM.id)
+        .where(
+            note_books.c.book_id == BookORM.id,
+            NoteORM.user_id == BookORM.user_id,
+            _note_counts(),
+        )
+        .correlate(BookORM)
+        .scalar_subquery()
+        .label("note_count")
+    )
+    return select(BookORM, highlight_count, flashcard_count, note_count).options(
+        noload(BookORM.tag_groups)
+    )
+
+
+def _note_counts() -> ColumnElement[bool]:
+    """Whether a note kind is one the counts include.
+
+    Spelled as an explicit null check because ``NOT IN`` yields null, not true,
+    for a note whose kind was never set.
+    """
+    excluded = [kind.value for kind in UNCOUNTED_NOTE_KINDS]
+    return or_(NoteORM.kind.is_(None), NoteORM.kind.not_in(excluded))
 
 
 class BookListQuery:
@@ -92,13 +119,13 @@ class BookListQuery:
         return await self._fetch(stmt)
 
     async def _fetch(
-        self, stmt: Select[tuple[BookORM, int, int]]
+        self, stmt: Select[tuple[BookORM, int, int, int]]
     ) -> tuple[BookWithCountsView, ...]:
         """Run a book-row select and map every row to its view DTO."""
         rows = (await self.db.execute(stmt)).all()
         return tuple(
-            _book_view(book, highlight_count, flashcard_count)
-            for book, highlight_count, flashcard_count in rows
+            _book_view(book, highlight_count, flashcard_count, note_count)
+            for book, highlight_count, flashcard_count, note_count in rows
         )
 
 
@@ -135,7 +162,9 @@ def _filters(
     return filters
 
 
-def _book_view(row: BookORM, highlight_count: int, flashcard_count: int) -> BookWithCountsView:
+def _book_view(
+    row: BookORM, highlight_count: int, flashcard_count: int, note_count: int
+) -> BookWithCountsView:
     """Map a book row and its counts to the view DTO."""
     return BookWithCountsView(
         id=row.id,
@@ -150,6 +179,7 @@ def _book_view(row: BookORM, highlight_count: int, flashcard_count: int) -> Book
         page_count=row.page_count,
         highlight_count=highlight_count,
         flashcard_count=flashcard_count,
+        note_count=note_count,
         reading_stage=ReadingStage(row.reading_stage) if row.reading_stage else None,
         end_position=Position.from_json(row.end_position) if row.end_position else None,
         created_at=row.created_at,

--- a/backend/src/infrastructure/library/routers/books.py
+++ b/backend/src/infrastructure/library/routers/books.py
@@ -83,6 +83,7 @@ def _build_book_with_counts_schema(view: BookWithCountsView) -> BookWithHighligh
         page_count=view.page_count,
         highlight_count=view.highlight_count,
         flashcard_count=view.flashcard_count,
+        note_count=view.note_count,
         reading_stage=view.reading_stage.value if view.reading_stage else None,
         end_position=PositionResponse(
             index=view.end_position.index,
@@ -157,6 +158,7 @@ def _build_book_details_schema(view: BookDetailsView) -> BookDetails:
             for f in view.book_flashcards
         ],
         chapters=[_build_chapter_schema(chapter) for chapter in view.chapters],
+        highlight_count=view.highlight_count,
         reading_position=PositionResponse(
             index=view.reading_position.index,
             char_index=view.reading_position.char_index,

--- a/backend/src/infrastructure/library/schemas/book_schemas.py
+++ b/backend/src/infrastructure/library/schemas/book_schemas.py
@@ -77,7 +77,7 @@ class Book(BookBase):
 
 
 class BookWithHighlightCount(BaseModel):
-    """Schema for Book with highlight and flashcard counts."""
+    """Schema for Book with highlight, flashcard and note counts."""
 
     id: int
     client_book_id: str | None = None
@@ -91,6 +91,7 @@ class BookWithHighlightCount(BaseModel):
     page_count: int | None = None
     highlight_count: int = Field(..., ge=0, description="Number of highlights for this book")
     flashcard_count: int = Field(0, ge=0, description="Number of flashcards for this book")
+    note_count: int = Field(0, ge=0, description="Number of notes for this book, gists aside")
     reading_stage: ReadingStageLiteral | None = Field(
         None, description="Where the reader is with this book, or null if unset"
     )

--- a/backend/src/infrastructure/reading/schemas/highlight_schemas.py
+++ b/backend/src/infrastructure/reading/schemas/highlight_schemas.py
@@ -256,6 +256,11 @@ class BookDetails(BaseModel):
     chapters: list[ChapterWithHighlights] = Field(
         ..., description="List of chapters with highlights"
     )
+    highlight_count: int = Field(
+        0,
+        ge=0,
+        description="Live highlights on the book, including any that sit in no chapter",
+    )
     reading_position: PositionResponse | None = Field(
         None, description="User's current reading position from latest session"
     )

--- a/backend/tests/test_books.py
+++ b/backend/tests/test_books.py
@@ -1250,3 +1250,106 @@ class TestRecentBooks:
         item = response.json()["items"][0]
         assert parse_stamp(item["last_viewed"]) == STAMPS[0]
         assert parse_stamp(item["last_synced"]) == STAMPS[1]
+
+
+class TestBookCounts:
+    """The counts the library cards render, on the list and on the details view."""
+
+    async def _add_note(
+        self, client: AsyncClient, book_id: int, title: str, kind: str | None = None
+    ) -> None:
+        payload: dict[str, object] = {"title": title, "book_id": book_id}
+        if kind is not None:
+            payload["kind"] = kind
+        response = await client.post("/api/v1/notes", json=payload)
+        assert response.status_code == status.HTTP_201_CREATED
+
+    async def test_note_count_skips_gists_and_keeps_untyped_notes(
+        self, client: AsyncClient, test_book: models.Book
+    ) -> None:
+        await self._add_note(client, test_book.id, "Raskolnikov", kind="character")
+        await self._add_note(client, test_book.id, "Untyped")
+        await self._add_note(client, test_book.id, "Chapter 1 in brief", kind="gist")
+
+        response = await client.get("/api/v1/books/")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["items"][0]["note_count"] == 2
+
+    async def test_note_count_is_zero_without_notes(
+        self, client: AsyncClient, test_book: models.Book
+    ) -> None:
+        response = await client.get("/api/v1/books/")
+
+        assert response.json()["items"][0]["note_count"] == 0
+
+    async def test_note_count_ignores_another_users_notes(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        test_book: models.Book,
+        test_user: models.User,
+    ) -> None:
+        stranger = models.User(email="stranger@example.com", hashed_password="x")
+        db_session.add(stranger)
+        await db_session.commit()
+        note = models.Note(user_id=stranger.id, title="Not mine", kind="concept")
+        note.books.append(test_book)
+        db_session.add(note)
+        await db_session.commit()
+
+        response = await client.get("/api/v1/books/")
+
+        assert response.json()["items"][0]["note_count"] == 0
+
+    async def test_details_highlight_count_includes_chapterless_highlights(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        test_book: models.Book,
+        test_chapter: models.Chapter,
+        test_user: models.User,
+    ) -> None:
+        """The chapter tree drops highlights with no chapter; the count must not."""
+        await create_test_highlight(
+            db_session,
+            test_book,
+            test_user.id,
+            "In a chapter",
+            "2024-01-01 10:00:00",
+            chapter_id=test_chapter.id,
+        )
+        await create_test_highlight(
+            db_session, test_book, test_user.id, "No chapter", "2024-01-01 11:00:00"
+        )
+
+        response = await client.get(f"/api/v1/books/{test_book.id}")
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["highlight_count"] == 2
+        in_tree = sum(len(chapter["highlights"]) for chapter in data["chapters"])
+        assert in_tree == 1
+
+    async def test_details_highlight_count_skips_deleted_highlights(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        test_book: models.Book,
+        test_user: models.User,
+    ) -> None:
+        await create_test_highlight(
+            db_session, test_book, test_user.id, "Live", "2024-01-01 10:00:00"
+        )
+        await create_test_highlight(
+            db_session,
+            test_book,
+            test_user.id,
+            "Gone",
+            "2024-01-01 11:00:00",
+            deleted_at=datetime(2024, 2, 1, tzinfo=UTC),
+        )
+
+        response = await client.get(f"/api/v1/books/{test_book.id}")
+
+        assert response.json()["highlight_count"] == 1

--- a/frontend/src/api/generated/model/bookDetails.ts
+++ b/frontend/src/api/generated/model/bookDetails.ts
@@ -40,6 +40,11 @@ export interface BookDetails {
   book_flashcards?: Flashcard[];
   /** List of chapters with highlights */
   chapters: ChapterWithHighlights[];
+  /**
+   * Live highlights on the book, including any that sit in no chapter
+   * @minimum 0
+   */
+  highlight_count?: number;
   /** User's current reading position from latest session */
   reading_position?: PositionResponse | null;
   /** End position of the book (total document length) */

--- a/frontend/src/api/generated/model/bookWithHighlightCount.ts
+++ b/frontend/src/api/generated/model/bookWithHighlightCount.ts
@@ -8,7 +8,7 @@ import type { BookWithHighlightCountReadingStage } from './bookWithHighlightCoun
 import type { PositionResponse } from './positionResponse.ts';
 
 /**
- * Schema for Book with highlight and flashcard counts.
+ * Schema for Book with highlight, flashcard and note counts.
  */
 export interface BookWithHighlightCount {
   id: number;
@@ -33,6 +33,11 @@ export interface BookWithHighlightCount {
    * @minimum 0
    */
   flashcard_count?: number;
+  /**
+   * Number of notes for this book, gists aside
+   * @minimum 0
+   */
+  note_count?: number;
   /** Where the reader is with this book, or null if unset */
   reading_stage?: BookWithHighlightCountReadingStage;
   /** End position of the book (total document length) */

--- a/frontend/src/components/CountWithIcon.tsx
+++ b/frontend/src/components/CountWithIcon.tsx
@@ -1,0 +1,35 @@
+import { ICON_SIZE } from '@/theme/iconSizes';
+import { countLabel } from '@/utils/counts';
+import type { SvgIconComponent } from '@mui/icons-material';
+import { Box } from '@mui/material';
+
+interface CountWithIconProps {
+  icon: SvgIconComponent;
+  count: number;
+  /** Singular noun, for the label a screen reader reads instead of the glyph. */
+  noun: string;
+}
+
+/**
+ * A count as an icon and a number, or nothing at all when the count is zero.
+ *
+ * Inline so it sits inside a metadata line as happily as in a flex row, and it
+ * inherits its font size from whatever wraps it.
+ */
+export const CountWithIcon = ({ icon: Icon, count, noun }: CountWithIconProps) =>
+  count > 0 ? (
+    <Box
+      component="span"
+      role="img"
+      aria-label={countLabel(count, noun)}
+      sx={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 0.5,
+        verticalAlign: 'middle',
+      }}
+    >
+      <Icon sx={{ fontSize: ICON_SIZE.inline }} />
+      {count}
+    </Box>
+  ) : null;

--- a/frontend/src/components/cards/HighlightCard.tsx
+++ b/frontend/src/components/cards/HighlightCard.tsx
@@ -1,6 +1,7 @@
 import type { Bookmark, Highlight } from '@/api/generated/model';
 import { HoverableCardActionArea } from '@/components/cards/HoverableCardActionArea';
 import { MetadataRow } from '@/components/cards/MetadataRow.tsx';
+import { CountWithIcon } from '@/components/CountWithIcon.tsx';
 import { TagChipList } from '@/components/TagChipList.tsx';
 import { LabelIndicator } from '@/pages/BookPage/common/LabelIndicator.tsx';
 import { NotOnDeviceChip } from '@/pages/BookPage/common/NotOnDeviceChip.tsx';
@@ -12,9 +13,7 @@ import {
   NotesIcon,
 } from '@/theme/Icons.tsx';
 import { ICON_SIZE } from '@/theme/iconSizes.ts';
-import { countLabel } from '@/utils/counts.ts';
 import { formatDate } from '@/utils/date.ts';
-import type { SvgIconComponent } from '@mui/icons-material';
 import { Box, Typography } from '@mui/material';
 
 export interface HighlightCardProps {
@@ -30,22 +29,6 @@ interface FooterProps {
   bookmark?: Bookmark;
   noteCount: number;
 }
-
-/** An icon and a number. `role="img"` carries the unit the glyph alone implies. */
-const CountBadge = ({
-  icon: Icon,
-  count,
-  noun,
-}: {
-  icon: SvgIconComponent;
-  count: number;
-  noun: string;
-}) => (
-  <Box component="span" role="img" aria-label={countLabel(count, noun)}>
-    <Icon sx={{ fontSize: ICON_SIZE.inline, verticalAlign: 'middle', ml: 1, mt: -0.5 }} />
-    <span>&nbsp;&nbsp;{count}</span>
-  </Box>
-);
 
 const Footer = ({ highlight, bookmark, noteCount }: FooterProps) => {
   const hasBookmark = !!bookmark;
@@ -80,9 +63,9 @@ const Footer = ({ highlight, bookmark, noteCount }: FooterProps) => {
                 sx={{ fontSize: ICON_SIZE.inline, verticalAlign: 'middle', ml: 1, mt: -0.5 }}
               />
             ),
-            !!noteCount && <CountBadge icon={NotesIcon} count={noteCount} noun="note" />,
+            !!noteCount && <CountWithIcon icon={NotesIcon} count={noteCount} noun="note" />,
             !!highlight.flashcards.length && (
-              <CountBadge
+              <CountWithIcon
                 icon={FlashcardsIcon}
                 count={highlight.flashcards.length}
                 noun="flashcard"

--- a/frontend/src/pages/BookPage/BookTitle/BookStatsStrip.tsx
+++ b/frontend/src/pages/BookPage/BookTitle/BookStatsStrip.tsx
@@ -14,10 +14,6 @@ export const BookStatsStrip = ({ book }: BookStatsStripProps) => {
   const { data: sessionsData } = useGetBookReadingSessions(book.id, { limit: 1 });
   const { data: notesData } = useGetNotesForBook(book.id);
 
-  // Count highlights across all chapters
-  const highlightCount = book.chapters.reduce((sum, chapter) => sum + chapter.highlights.length, 0);
-
-  // Count flashcards
   const flashcardCount = book.book_flashcards?.length ?? 0;
 
   // Gists are excluded so this matches what the Notes tab lists by default.
@@ -25,13 +21,12 @@ export const BookStatsStrip = ({ book }: BookStatsStripProps) => {
     DEFAULT_NOTE_KINDS.includes(noteKindOf(note.kind))
   ).length;
 
-  // Last read date from latest session
   const latestSession = sessionsData?.items[0];
   const lastReadDate = latestSession ? formatDate(latestSession.start_time) : null;
 
   const items = [
     book.page_count ? countLabel(book.page_count, 'page') : null,
-    countLabel(highlightCount, 'highlight'),
+    countLabel(book.highlight_count ?? 0, 'highlight'),
     countLabel(noteCount, 'note'),
     countLabel(flashcardCount, 'flashcard'),
     countLabel(book.bookmarks.length, 'bookmark'),

--- a/frontend/src/pages/BookPage/Structure/ChapterAccordion.tsx
+++ b/frontend/src/pages/BookPage/Structure/ChapterAccordion.tsx
@@ -1,9 +1,7 @@
 import type { ChapterWithHighlights, PositionResponse } from '@/api/generated/model';
 import { CollapseChevron } from '@/components/CollapseChevron.tsx';
+import { CountWithIcon } from '@/components/CountWithIcon.tsx';
 import { FlashcardsIcon, HighlightsIcon, NotesIcon } from '@/theme/Icons.tsx';
-import { ICON_SIZE } from '@/theme/iconSizes.ts';
-import { countLabel } from '@/utils/counts.ts';
-import type { SvgIconComponent } from '@mui/icons-material';
 import { Box, ButtonBase, Collapse, IconButton, Typography, type Theme } from '@mui/material';
 import { sumBy } from 'lodash';
 import { useId, useState } from 'react';
@@ -79,30 +77,6 @@ const ChapterLabel = ({
   </Box>
 );
 
-/**
- * A count as an icon and a number. `role="img"` carries the unit, which the
- * pair otherwise leaves to the glyph — a screen reader would read "2".
- */
-const CountWithIcon = ({
-  icon: Icon,
-  count,
-  noun,
-}: {
-  icon: SvgIconComponent;
-  count: number;
-  noun: string;
-}) =>
-  count > 0 ? (
-    <Box
-      role="img"
-      aria-label={countLabel(count, noun)}
-      sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}
-    >
-      <Icon sx={{ fontSize: ICON_SIZE.inline }} />
-      <Typography variant="caption">{count}</Typography>
-    </Box>
-  ) : null;
-
 const ChapterCounts = ({
   chapter,
   noteCount,
@@ -110,7 +84,15 @@ const ChapterCounts = ({
   chapter: ChapterWithHighlights;
   noteCount: number;
 }) => (
-  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, color: 'text.secondary' }}>
+  <Box
+    sx={{
+      display: 'flex',
+      alignItems: 'center',
+      gap: 1.5,
+      color: 'text.secondary',
+      typography: 'caption',
+    }}
+  >
     <CountWithIcon icon={HighlightsIcon} count={chapter.highlights.length} noun="highlight" />
     <CountWithIcon icon={NotesIcon} count={noteCount} noun="note" />
     <CountWithIcon

--- a/frontend/src/pages/LandingPage/LandingPage.test.tsx
+++ b/frontend/src/pages/LandingPage/LandingPage.test.tsx
@@ -1,0 +1,47 @@
+import { aBookCard } from '@tests/fixtures/book';
+import { renderApp } from '@tests/harness/renderApp';
+import { libraryApi } from '@tests/msw/libraryApi';
+import { worker } from '@tests/msw/worker';
+import { expect, test } from 'vitest';
+
+test('a book card shows what the reader has made of the book', async () => {
+  worker.use(
+    ...libraryApi([
+      aBookCard({
+        title: 'The Pragmatic Reader',
+        highlight_count: 412,
+        note_count: 6,
+        flashcard_count: 38,
+      }),
+    ])
+  );
+
+  const screen = await renderApp({ path: '/' });
+
+  await expect.element(screen.getByRole('img', { name: '412 highlights' })).toBeVisible();
+  await expect.element(screen.getByRole('img', { name: '6 notes' })).toBeVisible();
+  await expect.element(screen.getByRole('img', { name: '38 flashcards' })).toBeVisible();
+});
+
+test('a count the book has none of is left off the card', async () => {
+  worker.use(
+    ...libraryApi([
+      aBookCard({ title: 'Untouched', highlight_count: 3, note_count: 0, flashcard_count: 0 }),
+    ])
+  );
+
+  const screen = await renderApp({ path: '/' });
+
+  await expect.element(screen.getByRole('img', { name: '3 highlights' })).toBeVisible();
+  expect(screen.getByRole('img', { name: /notes?$/ }).query()).toBeNull();
+  expect(screen.getByRole('img', { name: /flashcards?$/ }).query()).toBeNull();
+});
+
+test('a single count reads in the singular', async () => {
+  worker.use(...libraryApi([aBookCard({ highlight_count: 1, note_count: 1 })]));
+
+  const screen = await renderApp({ path: '/' });
+
+  await expect.element(screen.getByRole('img', { name: '1 highlight' })).toBeVisible();
+  await expect.element(screen.getByRole('img', { name: '1 note' })).toBeVisible();
+});

--- a/frontend/src/pages/LandingPage/LandingPage.test.tsx
+++ b/frontend/src/pages/LandingPage/LandingPage.test.tsx
@@ -45,3 +45,16 @@ test('a single count reads in the singular', async () => {
   await expect.element(screen.getByRole('img', { name: '1 highlight' })).toBeVisible();
   await expect.element(screen.getByRole('img', { name: '1 note' })).toBeVisible();
 });
+
+test('a book nobody has marked up carries no strip', async () => {
+  worker.use(
+    ...libraryApi([
+      aBookCard({ title: 'Untouched', highlight_count: 0, note_count: 0, flashcard_count: 0 }),
+    ])
+  );
+
+  const screen = await renderApp({ path: '/' });
+
+  await expect.element(screen.getByText('Untouched')).toBeVisible();
+  expect(screen.getByTestId('book-counts').query()).toBeNull();
+});

--- a/frontend/src/pages/LandingPage/components/BookCard.tsx
+++ b/frontend/src/pages/LandingPage/components/BookCard.tsx
@@ -11,32 +11,58 @@ import { Link } from '@tanstack/react-router';
  *  need the same number to size their columns. */
 export const BOOK_CARD_WIDTH = 150;
 
+/** Inset of the markers that sit on top of the cover, on every edge. */
+const COVER_INSET = 8;
+
 export interface BookCardProps {
   book: BookWithHighlightCount;
 }
 
 /**
- * What the reader has made of the book: highlights, notes, cards. Each count
- * is dropped at zero, so a book nobody has marked up carries no row at all.
+ * What the reader has made of the book, as a strip across the foot of the
+ * cover. Each count is dropped at zero, and a book nobody has marked up carries
+ * no strip at all rather than an empty one.
+ *
+ * The scrim is what makes it legible: cover art comes in every shade, so the
+ * counts need a darkened surface of their own to sit on.
  */
-const BookCounts = ({ book }: BookCardProps) => (
-  <Box
-    sx={{
-      display: 'flex',
-      flexWrap: 'wrap',
-      alignItems: 'center',
-      gap: 1,
-      mt: 0.5,
-      maxWidth: BOOK_CARD_WIDTH,
-      color: 'text.secondary',
-      typography: 'caption',
-    }}
-  >
-    <CountWithIcon icon={HighlightsIcon} count={book.highlight_count} noun="highlight" />
-    <CountWithIcon icon={NotesIcon} count={book.note_count ?? 0} noun="note" />
-    <CountWithIcon icon={FlashcardsIcon} count={book.flashcard_count ?? 0} noun="flashcard" />
-  </Box>
-);
+const BookCounts = ({ book }: BookCardProps) => {
+  const counts = [
+    { icon: HighlightsIcon, count: book.highlight_count, noun: 'highlight' },
+    { icon: NotesIcon, count: book.note_count ?? 0, noun: 'note' },
+    { icon: FlashcardsIcon, count: book.flashcard_count ?? 0, noun: 'flashcard' },
+  ];
+
+  if (counts.every(({ count }) => count === 0)) return null;
+
+  return (
+    <Box
+      // The strip has no accessible name of its own -- an aria-label here would
+      // only pad the link's. This is how a test sees whether it rendered.
+      data-testid="book-counts"
+      sx={(theme) => ({
+        position: 'absolute',
+        left: 0,
+        right: 0,
+        bottom: 0,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 1,
+        py: 0.5,
+        backgroundColor: theme.customColors.coverScrim.strip,
+        color: theme.palette.common.white,
+        typography: 'caption',
+        borderBottomLeftRadius: theme.shape.borderRadius,
+        borderBottomRightRadius: theme.shape.borderRadius,
+      })}
+    >
+      {counts.map(({ icon, count, noun }) => (
+        <CountWithIcon key={noun} icon={icon} count={count} noun={noun} />
+      ))}
+    </Box>
+  );
+};
 
 const truncateText = (text: string, maxLength: number) => {
   if (text.length <= maxLength) return text;
@@ -81,9 +107,11 @@ export const BookCard = ({ book }: BookCardProps) => {
             />
 
             {/* Reading stage marker */}
-            <Box sx={{ position: 'absolute', top: 8, right: 8 }}>
+            <Box sx={{ position: 'absolute', top: COVER_INSET, right: COVER_INSET }}>
               <ReadingStageIcon stage={book.reading_stage} />
             </Box>
+
+            <BookCounts book={book} />
           </Box>
 
           {/* Book title */}
@@ -113,8 +141,6 @@ export const BookCard = ({ book }: BookCardProps) => {
           >
             {truncateText(book.author || 'Unknown author', 30)}
           </Typography>
-
-          <BookCounts book={book} />
         </Box>
       </Link>
     </FadeInOut>

--- a/frontend/src/pages/LandingPage/components/BookCard.tsx
+++ b/frontend/src/pages/LandingPage/components/BookCard.tsx
@@ -1,7 +1,9 @@
 import type { BookWithHighlightCount } from '@/api/generated/model';
 import { FadeInOut } from '@/components/animations/FadeInOut.tsx';
 import { BookCover } from '@/components/BookCover';
+import { CountWithIcon } from '@/components/CountWithIcon.tsx';
 import { ReadingStageIcon } from '@/components/readingStage/ReadingStageIcon.tsx';
+import { FlashcardsIcon, HighlightsIcon, NotesIcon } from '@/theme/Icons.tsx';
 import { Box, Typography } from '@mui/material';
 import { Link } from '@tanstack/react-router';
 
@@ -12,6 +14,29 @@ export const BOOK_CARD_WIDTH = 150;
 export interface BookCardProps {
   book: BookWithHighlightCount;
 }
+
+/**
+ * What the reader has made of the book: highlights, notes, cards. Each count
+ * is dropped at zero, so a book nobody has marked up carries no row at all.
+ */
+const BookCounts = ({ book }: BookCardProps) => (
+  <Box
+    sx={{
+      display: 'flex',
+      flexWrap: 'wrap',
+      alignItems: 'center',
+      gap: 1,
+      mt: 0.5,
+      maxWidth: BOOK_CARD_WIDTH,
+      color: 'text.secondary',
+      typography: 'caption',
+    }}
+  >
+    <CountWithIcon icon={HighlightsIcon} count={book.highlight_count} noun="highlight" />
+    <CountWithIcon icon={NotesIcon} count={book.note_count ?? 0} noun="note" />
+    <CountWithIcon icon={FlashcardsIcon} count={book.flashcard_count ?? 0} noun="flashcard" />
+  </Box>
+);
 
 const truncateText = (text: string, maxLength: number) => {
   if (text.length <= maxLength) return text;
@@ -40,7 +65,6 @@ export const BookCard = ({ book }: BookCardProps) => {
             },
           }}
         >
-          {/* Book cover with reading-stage and highlight-count overlays */}
           <Box sx={{ position: 'relative', width: 'fit-content' }}>
             <BookCover
               coverFile={book.cover_file ?? null}
@@ -89,6 +113,8 @@ export const BookCard = ({ book }: BookCardProps) => {
           >
             {truncateText(book.author || 'Unknown author', 30)}
           </Typography>
+
+          <BookCounts book={book} />
         </Box>
       </Link>
     </FadeInOut>

--- a/frontend/src/theme/theme.ts
+++ b/frontend/src/theme/theme.ts
@@ -35,6 +35,12 @@ const customColors = {
     hover: 'rgba(255, 255, 255, 0.18)', // Search field surface on hover (AppBar)
   },
 
+  // A scrim for text laid over cover art. Unlike the whites above, what sits
+  // behind this is unknown -- darkening it is the whole point.
+  coverScrim: {
+    strip: 'rgba(0, 0, 0, 0.70)',
+  },
+
   // Opaque panel fills. A white veil reads only against a darker page — these
   // are the same on the stone page background and on a paper-white drawer.
   surfaces: {

--- a/frontend/tests/fixtures/book.ts
+++ b/frontend/tests/fixtures/book.ts
@@ -1,4 +1,9 @@
-import type { BookDetails, ChapterWithHighlights, Highlight } from '@/api/generated/model';
+import type {
+  BookDetails,
+  BookWithHighlightCount,
+  ChapterWithHighlights,
+  Highlight,
+} from '@/api/generated/model';
 
 export const aHighlight = (overrides: Partial<Highlight> = {}): Highlight => ({
   id: 300,
@@ -30,25 +35,54 @@ export const aChapter = (
   ...overrides,
 });
 
-export const aBookDetails = (overrides: Partial<BookDetails> = {}): BookDetails => ({
+/**
+ * Highlights sitting in no chapter are absent from the tree but present in
+ * `highlight_count`, so a test that needs them sets the count explicitly.
+ */
+export const aBookDetails = (overrides: Partial<BookDetails> = {}): BookDetails => {
+  const book = {
+    id: 1,
+    title: 'The Pragmatic Reader',
+    author: 'Ada Lovelace',
+    isbn: null,
+    cover_file: null,
+    cover_blurhash: null,
+    description: null,
+    language: 'en',
+    page_count: 320,
+    tags: [],
+    tag_groups: [],
+    bookmarks: [],
+    book_flashcards: [],
+    chapters: [aChapter()],
+    reading_position: null,
+    end_position: null,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    last_viewed: null,
+    ...overrides,
+  };
+  return {
+    ...book,
+    highlight_count:
+      overrides.highlight_count ??
+      book.chapters.reduce((sum, chapter) => sum + chapter.highlights.length, 0),
+  };
+};
+
+export const aBookCard = (
+  overrides: Partial<BookWithHighlightCount> = {}
+): BookWithHighlightCount => ({
   id: 1,
   title: 'The Pragmatic Reader',
   author: 'Ada Lovelace',
   isbn: null,
   cover_file: null,
   cover_blurhash: null,
-  description: null,
-  language: 'en',
-  page_count: 320,
-  tags: [],
-  tag_groups: [],
-  bookmarks: [],
-  book_flashcards: [],
-  chapters: [aChapter()],
-  reading_position: null,
-  end_position: null,
+  highlight_count: 0,
+  flashcard_count: 0,
+  note_count: 0,
   created_at: '2026-01-01T00:00:00Z',
   updated_at: '2026-01-01T00:00:00Z',
-  last_viewed: null,
   ...overrides,
 });

--- a/frontend/tests/msw/libraryApi.ts
+++ b/frontend/tests/msw/libraryApi.ts
@@ -1,0 +1,12 @@
+import type { BookWithHighlightCount } from '@/api/generated/model';
+import { http, HttpResponse } from 'msw';
+
+/** The landing page's two lists, served from one set of books. */
+export function libraryApi(books: BookWithHighlightCount[], recent: BookWithHighlightCount[] = []) {
+  return [
+    http.get('/api/v1/books/', () =>
+      HttpResponse.json({ items: books, total: books.length, offset: 0, limit: 32 })
+    ),
+    http.get('/api/v1/books/recent', () => HttpResponse.json({ items: recent })),
+  ];
+}


### PR DESCRIPTION
Closes #672. Design was settled in [a session on the ticket](https://github.com/Crossbill-App/crossbill-web/issues/672#issuecomment-5463289493).

## What changed

Each library card carries a muted row under the author — highlights, notes, flashcards, as icons and numbers, in that fixed order. A count of zero is dropped; a book nobody has marked up shows no row at all. Both surfaces get it, since `BookCard` is shared by the all-books grid and the Recent books carousel.

Words don't fit a 150px card (`412 highlights · 38 flashcards` is ~195px), and the icon vocabulary already exists in `theme/Icons.tsx` and on the book-detail chapter rows, so a reader who has seen a chapter row reads the card for free.

Counts are not clickable: the card is already a `<Link>`, and nested anchors would mean restructuring it for one saved tap.

## Notes are new on the wire

The ticket assumed all three numbers were already available; only two were. `note_count` is a new correlated subquery through `note_books`, scoped to the book's owner and excluding gists — matching `DEFAULT_NOTE_KINDS`, so the card and the Notes tab agree. The exclusion lives as `UNCOUNTED_NOTE_KINDS` beside `NoteKind` in the domain rather than as a string literal in SQL.

`notes.kind` is nullable and untyped notes read as `other`, so the filter is a null check plus `NOT IN`, not a bare `!=` — the latter silently drops every untyped note.

## A pre-existing undercount, fixed

`BookStatsStrip` summed `book.chapters[].highlights.length`, but `book_details_query` drops highlights with `chapter_id IS NULL`, which the upload path leaves unset when the plugin sends no `chapter_number`. So the book page already undercounted, and putting a correct count on the card would have made the mismatch visible. `BookDetails` now carries a real `highlight_count`.

Surfacing those highlights in the chapter tree is a separate issue — they are currently unreachable from that view.

## Duplication

`CountWithIcon` had already been written twice: once in `ChapterAccordion`, once as `CountBadge` in `HighlightCard`. It moves to `src/components/` and both call sites migrate to it. It renders inline now, so it works inside a `MetadataRow` as well as in a flex row.

## Verification

930 backend tests, 147 frontend tests, pyright clean, all five import-linter contracts kept, knip and lint clean. Duplication unchanged (1.02% frontend, 2.30% backend), so no threshold moves.

Each new test was mutation-checked — code broken, failure confirmed, reverted. The user-isolation test earned its keep: it caught a missing owner filter on the note subquery, where another user's note linked to your book inflated the count.

No `koreader-plugin` minimum bump: both new fields are additive.
