### PR TITLE
Commit every search field on Enter, never while typing

### DIFF
--- a/frontend/src/components/inputs/SearchBar.tsx
+++ b/frontend/src/components/inputs/SearchBar.tsx
@@ -1,19 +1,16 @@
 import { useResetOnChange } from '@/hooks/useResetOnChange.ts';
 import { CloseIcon } from '@/theme/Icons.tsx';
 import { Box, IconButton, TextField, type SxProps, type Theme } from '@mui/material';
-import { debounce } from 'lodash';
-import { useEffect, useMemo, useState } from 'react';
+import { useState } from 'react';
 
 interface SearchBarProps {
+  /**
+   * Called with the committed query — on Enter, on blur, and on a clear.
+   * Never per keystroke, so it may run an expensive search.
+   */
   onSearch: (searchText: string) => void;
   placeholder?: string;
   initialValue?: string;
-  /**
-   * `change` searches while typing, debounced — right for filtering data the
-   * page already has. `submit` waits for Enter or blur, so an expensive search
-   * runs once per finished query rather than once per keystroke.
-   */
-  commitOn?: 'change' | 'submit';
   /** Applied to the TextField, for callers on a non-default background. */
   sx?: SxProps<Theme>;
   /** Off by default: only a caller that owns the field's only focus target (e.g. a just-opened dialog) should set this. */
@@ -23,51 +20,29 @@ interface SearchBarProps {
   slotProps?: { htmlInput?: React.InputHTMLAttributes<HTMLInputElement> };
 }
 
+/**
+ * The one search field in the app. Every search box commits the same way —
+ * Enter or blur — whatever engine sits behind it, so two tabs apart cannot
+ * behave differently. Typing changes nothing until the query is finished.
+ */
 export const SearchBar = ({
   onSearch,
   placeholder = 'Search...',
   initialValue = '',
-  commitOn = 'change',
   sx,
   autoFocus = false,
   slotProps,
 }: SearchBarProps) => {
   const [searchInput, setSearchInput] = useState(initialValue);
 
-  const debouncedSearch = useMemo(
-    () =>
-      debounce((value: string) => {
-        onSearch(value);
-      }, 300),
-    [onSearch]
-  );
-
   // Update search input when initialValue changes (e.g., browser back/forward)
   useResetOnChange([initialValue], () => setSearchInput(initialValue));
 
-  // Cleanup on unmount
-  useEffect(() => {
-    return () => {
-      debouncedSearch.cancel();
-    };
-  }, [debouncedSearch]);
-
-  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const value = event.target.value;
-    setSearchInput(value);
-    if (commitOn === 'change') {
-      debouncedSearch(value);
-    }
-  };
-
   const handleCommit = () => {
-    if (commitOn === 'submit') {
-      onSearch(searchInput);
-    }
+    onSearch(searchInput);
   };
 
   const handleClear = () => {
-    debouncedSearch.cancel();
     setSearchInput('');
     onSearch('');
   };
@@ -79,7 +54,7 @@ export const SearchBar = ({
         autoFocus={autoFocus}
         placeholder={placeholder}
         value={searchInput}
-        onChange={handleChange}
+        onChange={(event) => setSearchInput(event.target.value)}
         sx={sx}
         onBlur={handleCommit}
         onKeyDown={(e) => {

--- a/frontend/src/components/search/SemanticSearchField.tsx
+++ b/frontend/src/components/search/SemanticSearchField.tsx
@@ -17,9 +17,9 @@ interface SemanticSearchFieldProps {
 }
 
 /**
- * Natural-language search box, hidden when embeddings are off. The query is
- * submitted on Enter or blur, never per keystroke: each search is an embedding
- * call, so half-typed queries are not worth running.
+ * Natural-language search box, hidden when embeddings are off. Commit timing is
+ * `SearchBar`'s, shared with every other search field: Enter or blur, never per
+ * keystroke — which also keeps half-typed queries out of the embedding calls.
  *
  * Deliberately dumb: it renders the input and knows
  * nothing about results. Callers pair it with `useSemanticSearch` and decide
@@ -39,7 +39,6 @@ export const SemanticSearchField = ({
         onSearch={onChange}
         placeholder={placeholder}
         initialValue={value}
-        commitOn="submit"
         sx={sx}
         autoFocus={autoFocus}
         slotProps={slotProps}

--- a/frontend/src/pages/LibraryPage/LibraryPage.test.tsx
+++ b/frontend/src/pages/LibraryPage/LibraryPage.test.tsx
@@ -2,7 +2,9 @@ import { aBookCard } from '@tests/fixtures/book';
 import { renderApp } from '@tests/harness/renderApp';
 import { libraryApi } from '@tests/msw/libraryApi';
 import { worker } from '@tests/msw/worker';
+import { http, HttpResponse } from 'msw';
 import { expect, test } from 'vitest';
+import { userEvent } from 'vitest/browser';
 
 test('a book card shows what the reader has made of the book', async () => {
   worker.use(
@@ -66,5 +68,32 @@ test('a link to the old all-books page still finds the books it searched for', a
 
   await expect.element(screen.getByText('The Pragmatic Reader')).toBeVisible();
   expect(window.location.pathname).toBe('/library');
+  expect(window.location.search).toContain('search=pragmatic');
+});
+
+test('the search runs on Enter, not while the query is still being typed', async () => {
+  worker.use(
+    http.get('/api/v1/books/', ({ request }) => {
+      const query = new URL(request.url).searchParams.get('search');
+      const books = [aBookCard({ title: query ? 'The Pragmatic Reader' : 'Every Book' })];
+      return HttpResponse.json({ items: books, total: books.length, offset: 0, limit: 32 });
+    }),
+    ...libraryApi([])
+  );
+
+  const screen = await renderApp({ path: '/library' });
+  await expect.element(screen.getByText('Every Book')).toBeVisible();
+
+  await userEvent.fill(screen.getByPlaceholder('Search books by title or author...'), 'pragmatic');
+
+  // Longer than the debounce this field used to carry: a half-typed query now
+  // stays in the box however long the reader pauses.
+  await new Promise((resolve) => setTimeout(resolve, 500));
+  expect(window.location.search).not.toContain('search=');
+  await expect.element(screen.getByText('Every Book')).toBeVisible();
+
+  await userEvent.keyboard('{Enter}');
+
+  await expect.element(screen.getByText('The Pragmatic Reader')).toBeVisible();
   expect(window.location.search).toContain('search=pragmatic');
 });


### PR DESCRIPTION
The library, highlights and flashcards boxes searched as the reader
typed, on a 300 ms debounce, while the notes, structure and app-bar
boxes waited for Enter or blur. Two identical-looking fields one tab
apart behaved differently.

`SearchBar` now has one commit rule for every caller — Enter, blur, or a
clear — so the `commitOn` prop and the debounce it needed are gone.
Clearing (Escape or the × button) still applies at once: emptying a query
is not a query.

Part of #668, which also asks how the engines themselves should be
unified or marked; that half is untouched here.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Dy5EFbVyVp996FaDU3eyB5