### PR TITLE
Give the search results room to breathe

### DIFF
--- a/frontend/src/components/search/GlobalSearch.tsx
+++ b/frontend/src/components/search/GlobalSearch.tsx
@@ -1,4 +1,5 @@
 import { EmbeddingFeature } from '@/components/features/EmbeddingFeature.tsx';
+import { GLOBAL_SEARCH_INSET_X } from '@/components/search/globalSearchLayout.ts';
 import { GlobalSearchResults } from '@/components/search/GlobalSearchResults.tsx';
 import {
   globalSearchRowDomId,
@@ -164,7 +165,7 @@ export const GlobalSearch = () => {
             // Reopens the dropdown when the field regains focus with a query
             // already in it, e.g. tapping the icon again after a prior visit.
             onFocus={() => setIsDismissed(false)}
-            sx={{ p: 2, display: 'flex', alignItems: 'center', gap: 1 }}
+            sx={{ px: GLOBAL_SEARCH_INSET_X, py: 2, display: 'flex', alignItems: 'center', gap: 1 }}
           >
             <Box sx={{ flex: 1 }}>
               <SemanticSearchField

--- a/frontend/src/components/search/GlobalSearchResultRow.tsx
+++ b/frontend/src/components/search/GlobalSearchResultRow.tsx
@@ -1,5 +1,6 @@
 import { BookCover } from '@/components/BookCover.tsx';
 import { MetadataRow } from '@/components/cards/MetadataRow.tsx';
+import { GLOBAL_SEARCH_INSET_X } from '@/components/search/globalSearchLayout.ts';
 import {
   globalSearchRowDomId,
   rowLinkProps,
@@ -35,7 +36,7 @@ export const GlobalSearchResultRow = ({ row, isActive, onSelect }: GlobalSearchR
     aria-selected={isActive}
     selected={isActive}
     onClick={onSelect}
-    sx={{ alignItems: 'center', gap: 1.5, py: 1.5, display: 'flex' }}
+    sx={{ alignItems: 'center', gap: 2, px: GLOBAL_SEARCH_INSET_X, py: 2, display: 'flex' }}
   >
     <BookCover
       coverFile={row.coverFile}
@@ -46,7 +47,7 @@ export const GlobalSearchResultRow = ({ row, isActive, onSelect }: GlobalSearchR
       objectFit="cover"
       sx={{ borderRadius: 0.5, flexShrink: 0 }}
     />
-    <Stack sx={{ minWidth: 0 }} spacing={0.25}>
+    <Stack sx={{ minWidth: 0 }} spacing={0.75}>
       {row.title && (
         <Typography variant="subtitle2" noWrap>
           {row.title}

--- a/frontend/src/components/search/GlobalSearchResults.tsx
+++ b/frontend/src/components/search/GlobalSearchResults.tsx
@@ -1,4 +1,5 @@
 import { EmptyStateText } from '@/components/EmptyStateText.tsx';
+import { GLOBAL_SEARCH_INSET_X } from '@/components/search/globalSearchLayout.ts';
 import { GlobalSearchResultRow } from '@/components/search/GlobalSearchResultRow.tsx';
 import {
   MAX_GLOBAL_SEARCH_ROWS,
@@ -33,7 +34,7 @@ export const GlobalSearchResults = ({
 }: GlobalSearchResultsProps) => {
   if (isError) {
     return (
-      <Box sx={{ p: 2 }}>
+      <Box sx={{ px: GLOBAL_SEARCH_INSET_X, py: 2.5 }}>
         <Typography variant="body2" color="error">
           Search failed. Try again.
         </Typography>
@@ -43,7 +44,7 @@ export const GlobalSearchResults = ({
 
   if (isFetching && rows.length === 0) {
     return (
-      <Box sx={{ display: 'flex', justifyContent: 'center', p: 3 }}>
+      <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
         <CircularProgress size={24} aria-label="Searching" />
       </Box>
     );
@@ -51,7 +52,7 @@ export const GlobalSearchResults = ({
 
   if (rows.length === 0) {
     return (
-      <Box sx={{ p: 2 }}>
+      <Box sx={{ px: GLOBAL_SEARCH_INSET_X, py: 2.5 }}>
         <EmptyStateText>No matches</EmptyStateText>
       </Box>
     );
@@ -72,7 +73,11 @@ export const GlobalSearchResults = ({
         ))}
       </List>
       {rows.length === MAX_GLOBAL_SEARCH_ROWS && (
-        <Typography variant="caption" color="text.secondary" sx={{ display: 'block', p: 1.5 }}>
+        <Typography
+          variant="caption"
+          color="text.secondary"
+          sx={{ display: 'block', px: GLOBAL_SEARCH_INSET_X, py: 2 }}
+        >
           Showing top {MAX_GLOBAL_SEARCH_ROWS}
         </Typography>
       )}

--- a/frontend/src/components/search/globalSearchLayout.ts
+++ b/frontend/src/components/search/globalSearchLayout.ts
@@ -1,0 +1,6 @@
+/**
+ * Horizontal inset shared by the rows and by the states that replace them, so
+ * "No matches" and a row's text start on the same edge. Narrower on a phone,
+ * where the dropdown fills the screen and 24px each side costs real width.
+ */
+export const GLOBAL_SEARCH_INSET_X = { xs: 2, md: 3 };


### PR DESCRIPTION
Fixes #716

The global search dropdown was cramped: rows sat 16px from the panel edge and the three lines inside a row were 2px apart, so a result read as one dense block.

- Row padding: `py: 1.5` → `py: 2`, and a horizontal inset where there was none beyond MUI's default (24px on desktop, 16px on a phone, where the dialog fills the screen).
- Inside a row: `spacing 0.25` → `0.75` between title, chip line, and text; cover-to-text gap `1.5` → `2`.
- The error, empty, and "Showing top 10" states share the row inset through `GLOBAL_SEARCH_INSET_X`, so "No matches" starts on the same edge as a result's text.

Verified in headless Chromium at 1440px and at 400px. Full frontend suite passes (192 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013dt98wnbYUTQwxBHsaid4s