### PR TITLE
Bump backend/uv.lock in the release workflow, and guard it in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,11 @@ jobs:
       - name: Setup Python
         run: uv python install 3.12
 
+      # Before uv sync, which would quietly rewrite a stale lock instead of
+      # failing on it.
+      - name: Check uv.lock matches pyproject.toml
+        run: uv lock --check
+
       - name: Install dependencies
         run: uv sync
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -172,9 +172,25 @@ jobs:
           # Update the backend version; anchored so dependency pins stay untouched
           sed -i -E "s|^version = \".*\"|version = \"$NEW_VERSION\"|" backend/pyproject.toml
 
+          # uv.lock records the workspace package's own version too, and sed on
+          # pyproject.toml does not reach it. Scoped to the crossbill-backend
+          # entry so no dependency's version line is touched.
+          node -e '
+            const fs = require("fs");
+            const path = "backend/uv.lock";
+            const entry = /(\[\[package\]\]\nname = "crossbill-backend"\nversion = )"[^"]*"/g;
+            const lock = fs.readFileSync(path, "utf8");
+            const found = lock.match(entry) ?? [];
+            if (found.length !== 1) {
+              throw new Error("expected one crossbill-backend version entry, found " + found.length);
+            }
+            fs.writeFileSync(path, lock.replace(entry, `$1"${process.argv[1]}"`));
+          ' "$NEW_VERSION"
+
           # Commit version bump
           git add package.json package-lock.json frontend/package.json \
-            site/package.json site/package-lock.json backend/pyproject.toml
+            site/package.json site/package-lock.json backend/pyproject.toml \
+            backend/uv.lock
           git commit -m "chore: bump version to $NEW_VERSION"
           git push origin main
 

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -628,7 +628,7 @@ wheels = [
 
 [[package]]
 name = "crossbill-backend"
-version = "0.27.2"
+version = "0.28.1"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
Fixes #689

Every release bumped the version in five places but left `backend/uv.lock`'s own `crossbill-backend` entry stale, so the lock drifted one version behind and the next `uv` command in anyone's working tree silently rewrote it.

## Changes

| File | Change |
|---|---|
| `.github/workflows/release.yml` | Patch the `crossbill-backend` version entry alongside the `pyproject.toml` sed, and add `backend/uv.lock` to the step's `git add` |
| `.github/workflows/ci.yml` | New `uv lock --check` step in the backend job, before `uv sync` |
| `backend/uv.lock` | `0.27.2` → `0.28.1`, the drift already on `main` |

The patch is surgical rather than a `uv lock` run, for the two reasons the issue gives: `uv` is not installed in the `release` job, and a version bump should not re-resolve dependencies as a side effect.

## Deviation from the issue's sketch

The issue sketched the patch as a `python3` heredoc. That can't work in this step: `<<'PY'` needs its terminator at column 0, and a column-0 line ends the YAML block scalar the whole step lives in (`<<-` strips only tabs, not spaces).

This uses `node -e` instead — Node is already set up in the `release` job, and it matches the `package-lock.json` patch three lines above. The issue's `assert n == 1` guard is preserved as a thrown `Error`, which exits non-zero and fails the step. That guard is the part that matters: a silently zero-matching regex is how this bug comes back.

## Verification

- Extracted the real `Bump version` script from the parsed YAML and ran the snippet against a copy of `uv.lock`: exactly one line changed, no dependency version line touched.
- Renamed the package in that copy to force a zero-match: the guard threw and exited 1.
- Both workflow files parse as YAML.
- `uv lock --check` passes on this branch.

## Note for review

`uv lock --check` will now fail CI on any PR that edits `backend/pyproject.toml` dependencies without re-running `uv lock`. That is the intent — it turns a silent drift into a hard stop — but it is a new way for CI to go red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179MV3JB7vBXXfwx57VUbi6