### PR TITLE
Fix the mobile filter drawer leaving the page unscrollable

### DIFF
--- a/frontend/src/pages/BookPage/common/FilterFab.tsx
+++ b/frontend/src/pages/BookPage/common/FilterFab.tsx
@@ -13,7 +13,12 @@ export const FilterFab = ({ activeFilterCount, onClick }: FilterFabProps) => {
 
   return (
     <Zoom in={true} mountOnEnter unmountOnExit>
-      <Badge badgeContent={activeFilterCount} color="secondary" overlap="circular">
+      <Badge
+        badgeContent={activeFilterCount}
+        color="secondary"
+        overlap="circular"
+        slotProps={{ badge: { sx: { zIndex: (theme) => theme.zIndex.fab + 1 } } }}
+      >
         <Fab
           size="small"
           color={isFiltered ? 'primary' : 'default'}

--- a/frontend/src/pages/BookPage/navigation/FilterDrawer.test.tsx
+++ b/frontend/src/pages/BookPage/navigation/FilterDrawer.test.tsx
@@ -1,0 +1,104 @@
+import { aBookDetails, aChapter, aHighlight } from '@tests/fixtures/book';
+import { renderApp } from '@tests/harness/renderApp';
+import { bookApi } from '@tests/msw/bookApi';
+import { worker } from '@tests/msw/worker';
+import { expect, test } from 'vitest';
+import { page, userEvent } from 'vitest/browser';
+
+type Screen = Awaited<ReturnType<typeof renderApp>>;
+
+const aTaggedBook = () =>
+  aBookDetails({
+    tags: [{ id: 5, name: 'Method', tag_group_id: null }],
+    chapters: [
+      aChapter({
+        highlights: [
+          aHighlight({ id: 301, text: 'Tagged one', tags: [{ id: 5, name: 'Method' }] }),
+          aHighlight({ id: 302, text: 'Untagged two' }),
+        ],
+      }),
+    ],
+  });
+
+/** Every property `lockBodyScroll` sets, so a leftover from any owner shows up. */
+const bodyLockStyles = () => {
+  const { overflow, position, top, width } = document.body.style;
+  return { overflow, position, top, width };
+};
+
+const UNLOCKED = { overflow: '', position: '', top: '', width: '' };
+
+/** The drawer is mobile-only, so these run at a phone width throughout. */
+const onMobile = async (body: () => Promise<void>) => {
+  await page.viewport(400, 800);
+  try {
+    await body();
+  } finally {
+    await page.viewport(1440, 900);
+  }
+};
+
+const openFilterDrawer = async (): Promise<Screen> => {
+  worker.use(...bookApi({ book: aTaggedBook() }).handlers);
+  const screen = await renderApp({ path: '/book/1/highlights' });
+
+  await expect.element(screen.getByText('Tagged one')).toBeVisible();
+  await userEvent.click(screen.getByRole('button', { name: 'Open filters' }));
+  await expect.element(screen.getByRole('tab', { name: 'Chapters' })).toBeVisible();
+
+  return screen;
+};
+
+/**
+ * Resolves once the drawer's modal has left the DOM.
+ *
+ * MUI puts its own body styles back when the exit transition ends, so a check
+ * made before that races the very restore these tests are about.
+ */
+const drawerGone = async (screen: Screen) => {
+  await expect.poll(() => screen.getByRole('presentation').elements()).toHaveLength(0);
+};
+
+/**
+ * Regression for the filter drawer leaving the page unscrollable.
+ *
+ * MUI's Modal runs a body scroll lock of its own, and it records the styles to
+ * restore when its portal mounts — a render *after* `useBodyScrollLock` has
+ * already pinned the body. It therefore took `overflow: hidden` for the page's
+ * own value and put it back on close, and nothing short of a reload got the
+ * page scrolling again. The drawer's lock is ours alone; MUI's is off.
+ */
+test('picking a filter closes the drawer and leaves the page scrollable', async () => {
+  await onMobile(async () => {
+    const screen = await openFilterDrawer();
+    await userEvent.click(screen.getByRole('tab', { name: 'Tags' }));
+
+    // While it is open the drawer owns the body: pinned, and parked at the
+    // scroll position to restore (`0px` here — the list starts at the top).
+    expect(bodyLockStyles()).toEqual({
+      overflow: 'hidden',
+      position: 'fixed',
+      top: '0px',
+      width: '100%',
+    });
+
+    await userEvent.click(screen.getByRole('button', { name: /Method/ }));
+
+    await expect.poll(() => window.location.search).toContain('tagId=5');
+    await drawerGone(screen);
+
+    expect(bodyLockStyles()).toEqual(UNLOCKED);
+    expect(screen.getByText('Untagged two').elements()).toHaveLength(0);
+  });
+});
+
+test('closing the drawer by hand leaves the page scrollable', async () => {
+  await onMobile(async () => {
+    const screen = await openFilterDrawer();
+
+    await userEvent.click(screen.getByRole('button', { name: 'close' }));
+    await drawerGone(screen);
+
+    expect(bodyLockStyles()).toEqual(UNLOCKED);
+  });
+});

--- a/frontend/src/pages/BookPage/navigation/FilterDrawer.tsx
+++ b/frontend/src/pages/BookPage/navigation/FilterDrawer.tsx
@@ -26,7 +26,7 @@ export const FilterDrawer = ({ open, onClose, tabs, header }: FilterDrawerProps)
   };
 
   return (
-    <Drawer anchor="bottom" open={open} onClose={handleClose}>
+    <Drawer anchor="bottom" open={open} onClose={handleClose} disableScrollLock>
       {/* Capped against the *dynamic* viewport, so the drawer stays clear of
           mobile browser chrome however much of it is showing. It scrolls its
           own content; `contain` keeps a pull that runs past either end from


### PR DESCRIPTION
## Two mobile filter bugs

### Scrolling stops after setting a filter

Setting a filter on mobile left `<body>` stuck at `overflow: hidden` — the page stopped scrolling and nothing short of a reload brought it back.

Two scroll locks were fighting over the body. The drawer holds our reference-counted `useBodyScrollLock`, but MUI's `Modal` runs one of its own that nothing turned off. MUI records the styles it will restore when its *portal* mounts, which is a render **after** our lock has already pinned the body — so it took our `overflow: hidden` for the page's own value and dutifully put it back on close.

Traced with a `MutationObserver` on `<body>`:

```
--- clicking a tag ---
overflow=<empty> position=<empty> top=<empty>   ← our unlock, correct
overflow=hidden  position=<empty> top=<empty>   ← MUI restoring our own lock
```

That shape matches the symptom exactly: `overflow: hidden` without `position: fixed`, so the page never visibly jumped — it just stopped scrolling.

The fix is the prop `CommonDialog` already passes: `disableScrollLock` on the `Drawer`, leaving our lock as the body's single owner. The reference counting itself was never at fault.

This was not specific to highlights — Notes and Flashcards use the same drawer and had the same bug.

### The filter count sat behind the FAB

MUI puts `zIndex: theme.zIndex.fab` (1050) on the `Fab` root but only `zIndex: 1` on the badge, both inside the badge's own stacking context, so the button painted over its own count. Lifted the badge to `theme.zIndex.fab + 1`.

## Tests

- `FilterDrawer.test.tsx` — picking a tag, and closing by hand, both assert the body is fully unlocked. The check waits for the modal to leave the DOM: MUI restores its bookkeeping only when the exit transition ends, so an earlier assertion races the very restore under test (my first version passed for that reason).
- `FilterFab.test.tsx` — `elementFromPoint` at the badge's centre, so the assertion is that the count is genuinely on top rather than that a style string is present.

Both fail without their fix. Full frontend suite passes (151 tests); lint, type-check and jscpd (1.0%, threshold 1.1) clean. Verified by hand in the dev server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FFqeXVpUvLgcYmyobDkwvf