### PR TITLE
Show empty state instead of hiding sections for new readers

### DIFF
--- a/frontend/src/components/reading/ReadingActivityGrid.tsx
+++ b/frontend/src/components/reading/ReadingActivityGrid.tsx
@@ -17,13 +17,23 @@ export interface ActivityGridData {
 }
 
 interface ReadingActivityGridProps {
-  activity: ActivityGridData;
+  /**
+   * The reading to draw, or `null` for the blank year a reader with nothing
+   * read yet is shown -- an empty grid says what no grid at all cannot.
+   */
+  activity: ActivityGridData | null;
   /** What else there is to say about a day, appended to its label. */
   dayNote?: (isoDate: string) => string | undefined;
   blockSize?: number;
 }
 
+/** The window a grid spans, and whichever of its days are worth colouring. */
+type ActivityWindow = Pick<ActivityGridData, 'range_start' | 'range_end' | 'days'>;
+
 const DEFAULT_BLOCK_SIZE = 12;
+
+/** Days a grid spans, the last one included -- the window the backend draws. */
+const WINDOW_DAYS = 365;
 
 /** The gap between two squares, as a share of the square itself. */
 const MARGIN_RATIO = 1 / 3;
@@ -39,7 +49,7 @@ const UNIT_NOUN = { pages: 'page', minutes: 'minute' } as const;
  * The backend sends only the days worth drawing, so the window's own bounds go
  * in as empty days; the library fills every gap between its first and last.
  */
-const withWindowBounds = (activity: ActivityGridData): Activity[] => {
+const withWindowBounds = (activity: ActivityWindow): Activity[] => {
   const byDate = new Map<string, Activity>(
     activity.days.map((day) => [day.date, { date: day.date, count: day.value, level: day.level }])
   );
@@ -52,6 +62,15 @@ const withWindowBounds = (activity: ActivityGridData): Activity[] => {
 
   return [...byDate.values()].sort((a, b) => a.date.localeCompare(b.date));
 };
+
+/** The year ending today, with no day coloured on it. */
+const emptyYear = (): ActivityWindow => ({
+  range_start: DateTime.now()
+    .minus({ days: WINDOW_DAYS - 1 })
+    .toFormat('yyyy-MM-dd'),
+  range_end: DateTime.now().toFormat('yyyy-MM-dd'),
+  days: [],
+});
 
 /**
  * `getStartOfWeek` counts 1-7 from Monday against the calendar's 0-6 from
@@ -72,7 +91,11 @@ const useCalendarLocale = () =>
  * Labels the square and fills its tooltip both, since a phone has no pointer to
  * hover with and the label is its only way to the number.
  */
-const dayLabel = (activity: ActivityGridData, day: Activity, note?: string) => {
+const dayLabel = (activity: ActivityGridData | null, day: Activity, note?: string) => {
+  if (!activity) {
+    return `Nothing read on ${formatDate(day.date)}`;
+  }
+
   const reading = `${countLabel(day.count, UNIT_NOUN[activity.unit])} on ${formatDate(day.date)}`;
   return note ? `${reading} — ${note}` : reading;
 };
@@ -92,7 +115,9 @@ export const ReadingActivityGrid = ({
 }: ReadingActivityGridProps) => {
   const theme = useTheme();
   const { locale, months, weekStart } = useCalendarLocale();
-  const data = useMemo(() => withWindowBounds(activity), [activity]);
+  // A reader with nothing read still gets a year of squares, all uncoloured.
+  const span = useMemo(() => activity ?? emptyYear(), [activity]);
+  const data = useMemo(() => withWindowBounds(span), [span]);
   const section = useRef<HTMLDivElement>(null);
 
   // Opened on the most recent weeks. Reached by class because the component
@@ -110,6 +135,8 @@ export const ReadingActivityGrid = ({
 
   const asMonth = (date: string) =>
     DateTime.fromISO(date).setLocale(locale).toLocaleString({ month: 'short', year: 'numeric' });
+
+  const period = `${asMonth(span.range_start)} – ${asMonth(span.range_end)}`;
 
   return (
     <Box
@@ -134,10 +161,14 @@ export const ReadingActivityGrid = ({
         }}
         blockSize={blockSize}
         blockMargin={Math.round(blockSize * MARGIN_RATIO)}
+        // A scale from less to more explains nothing on a grid with neither.
+        showColorLegend={activity !== null}
         labels={{
           months,
           legend: { less: 'Less', more: 'More' },
-          totalCount: `${asMonth(activity.range_start)} – ${asMonth(activity.range_end)} · ${activity.unit} read`,
+          totalCount: activity
+            ? `${period} · ${activity.unit} read`
+            : `${period} · nothing read yet`,
         }}
         renderBlock={(block, day) =>
           cloneElement(block, {

--- a/frontend/src/pages/BookPage/ReadingStatistics/ReadingStatisticsPage.test.tsx
+++ b/frontend/src/pages/BookPage/ReadingStatistics/ReadingStatisticsPage.test.tsx
@@ -88,13 +88,21 @@ test('the tab summarises the reading above the list', async () => {
   await expect.element(screen.getByText('Last read', { exact: true })).toBeVisible();
 });
 
-test('the summary stays away until the book has been read', async () => {
+test('a book nobody has opened summarises itself at zero', async () => {
   const screen = await renderStatisticsTab({ sessions: [] });
 
   await expect.element(screen.getByText('No reading sessions recorded yet.')).toBeVisible();
-  // The list keeps its own heading; only the summary above it stands down.
-  await expect.element(screen.getByRole('heading', { name: 'Sessions' })).toBeVisible();
-  expect(screen.getByText('Time read').elements()).toHaveLength(0);
+  // Zeroes rather than a missing summary: a section that disappears reads as
+  // a page that failed to load.
+  await expect.element(screen.getByText('Time read')).toBeVisible();
+  await expect.element(screen.getByText('0m')).toBeVisible();
+  await expect.element(screen.getByText('Sessions').first()).toBeVisible();
+  await expect
+    .element(screen.getByRole('progressbar', { name: 'Reading progress' }))
+    .toHaveAttribute('aria-valuenow', '0');
+  // Nothing was measured, so nothing is claimed about what a session is like.
+  expect(screen.getByText('Average session').elements()).toHaveLength(0);
+  expect(screen.getByText('Reading span').elements()).toHaveLength(0);
 });
 
 test('a book with no recorded position summarises the sessions without a progress bar', async () => {
@@ -158,13 +166,16 @@ test('a book synced without page numbers has its grid measured in minutes', asyn
   await expect.element(screen.getByText(/· minutes read$/)).toBeVisible();
 });
 
-test('a book with nothing to plot draws no grid', async () => {
+test('a book with nothing to plot draws the year empty', async () => {
   const screen = await renderStatisticsTab({ sessions: [] });
 
-  // The grid stands down with the rest of the summary rather than reporting
-  // an absence of its own.
-  await expect.element(screen.getByText('No reading sessions recorded yet.')).toBeVisible();
-  expect(screen.getByRole('img', { name: / on / }).elements()).toHaveLength(0);
+  await expect
+    .element(screen.getByRole('img', { name: /^Nothing read on / }).first())
+    .toBeVisible();
+  expect(screen.getByRole('img', { name: /^Nothing read on / }).elements()).toHaveLength(365);
+  // Nothing was read, so there is no scale from less to more to explain.
+  await expect.element(screen.getByText(/· nothing read yet$/)).toBeVisible();
+  expect(screen.getByText('Less').elements()).toHaveLength(0);
 });
 
 test('a failed statistics request leaves the grid off the page entirely', async () => {
@@ -176,4 +187,5 @@ test('a failed statistics request leaves the grid off the page entirely', async 
     .element(screen.getByRole('alert').filter({ hasText: 'Failed to load reading statistics.' }))
     .toBeVisible();
   expect(screen.getByRole('img', { name: / on / }).elements()).toHaveLength(0);
+  expect(screen.getByRole('img', { name: /^Nothing read on / }).elements()).toHaveLength(0);
 });

--- a/frontend/src/pages/BookPage/ReadingStatistics/ReadingStatsSection.tsx
+++ b/frontend/src/pages/BookPage/ReadingStatistics/ReadingStatsSection.tsx
@@ -56,6 +56,12 @@ const StatsGrid = ({ stats }: StatsGridProps) => (
   </Box>
 );
 
+/**
+ * What a book's reading adds up to: how far through it the reader is, the
+ * numbers, and the year of squares. Drawn for a book nobody has opened too,
+ * with zeroes and an empty grid -- the sessions list below says the same in
+ * words, and a summary that disappears reads as a page that failed to load.
+ */
 export const ReadingStatsSection = ({ bookId }: ReadingStatsSectionProps) => {
   const { data, isError } = useGetBookStatistics(bookId, { tz: browserTimeZone() });
   const { showSnackbar } = useSnackbar();
@@ -68,11 +74,13 @@ export const ReadingStatsSection = ({ bookId }: ReadingStatsSectionProps) => {
     }
   }, [isError, showSnackbar]);
 
-  if (!data || data.session_count === 0) {
+  if (!data) {
     return null;
   }
 
-  const progress = data.progress_percent;
+  // A book with no session behind it is at the start of it rather than at an
+  // unknown place, so the bar reads 0% instead of going missing.
+  const progress = data.progress_percent ?? (data.session_count === 0 ? 0 : null);
 
   const stats: StatProps[] = [
     { value: formatSeconds(data.total_reading_seconds), label: 'Time read' },
@@ -93,12 +101,11 @@ export const ReadingStatsSection = ({ bookId }: ReadingStatsSectionProps) => {
       {progress != null && <ReadingProgress percent={progress} />}
       <StatsGrid stats={stats} />
       {/* The grid is more of the same summary, not a section of its own, so it
-          sits under the numbers rather than beside them with a heading. */}
-      {data.activity && (
-        <Box sx={{ mt: 4 }}>
-          <ReadingActivityGrid activity={data.activity} />
-        </Box>
-      )}
+          sits under the numbers rather than beside them with a heading. A book
+          with nothing read yet gets the year empty rather than not at all. */}
+      <Box sx={{ mt: 4 }}>
+        <ReadingActivityGrid activity={data.activity ?? null} />
+      </Box>
     </Box>
   );
 };

--- a/frontend/src/pages/LandingPage/LandingPage.test.tsx
+++ b/frontend/src/pages/LandingPage/LandingPage.test.tsx
@@ -83,16 +83,28 @@ test('the numbers beside the grid say what the year adds up to', async () => {
   await expect.element(screen.getByText('42')).toBeVisible();
 });
 
-test('a reader with nothing on the grid is shown no grid', async () => {
+test('a reader with nothing on the grid is shown the year empty', async () => {
   worker.use(...libraryApi([], [aBookCard({ title: 'Emma' })]));
 
   const screen = await renderApp({ path: '/' });
 
-  // Polled rather than read once: the section is on screen with its spinner
-  // until the request answers, and only then takes itself off.
-  await expect
-    .element(screen.getByRole('heading', { name: 'Reading activity' }))
-    .not.toBeInTheDocument();
+  await expect.element(screen.getByText(/^No reading recorded yet\./)).toBeVisible();
+
+  // A year of uncoloured squares rather than no grid: the section says what
+  // will fill it instead of leaving a heading out of the dashboard.
+  expect(screen.getByRole('img', { name: /^Nothing read on / }).elements()).toHaveLength(365);
+});
+
+test('an empty grid counts nothing beside it', async () => {
+  worker.use(...libraryApi([], [aBookCard({ title: 'Emma' })]));
+
+  const screen = await renderApp({ path: '/' });
+
+  await expect.element(screen.getByRole('heading', { name: 'Reading activity' })).toBeVisible();
+  // The numbers wait until there is something to count; a row of zeroes is
+  // not what a new reader should meet first.
+  expect(screen.getByText('Days read').elements()).toHaveLength(0);
+  expect(screen.getByText('Current streak').elements()).toHaveLength(0);
 });
 
 test('the capture feed cuts the newest highlights and notes into days', async () => {
@@ -169,12 +181,26 @@ test("a note's body is read as the markdown it is", async () => {
   expect(emphasised.element().tagName).toBe('STRONG');
 });
 
-test('a reader who has captured nothing is shown no feed', async () => {
+test('a reader who has captured nothing is told what will fill the feed', async () => {
   worker.use(...aFeedOf([]));
 
   const screen = await renderApp({ path: '/' });
 
   await expect
     .element(screen.getByRole('heading', { name: 'Recent highlights and notes' }))
-    .not.toBeInTheDocument();
+    .toBeVisible();
+  await expect.element(screen.getByText(/^No highlights or notes yet\./)).toBeVisible();
+});
+
+test('a first-time reader gets every section, each saying what will fill it', async () => {
+  worker.use(...libraryApi([], []));
+
+  const screen = await renderApp({ path: '/' });
+
+  await expect.element(screen.getByText(/^No books yet\./)).toBeVisible();
+  await expect.element(screen.getByText(/^No reading recorded yet\./)).toBeVisible();
+  await expect.element(screen.getByText(/^No highlights or notes yet\./)).toBeVisible();
+  for (const section of ['Recent books', 'Reading activity', 'Recent highlights and notes']) {
+    await expect.element(screen.getByRole('heading', { name: section })).toBeVisible();
+  }
 });

--- a/frontend/src/pages/LandingPage/components/ReadingActivity.tsx
+++ b/frontend/src/pages/LandingPage/components/ReadingActivity.tsx
@@ -1,6 +1,7 @@
 import type { LibraryActivity, LibraryStats } from '@/api/generated/model';
 import { useGetLibraryReadingActivity } from '@/api/generated/statistics/statistics';
 import { Spinner } from '@/components/animations/Spinner.tsx';
+import { EmptyStateText } from '@/components/EmptyStateText.tsx';
 import { ReadingActivityGrid } from '@/components/reading/ReadingActivityGrid.tsx';
 import { Stat, type StatProps } from '@/components/reading/Stat.tsx';
 import { SectionTitle } from '@/components/typography/SectionTitle.tsx';
@@ -68,8 +69,10 @@ const summary = (stats: LibraryStats): StatProps[] => [
 ];
 
 /**
- * The dashboard's year of reading. Not drawn at all for a reader with nothing
- * on the grid: a blank year is worse than no year, and they would meet it first.
+ * The dashboard's year of reading. A reader with nothing on the grid still gets
+ * the grid, empty, with a line saying what will colour it: a blank year reads
+ * as a year yet to be filled, where a missing section reads as a missing page.
+ * The numbers wait until there is something to count.
  */
 export const ReadingActivity = () => {
   const { data, isLoading, isError } = useGetLibraryReadingActivity({ tz: browserTimeZone() });
@@ -78,9 +81,7 @@ export const ReadingActivity = () => {
   const read = useMemo(() => booksByDay(activity), [activity]);
   const roomy = useMediaQuery(`(min-width: ${ROOMY_VIEWPORT}px)`);
 
-  if (!isLoading && !isError && !activity) {
-    return null;
-  }
+  const empty = !isLoading && !isError && !activity;
 
   return (
     <Box sx={{ mb: 6 }}>
@@ -92,6 +93,18 @@ export const ReadingActivity = () => {
         <Box sx={{ py: 3 }}>
           <Alert severity="error">Failed to load reading activity.</Alert>
         </Box>
+      )}
+
+      {empty && (
+        <>
+          <EmptyStateText>
+            No reading recorded yet. Your reading days fill in here once you sync your e-reader.
+          </EmptyStateText>
+
+          <Box sx={{ mt: 3, maxWidth: { lg: `${RECENT_ROW_WIDTH}px` } }}>
+            <ReadingActivityGrid activity={null} blockSize={roomy ? ROOMY_BLOCK_SIZE : undefined} />
+          </Box>
+        </>
       )}
 
       {activity && (

--- a/frontend/src/pages/LandingPage/components/RecentBooks.tsx
+++ b/frontend/src/pages/LandingPage/components/RecentBooks.tsx
@@ -3,6 +3,7 @@ import { Spinner } from '@/components/animations/Spinner.tsx';
 import { BOOK_CARD_WIDTH, BookCard } from '@/components/books/BookCard.tsx';
 import { Carousel } from '@/components/carousel/Carousel.tsx';
 import { CarouselItem } from '@/components/carousel/CarouselItem.tsx';
+import { EmptyStateText } from '@/components/EmptyStateText.tsx';
 import { PAGE_GUTTER } from '@/components/layout/Layouts.tsx';
 import { SectionTitle } from '@/components/typography/SectionTitle.tsx';
 import { Alert, Box } from '@mui/material';
@@ -29,15 +30,14 @@ export const RECENT_ROW_WIDTH =
  * The landing page's row of covers for books the user last opened, or last
  * synced from an e-reader. One row rather than two: the same handful of books
  * tends to be both, and showing them twice said nothing extra.
+ *
+ * A reader with no books keeps the section and is told what fills it, rather
+ * than meeting a dashboard with a heading missing from it.
  */
 export const RecentBooks = () => {
   const { data, isLoading, isError } = useGetRecentBooks({ limit: RECENT_BOOKS_LIMIT });
   const books = data?.items;
-
-  // Don't render the section at all when the query came back with no books
-  if (!isLoading && !isError && (!books || books.length === 0)) {
-    return null;
-  }
+  const empty = !isLoading && !isError && !books?.length;
 
   return (
     <Box sx={{ mb: 6 }}>
@@ -49,6 +49,12 @@ export const RecentBooks = () => {
         <Box sx={{ py: 3 }}>
           <Alert severity="error">Failed to load recent books.</Alert>
         </Box>
+      )}
+
+      {empty && (
+        <EmptyStateText>
+          No books yet. Upload highlights from your e-reader to get started.
+        </EmptyStateText>
       )}
 
       {books && books.length > 0 && (

--- a/frontend/src/pages/LandingPage/components/RecentCaptures.tsx
+++ b/frontend/src/pages/LandingPage/components/RecentCaptures.tsx
@@ -1,6 +1,7 @@
 import { useGetRecentCaptures } from '@/api/generated/captures/captures';
 import type { RecentCapture } from '@/api/generated/model';
 import { Spinner } from '@/components/animations/Spinner.tsx';
+import { EmptyStateText } from '@/components/EmptyStateText.tsx';
 import { SectionTitle } from '@/components/typography/SectionTitle.tsx';
 import { browserTimeZone, formatDay } from '@/utils/date.ts';
 import { Alert, Box, Typography } from '@mui/material';
@@ -25,8 +26,8 @@ const byDay = (captures: RecentCapture[]): [string, RecentCapture[]][] => {
  * The dashboard's row of what the reader last marked: highlights on the
  * e-reader's own clock, notes on the reader's, cut into days.
  *
- * Not drawn at all for a reader who has captured nothing, the way the activity
- * grid is not drawn for a reader with no year to show.
+ * A reader who has captured nothing keeps the section and is told what will
+ * fill it, the way the activity grid keeps its squares with nothing on them.
  */
 export const RecentCaptures = () => {
   const { data, isLoading, isError } = useGetRecentCaptures({
@@ -36,9 +37,7 @@ export const RecentCaptures = () => {
   const captures = data?.items;
   const days = useMemo(() => byDay(captures ?? []), [captures]);
 
-  if (!isLoading && !isError && days.length === 0) {
-    return null;
-  }
+  const empty = !isLoading && !isError && days.length === 0;
 
   return (
     <Box sx={{ mb: 6 }}>
@@ -50,6 +49,12 @@ export const RecentCaptures = () => {
         <Box sx={{ py: 3 }}>
           <Alert severity="error">Failed to load recent highlights and notes.</Alert>
         </Box>
+      )}
+
+      {empty && (
+        <EmptyStateText>
+          No highlights or notes yet. They appear here once you sync your e-reader.
+        </EmptyStateText>
       )}
 
       {days.map(([day, dayCaptures]) => (

--- a/frontend/tests/fixtures/sessions.ts
+++ b/frontend/tests/fixtures/sessions.ts
@@ -45,3 +45,19 @@ export const aBookStatistics = (
   activity: aBookActivity(),
   ...overrides,
 });
+
+/**
+ * What the API sends for a book nobody has opened: a count of zero and nothing
+ * to average, span or plot.
+ */
+export const noBookStatistics = (): BookReadingStatistics =>
+  aBookStatistics({
+    session_count: 0,
+    total_reading_seconds: 0,
+    average_session_seconds: null,
+    first_session_start: null,
+    last_session_end: null,
+    span_days: null,
+    progress_percent: null,
+    activity: null,
+  });

--- a/frontend/tests/msw/bookApi.ts
+++ b/frontend/tests/msw/bookApi.ts
@@ -13,7 +13,7 @@ import type {
 import { http, HttpResponse } from 'msw';
 import { aBookDetails } from '../fixtures/book';
 import { aNote } from '../fixtures/notes';
-import { aBookActivity, aBookStatistics } from '../fixtures/sessions';
+import { aBookActivity, aBookStatistics, noBookStatistics } from '../fixtures/sessions';
 
 interface BookApiState {
   book: BookDetails;
@@ -38,15 +38,13 @@ export function bookApi(initial: Partial<BookApiState> = {}) {
     sessions: initial.sessions ?? [],
     sessionTotal: initial.sessionTotal ?? initial.sessions?.length ?? 0,
     // Counted off the sessions the handler was given, so a tab with no
-    // sessions does not come with statistics summarising them anyway.
+    // sessions does not come with statistics summarising them anyway: an
+    // unread book has nothing to average, to span, or to plot either.
     statistics:
       initial.statistics ??
-      aBookStatistics({
-        session_count: initial.sessions?.length ?? 0,
-        // A tab with no sessions gets no grid, for the same reason it gets no
-        // summary: there is nothing for either to be about.
-        activity: initial.sessions?.length ? aBookActivity() : null,
-      }),
+      (initial.sessions?.length
+        ? aBookStatistics({ session_count: initial.sessions.length, activity: aBookActivity() })
+        : noBookStatistics()),
   };
 
   const findNote = (noteId: string | readonly string[] | undefined) =>


### PR DESCRIPTION
## Summary

Changes the dashboard and book statistics pages to always show sections with empty state messaging, rather than hiding them entirely when a reader has no data. This improves UX by preventing layout shifts and making it clear what will fill each section once data is available.

## Key Changes

- **Landing page sections** (`RecentBooks`, `ReadingActivity`, `RecentCaptures`):
  - Now always render their section containers
  - Display `EmptyStateText` component with helpful messaging when no data exists
  - Prevents sections from disappearing and reappearing as data loads

- **Reading activity grid** (`ReadingActivityGrid`):
  - Now accepts `activity: ActivityGridData | null` instead of requiring data
  - When `activity` is `null`, renders an empty year (365 uncolored squares)
  - Hides the color legend when empty (no scale to explain)
  - Updates labels and total count text to reflect empty state
  - Added `emptyYear()` helper to generate a blank year window

- **Book statistics page** (`ReadingStatsSection`):
  - Shows summary stats (time read, sessions, etc.) even for unread books, displaying zeros
  - Always renders the activity grid, passing `null` when no sessions exist
  - Progress bar shows 0% for unread books instead of disappearing
  - Hides stats that require data (average session, reading span) when count is zero

- **Test fixtures and mocks**:
  - Added `noBookStatistics()` fixture for books with no reading sessions
  - Updated test expectations to verify empty states render with appropriate messaging
  - Tests now verify that sections remain visible with empty content rather than disappearing

## Implementation Details

- Empty state messaging uses consistent pattern: "No [thing] yet. [Action to fill it]."
- The activity grid's empty year spans 365 days ending today, matching the backend's window
- Stats that require data (averages, spans) are conditionally hidden based on `session_count === 0`
- Progress bar uses `0` for unread books (distinguishing from "unknown" which would be `null`)
- Color legend hidden on empty grids since there's no scale to explain

https://claude.ai/code/session_01N2WkTWqnNNwhgnxnt6XSXz