### PR TITLE
Share the compact-viewport test helper

### DIFF
--- a/frontend/src/components/layout/Layouts.tsx
+++ b/frontend/src/components/layout/Layouts.tsx
@@ -8,12 +8,7 @@ import { Container, styled } from '@mui/material';
  */
 export const PAGE_GUTTER = { xs: 2, sm: 3 };
 
-/**
- * What the sticky `AppBar` covers at the top of the viewport — MUI's `Toolbar`,
- * 56px below `sm` and 64px from there up. Anything scrolling a target to the
- * top of the page has to stop this far short of it, or the app bar lands on
- * top of what it just scrolled to.
- */
+/** What the sticky `AppBar` covers at the top of the viewport — MUI's `Toolbar`. */
 export const APP_BAR_HEIGHT = { xs: '56px', sm: '64px' };
 
 /** The bottom navigation's own height, plus air, plus the device's safe area. */

--- a/frontend/src/components/layout/Layouts.tsx
+++ b/frontend/src/components/layout/Layouts.tsx
@@ -8,6 +8,14 @@ import { Container, styled } from '@mui/material';
  */
 export const PAGE_GUTTER = { xs: 2, sm: 3 };
 
+/**
+ * What the sticky `AppBar` covers at the top of the viewport — MUI's `Toolbar`,
+ * 56px below `sm` and 64px from there up. Anything scrolling a target to the
+ * top of the page has to stop this far short of it, or the app bar lands on
+ * top of what it just scrolled to.
+ */
+export const APP_BAR_HEIGHT = { xs: '56px', sm: '64px' };
+
 /** The bottom navigation's own height, plus air, plus the device's safe area. */
 export const BOTTOM_NAV_CLEARANCE = 'calc(56px + 24px + env(safe-area-inset-bottom))';
 

--- a/frontend/src/components/search/GlobalSearch.test.tsx
+++ b/frontend/src/components/search/GlobalSearch.test.tsx
@@ -2,6 +2,7 @@ import { aBookDetails, aChapter, aHighlight } from '@tests/fixtures/book';
 import { aNote } from '@tests/fixtures/notes';
 import { aDigestHit, aHighlightHit, aNoteHit } from '@tests/fixtures/semantic';
 import { renderApp } from '@tests/harness/renderApp';
+import { atCompactViewport } from '@tests/harness/viewport';
 import { settingsWithEmbeddings } from '@tests/msw/auth';
 import { bookApi } from '@tests/msw/bookApi';
 import { coversApi } from '@tests/msw/covers';
@@ -9,7 +10,7 @@ import { semanticSearchApi } from '@tests/msw/semanticSearchApi';
 import { worker } from '@tests/msw/worker';
 import { delay, http, HttpResponse } from 'msw';
 import { expect, test } from 'vitest';
-import { page, userEvent } from 'vitest/browser';
+import { userEvent } from 'vitest/browser';
 
 const PLACEHOLDER = 'Search...';
 
@@ -295,20 +296,6 @@ test('a failing search reports the failure', async () => {
 
   await expect.element(screen.getByText('Search failed. Try again.')).toBeVisible();
 });
-
-/**
- * Runs `fn` with the browser resized below `md`, always restoring the
- * config's 1440×900 default afterward — even if `fn` throws — so a resize
- * from one test can never leak into the next.
- */
-const atCompactViewport = async (fn: () => Promise<void>) => {
-  await page.viewport(400, 800);
-  try {
-    await fn();
-  } finally {
-    await page.viewport(1440, 900);
-  }
-};
 
 /**
  * Renders a book page below `md` with embeddings on, where only the search

--- a/frontend/src/pages/BookPage/BookPage.test.tsx
+++ b/frontend/src/pages/BookPage/BookPage.test.tsx
@@ -2,10 +2,11 @@ import { getGetBookDetailsQueryKey } from '@/api/generated/books/books.ts';
 import { aBookDetails, aChapter, aHighlight } from '@tests/fixtures/book';
 import { aNote } from '@tests/fixtures/notes';
 import { renderApp } from '@tests/harness/renderApp';
+import { atCompactViewport } from '@tests/harness/viewport';
 import { bookApi } from '@tests/msw/bookApi';
 import { worker } from '@tests/msw/worker';
 import { http, HttpResponse } from 'msw';
-import { expect, test } from 'vitest';
+import { expect, test, vi } from 'vitest';
 
 test('renders the book and its chapters', async () => {
   const { handlers } = bookApi({
@@ -296,4 +297,56 @@ test('a tab renders its right rail into the shell, not inside its own content', 
   expect(screen.getByRole('main').getByRole('list', { name: 'Chapters' }).elements()).toHaveLength(
     0
   );
+});
+
+/**
+ * On a phone every tab hangs below the same cover, title and stats strip, so
+ * a tab change used to leave the screen looking untouched — the new tab's
+ * heading rendered below the fold, and only the bottom nav's selected icon
+ * moved. The page now snaps past the book header instead.
+ */
+test('switching tabs on mobile brings the tab heading into view', async () => {
+  worker.use(
+    ...bookApi({
+      book: aBookDetails({
+        chapters: [aChapter({ id: 10, highlights: [aHighlight({ id: 300 })] })],
+      }),
+    }).handlers
+  );
+
+  await atCompactViewport(async () => {
+    const screen = await renderApp({ path: '/book/1/structure' });
+    await expect.element(screen.getByRole('heading', { name: 'Structure' })).toBeVisible();
+    expect(window.scrollY).toBe(0);
+
+    await screen.getByRole('button', { name: 'Highlights' }).click();
+
+    const heading = screen.getByRole('heading', { name: 'Highlights' });
+    await expect.element(heading).toBeVisible();
+    // Polled rather than awaited on a timer: the snap is a smooth scroll, so
+    // the heading travels to the top over several frames.
+    await vi.waitFor(() => {
+      // Clear of the sticky app bar, and near enough to it that the book
+      // header above is off screen.
+      expect(heading.element().getBoundingClientRect().top).toBeGreaterThan(56);
+      expect(heading.element().getBoundingClientRect().top).toBeLessThan(120);
+    });
+  });
+});
+
+/** A book opens at its own top, header and all, rather than at its first tab. */
+test('opening a book on mobile leaves the page at the top', async () => {
+  worker.use(...bookApi({ book: aBookDetails({ title: 'The Pragmatic Reader' }) }).handlers);
+
+  await atCompactViewport(async () => {
+    const screen = await renderApp({ path: '/book/1/structure' });
+    await expect
+      .element(screen.getByRole('heading', { name: 'The Pragmatic Reader' }))
+      .toBeVisible();
+
+    // Settled rather than polled: a snap that fires when it should not would
+    // scroll a frame or two after the page first paints.
+    await new Promise((resolve) => setTimeout(resolve, 400));
+    expect(window.scrollY).toBe(0);
+  });
 });

--- a/frontend/src/pages/BookPage/BookPage.test.tsx
+++ b/frontend/src/pages/BookPage/BookPage.test.tsx
@@ -299,12 +299,7 @@ test('a tab renders its right rail into the shell, not inside its own content', 
   );
 });
 
-/**
- * On a phone every tab hangs below the same cover, title and stats strip, so
- * a tab change used to leave the screen looking untouched — the new tab's
- * heading rendered below the fold, and only the bottom nav's selected icon
- * moved. The page now snaps past the book header instead.
- */
+/** On a phone the book header alone used to fill the screen after a tab change. */
 test('switching tabs on mobile brings the tab heading into view', async () => {
   worker.use(
     ...bookApi({
@@ -323,11 +318,11 @@ test('switching tabs on mobile brings the tab heading into view', async () => {
 
     const heading = screen.getByRole('heading', { name: 'Highlights' });
     await expect.element(heading).toBeVisible();
-    // Polled rather than awaited on a timer: the snap is a smooth scroll, so
-    // the heading travels to the top over several frames.
+    // Polled: the snap is a smooth scroll, so the heading arrives over several
+    // frames.
     await vi.waitFor(() => {
-      // Clear of the sticky 56px app bar with air to spare, and near enough
-      // to it that the book header above is off screen.
+      // Clear of the sticky 56px app bar with air to spare, and high enough
+      // that the book header is off screen.
       expect(heading.element().getBoundingClientRect().top).toBeGreaterThan(72);
       expect(heading.element().getBoundingClientRect().top).toBeLessThan(120);
     });
@@ -344,8 +339,7 @@ test('opening a book on mobile leaves the page at the top', async () => {
       .element(screen.getByRole('heading', { name: 'The Pragmatic Reader' }))
       .toBeVisible();
 
-    // Settled rather than polled: a snap that fires when it should not would
-    // scroll a frame or two after the page first paints.
+    // Settled rather than polled: an unwanted snap lands a frame or two in.
     await new Promise((resolve) => setTimeout(resolve, 400));
     expect(window.scrollY).toBe(0);
   });

--- a/frontend/src/pages/BookPage/BookPage.test.tsx
+++ b/frontend/src/pages/BookPage/BookPage.test.tsx
@@ -326,9 +326,9 @@ test('switching tabs on mobile brings the tab heading into view', async () => {
     // Polled rather than awaited on a timer: the snap is a smooth scroll, so
     // the heading travels to the top over several frames.
     await vi.waitFor(() => {
-      // Clear of the sticky app bar, and near enough to it that the book
-      // header above is off screen.
-      expect(heading.element().getBoundingClientRect().top).toBeGreaterThan(56);
+      // Clear of the sticky 56px app bar with air to spare, and near enough
+      // to it that the book header above is off screen.
+      expect(heading.element().getBoundingClientRect().top).toBeGreaterThan(72);
       expect(heading.element().getBoundingClientRect().top).toBeLessThan(120);
     });
   });

--- a/frontend/src/pages/BookPage/BookPage.tsx
+++ b/frontend/src/pages/BookPage/BookPage.tsx
@@ -19,6 +19,13 @@ import { Alert, Box, useMediaQuery, useTheme } from '@mui/material';
 import { Outlet, useLocation, useParams } from '@tanstack/react-router';
 import { useEffect, useState } from 'react';
 
+/**
+ * The air a snapped-to tab heading keeps between itself and the app bar above
+ * it. Three spacing units: at less than that the heading reads as pinned to
+ * the edge of the screen rather than as the top of the page.
+ */
+const SNAP_AIR = '24px';
+
 export const BookPage = () => {
   const { bookId } = useParams({ strict: false });
   // Keys the tab fade below. Search params are excluded on purpose: filtering
@@ -133,7 +140,7 @@ export const BookPage = () => {
                   the minimum, a short tab cannot scroll past the book header
                   and the reader is back to seeing the cover they tapped from.
                   The scroll margin keeps the tab's heading clear of the sticky
-                  app bar it would otherwise land under. */}
+                  app bar it would otherwise land under, with air to spare. */}
               <Box
                 component="main"
                 ref={tabContentRef}
@@ -143,8 +150,8 @@ export const BookPage = () => {
                     sm: `calc(100dvh - ${APP_BAR_HEIGHT.sm} - ${BOTTOM_NAV_CLEARANCE})`,
                   },
                   scrollMarginTop: {
-                    xs: `calc(${APP_BAR_HEIGHT.xs} + 8px)`,
-                    sm: `calc(${APP_BAR_HEIGHT.sm} + 8px)`,
+                    xs: `calc(${APP_BAR_HEIGHT.xs} + ${SNAP_AIR})`,
+                    sm: `calc(${APP_BAR_HEIGHT.sm} + ${SNAP_AIR})`,
                   },
                 }}
               >

--- a/frontend/src/pages/BookPage/BookPage.tsx
+++ b/frontend/src/pages/BookPage/BookPage.tsx
@@ -19,11 +19,7 @@ import { Alert, Box, useMediaQuery, useTheme } from '@mui/material';
 import { Outlet, useLocation, useParams } from '@tanstack/react-router';
 import { useEffect, useState } from 'react';
 
-/**
- * The air a snapped-to tab heading keeps between itself and the app bar above
- * it. Three spacing units: at less than that the heading reads as pinned to
- * the edge of the screen rather than as the top of the page.
- */
+/** Air between a snapped-to tab heading and the app bar above it. */
 const SNAP_AIR = '24px';
 
 export const BookPage = () => {
@@ -135,12 +131,8 @@ export const BookPage = () => {
           ) : (
             <Box sx={{ maxWidth: '800px', mx: 'auto' }}>
               <BookTitle book={book} />
-              {/* Tall enough to fill the viewport on its own, so switching to a
-                  tab with little in it still has somewhere to snap to: without
-                  the minimum, a short tab cannot scroll past the book header
-                  and the reader is back to seeing the cover they tapped from.
-                  The scroll margin keeps the tab's heading clear of the sticky
-                  app bar it would otherwise land under, with air to spare. */}
+              {/* Tall enough to fill the viewport, so a tab with little in it
+                  still has somewhere to snap to. */}
               <Box
                 component="main"
                 ref={tabContentRef}

--- a/frontend/src/pages/BookPage/BookPage.tsx
+++ b/frontend/src/pages/BookPage/BookPage.tsx
@@ -3,6 +3,7 @@ import { FadeInOut } from '@/components/animations/FadeInOut.tsx';
 import { Spinner } from '@/components/animations/Spinner.tsx';
 import { ScrollToTopButton } from '@/components/buttons/ScrollToTopButton.tsx';
 import {
+  APP_BAR_HEIGHT,
   BOTTOM_NAV_CLEARANCE,
   PageContainer,
   SNACKBAR_CLEARANCE,
@@ -13,6 +14,7 @@ import { BookPageProvider } from '@/pages/BookPage/BookPageContext.tsx';
 import { BookTitle } from '@/pages/BookPage/BookTitle/BookTitle.tsx';
 import { DesktopNavLinks } from '@/pages/BookPage/navigation/DesktopNavLinks.tsx';
 import { MobileBottomNav } from '@/pages/BookPage/navigation/MobileBottomNav.tsx';
+import { useTabContentSnap } from '@/pages/BookPage/navigation/useTabContentSnap.ts';
 import { Alert, Box, useMediaQuery, useTheme } from '@mui/material';
 import { Outlet, useLocation, useParams } from '@tanstack/react-router';
 import { useEffect, useState } from 'react';
@@ -32,6 +34,8 @@ export const BookPage = () => {
   const [leftSidebarEl, setLeftSidebarEl] = useState<HTMLDivElement | null>(null);
   const [rightSidebarEl, setRightSidebarEl] = useState<HTMLDivElement | null>(null);
   const [fabContainerEl, setFabContainerEl] = useState<HTMLDivElement | null>(null);
+
+  const tabContentRef = useTabContentSnap({ enabled: !isDesktop, bookId, pathname });
 
   // Update recently viewed on mount. `cache` is memoised on the query client, so
   // listing it as a dependency does not make this run more than once.
@@ -124,7 +128,26 @@ export const BookPage = () => {
           ) : (
             <Box sx={{ maxWidth: '800px', mx: 'auto' }}>
               <BookTitle book={book} />
-              <Box component="main">
+              {/* Tall enough to fill the viewport on its own, so switching to a
+                  tab with little in it still has somewhere to snap to: without
+                  the minimum, a short tab cannot scroll past the book header
+                  and the reader is back to seeing the cover they tapped from.
+                  The scroll margin keeps the tab's heading clear of the sticky
+                  app bar it would otherwise land under. */}
+              <Box
+                component="main"
+                ref={tabContentRef}
+                sx={{
+                  minHeight: {
+                    xs: `calc(100dvh - ${APP_BAR_HEIGHT.xs} - ${BOTTOM_NAV_CLEARANCE})`,
+                    sm: `calc(100dvh - ${APP_BAR_HEIGHT.sm} - ${BOTTOM_NAV_CLEARANCE})`,
+                  },
+                  scrollMarginTop: {
+                    xs: `calc(${APP_BAR_HEIGHT.xs} + 8px)`,
+                    sm: `calc(${APP_BAR_HEIGHT.sm} + 8px)`,
+                  },
+                }}
+              >
                 <FadeInOut ekey={pathname} animateOnMount={false}>
                   <Outlet />
                 </FadeInOut>

--- a/frontend/src/pages/BookPage/navigation/useTabContentSnap.ts
+++ b/frontend/src/pages/BookPage/navigation/useTabContentSnap.ts
@@ -1,0 +1,58 @@
+import { useReducedMotion } from 'motion/react';
+import { useEffect, useRef } from 'react';
+
+interface TabContentSnapOptions {
+  /**
+   * False on desktop, where the nav sits beside the tab rather than above it
+   * and the tab that answered a click is already on screen.
+   */
+  enabled: boolean;
+  bookId: string | undefined;
+  /**
+   * The path alone. Search params are excluded on purpose: filtering or
+   * searching within a tab must not move the page under the reader.
+   */
+  pathname: string;
+}
+
+/**
+ * Scrolls a book tab's own content up to the top of the viewport when the
+ * reader switches tabs, and hands back the ref to put on that content.
+ *
+ * On mobile every tab hangs below the same tall book header — cover, title,
+ * blurb, stats — so tapping a different tab from the top of the page changed
+ * nothing the reader could see: the new tab's heading was still below the
+ * fold, and only the bottom nav's selected icon had moved. Snapping past the
+ * header puts that heading right under the app bar, so the tab they asked for
+ * is the first thing on screen.
+ */
+export const useTabContentSnap = ({ enabled, bookId, pathname }: TabContentSnapOptions) => {
+  const contentRef = useRef<HTMLElement | null>(null);
+  const previous = useRef({ bookId, pathname });
+  const prefersReducedMotion = useReducedMotion();
+
+  useEffect(() => {
+    const { bookId: previousBookId, pathname: previousPathname } = previous.current;
+    previous.current = { bookId, pathname };
+
+    // A tab change within one book, and nothing else: opening a book, or
+    // moving to another one, should leave the reader at that book's own top.
+    if (!enabled || pathname === previousPathname || bookId !== previousBookId) return;
+
+    const content = contentRef.current;
+    if (!content) return;
+
+    // A frame late on purpose. The router's scroll restoration runs on this
+    // same navigation, and whichever of the two scrolls last is the one the
+    // reader sees.
+    const frame = requestAnimationFrame(() => {
+      content.scrollIntoView({
+        behavior: prefersReducedMotion ? 'auto' : 'smooth',
+        block: 'start',
+      });
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [enabled, bookId, pathname, prefersReducedMotion]);
+
+  return contentRef;
+};

--- a/frontend/src/pages/BookPage/navigation/useTabContentSnap.ts
+++ b/frontend/src/pages/BookPage/navigation/useTabContentSnap.ts
@@ -2,29 +2,19 @@ import { useReducedMotion } from 'motion/react';
 import { useEffect, useRef } from 'react';
 
 interface TabContentSnapOptions {
-  /**
-   * False on desktop, where the nav sits beside the tab rather than above it
-   * and the tab that answered a click is already on screen.
-   */
+  /** False on desktop, where the nav sits beside the tab and nothing is hidden. */
   enabled: boolean;
   bookId: string | undefined;
-  /**
-   * The path alone. Search params are excluded on purpose: filtering or
-   * searching within a tab must not move the page under the reader.
-   */
+  /** The path alone: filtering within a tab must not move the page. */
   pathname: string;
 }
 
 /**
- * Scrolls a book tab's own content up to the top of the viewport when the
- * reader switches tabs, and hands back the ref to put on that content.
+ * Scrolls a book tab's content to the top of the viewport when the reader
+ * switches tabs, and returns the ref to put on that content.
  *
- * On mobile every tab hangs below the same tall book header — cover, title,
- * blurb, stats — so tapping a different tab from the top of the page changed
- * nothing the reader could see: the new tab's heading was still below the
- * fold, and only the bottom nav's selected icon had moved. Snapping past the
- * header puts that heading right under the app bar, so the tab they asked for
- * is the first thing on screen.
+ * On mobile every tab hangs below the same tall book header, so tapping a
+ * different tab from the top of the page left the screen looking untouched.
  */
 export const useTabContentSnap = ({ enabled, bookId, pathname }: TabContentSnapOptions) => {
   const contentRef = useRef<HTMLElement | null>(null);
@@ -35,16 +25,14 @@ export const useTabContentSnap = ({ enabled, bookId, pathname }: TabContentSnapO
     const { bookId: previousBookId, pathname: previousPathname } = previous.current;
     previous.current = { bookId, pathname };
 
-    // A tab change within one book, and nothing else: opening a book, or
-    // moving to another one, should leave the reader at that book's own top.
+    // Opening a book, or moving to another one, starts at that book's own top.
     if (!enabled || pathname === previousPathname || bookId !== previousBookId) return;
 
     const content = contentRef.current;
     if (!content) return;
 
-    // A frame late on purpose. The router's scroll restoration runs on this
-    // same navigation, and whichever of the two scrolls last is the one the
-    // reader sees.
+    // A frame late: the router's scroll restoration runs on this same
+    // navigation, and the later scroll is the one that sticks.
     const frame = requestAnimationFrame(() => {
       content.scrollIntoView({
         behavior: prefersReducedMotion ? 'auto' : 'smooth',

--- a/frontend/tests/harness/viewport.ts
+++ b/frontend/tests/harness/viewport.ts
@@ -1,11 +1,8 @@
 import { page } from 'vitest/browser';
 
 /**
- * Runs `fn` with the browser resized to a phone, below `md` — where the book
- * page swaps its sidebars for a bottom nav and the app bar swaps its search
- * field for an icon. The config's 1440×900 default is always restored
- * afterward, even if `fn` throws, so a resize from one test can never leak
- * into the next.
+ * Runs `fn` with the browser resized to a phone, always restoring the config's
+ * 1440×900 default afterward so a resize cannot leak into the next test.
  */
 export const atCompactViewport = async (fn: () => Promise<void>) => {
   await page.viewport(400, 800);

--- a/frontend/tests/harness/viewport.ts
+++ b/frontend/tests/harness/viewport.ts
@@ -1,0 +1,17 @@
+import { page } from 'vitest/browser';
+
+/**
+ * Runs `fn` with the browser resized to a phone, below `md` — where the book
+ * page swaps its sidebars for a bottom nav and the app bar swaps its search
+ * field for an icon. The config's 1440×900 default is always restored
+ * afterward, even if `fn` throws, so a resize from one test can never leak
+ * into the next.
+ */
+export const atCompactViewport = async (fn: () => Promise<void>) => {
+  await page.viewport(400, 800);
+  try {
+    await fn();
+  } finally {
+    await page.viewport(1440, 900);
+  }
+};


### PR DESCRIPTION
GlobalSearch's local `atCompactViewport` is the only way a test can drive
the phone layout, and the book page needs it too. Move it to the harness
so a resize is always paired with the restore that keeps it from leaking
into the next test.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01JGJx9ipSHZGMNfVh48k9n4