### PR TITLE
feat: Readium resource endpoint streaming EPUB zip members

### DIFF
--- a/backend/.jscpd.json
+++ b/backend/.jscpd.json
@@ -12,5 +12,5 @@
   "minLines": 5,
   "minTokens": 50,
   "reporters": ["ai", "threshold"],
-  "threshold": 2.55
+  "threshold": 2.45
 }

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -4391,6 +4391,67 @@
         }
       }
     },
+    "/api/v1/readium/books/{book_id}/resources/{path}": {
+      "get": {
+        "tags": [
+          "readium"
+        ],
+        "summary": "Get Readium Resource",
+        "description": "Get one file of a book's publication, unchanged.\n\n``path`` is a manifest href with the ``resources/`` prefix stripped, so it\narrives here as the container-root path the reading order or the resource\nlist published -- decoded once by ASGI, which is the archive member's own\nname. Only the files the manifest names are reachable; the package document\nand ``META-INF/`` are not part of the publication and answer 404 like any\nother path the manifest does not list.",
+        "operationId": "get_readium_resource",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "book_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Book Id"
+            }
+          },
+          {
+            "name": "path",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Path"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The file, under the media type the publication declares for it.",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "304": {
+            "description": "The caller already holds this version."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/settings": {
       "get": {
         "tags": [

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -157,6 +157,7 @@ modules = [
     "src.domain.reading",
     "src.domain.reflection",
     "src.domain.tagging",
+    "src.domain.web_reader",
 ]
 
 [[tool.importlinter.contracts]]

--- a/backend/src/application/web_reader/queries/get_publication_resource_use_case.py
+++ b/backend/src/application/web_reader/queries/get_publication_resource_use_case.py
@@ -1,0 +1,34 @@
+"""Read use case behind the publication resource endpoint."""
+
+from src.application.web_reader.queries.publication_resource import (
+    PublicationResourceQueryProtocol,
+    PublicationResourceView,
+)
+from src.domain.common.value_objects import BookId, UserId
+from src.domain.reading.exceptions import BookNotFoundError
+
+
+class GetPublicationResourceUseCase:
+    """Serve one file of a book's publication to the web reader."""
+
+    def __init__(self, publication_resource_query: PublicationResourceQueryProtocol) -> None:
+        self.publication_resource_query = publication_resource_query
+
+    async def get_publication_resource(
+        self, book_id: int, user_id: int, path: str
+    ) -> PublicationResourceView:
+        """Return the file the reader asked for.
+
+        Raises:
+            BookNotFoundError: If the user has no such book.
+            EbookFileNotFoundError: If the book has no stored EPUB to read.
+            InvalidEbookError: If the stored EPUB cannot be parsed.
+            PublicationResourceNotFoundError: If the publication lists no such
+                file.
+        """
+        resource = await self.publication_resource_query.get_publication_resource(
+            BookId(book_id), UserId(user_id), path
+        )
+        if resource is None:
+            raise BookNotFoundError(book_id)
+        return resource

--- a/backend/src/application/web_reader/queries/get_publication_resource_use_case.py
+++ b/backend/src/application/web_reader/queries/get_publication_resource_use_case.py
@@ -15,19 +15,27 @@ class GetPublicationResourceUseCase:
         self.publication_resource_query = publication_resource_query
 
     async def get_publication_resource(
-        self, book_id: int, user_id: int, path: str
+        self, book_id: int, user_id: int, path: str, known_versions: frozenset[str]
     ) -> PublicationResourceView:
         """Return the file the reader asked for.
+
+        Args:
+            book_id: The book whose EPUB holds the file.
+            user_id: The user the book must belong to.
+            path: The file's container-root path, decoded.
+            known_versions: Versions the caller already holds; a view whose
+                version is among them comes back without content.
 
         Raises:
             BookNotFoundError: If the user has no such book.
             EbookFileNotFoundError: If the book has no stored EPUB to read.
-            InvalidEbookError: If the stored EPUB cannot be parsed.
+            InvalidEbookError: If the stored EPUB cannot be parsed, or the file
+                is too large to serve.
             PublicationResourceNotFoundError: If the publication lists no such
                 file.
         """
         resource = await self.publication_resource_query.get_publication_resource(
-            BookId(book_id), UserId(user_id), path
+            BookId(book_id), UserId(user_id), path, known_versions
         )
         if resource is None:
             raise BookNotFoundError(book_id)

--- a/backend/src/application/web_reader/queries/publication_resource.py
+++ b/backend/src/application/web_reader/queries/publication_resource.py
@@ -11,6 +11,12 @@ from typing import Protocol
 
 from src.domain.common.value_objects.ids import BookId, UserId
 
+# A caller that holds whatever version there is, however new. Its only source is
+# an ``If-None-Match: *``, but the read model has no reason to know that: it
+# says "give me this only if I do not already have it", which is a question
+# about versions rather than about HTTP.
+ANY_VERSION = "*"
+
 
 @dataclass(frozen=True)
 class PublicationResourceView:
@@ -21,17 +27,17 @@ class PublicationResourceView:
             and therefore the one the manifest lists for it. The bytes are
             served under it unchanged.
         content: The file's decompressed bytes, byte-for-byte what the EPUB
-            holds.
-        version: An opaque token identifying these exact bytes *within this
-            book*. It changes when the book's stored EPUB is replaced or when
-            the file's contents change, which is what makes it usable as an
-            HTTP entity tag. Not a hash of the content itself: it is derived
-            from the archive's own checksum, which is read from the central
-            directory rather than computed.
+            holds -- or ``None`` when the caller said it already holds this
+            version, in which case the file was never read. Reading a member is
+            the expensive half of this view, so not reading it is the point of
+            asking rather than an optimisation on the side.
+        version: An opaque token identifying these exact bytes. It changes
+            whenever the book's stored EPUB changes, so it is safe to use as an
+            HTTP entity tag.
     """
 
     media_type: str
-    content: bytes
+    content: bytes | None
     version: str
 
 
@@ -39,7 +45,7 @@ class PublicationResourceQueryProtocol(Protocol):
     """Port for reading one file out of a book's stored EPUB."""
 
     async def get_publication_resource(
-        self, book_id: BookId, user_id: UserId, path: str
+        self, book_id: BookId, user_id: UserId, path: str, known_versions: frozenset[str]
     ) -> PublicationResourceView | None:
         """Return one file of a user's publication, or ``None`` when they have no such book.
 
@@ -50,11 +56,15 @@ class PublicationResourceQueryProtocol(Protocol):
                 container root and **decoded** -- the manifest's percent-encoded
                 href with its encoding undone exactly once, which is the archive
                 member's own name.
+            known_versions: Versions the caller says it already holds, or
+                ``{ANY_VERSION}``. When the file's version is among them the
+                view comes back with no content and the member is never read.
 
         Raises:
             EbookFileNotFoundError: If the book exists but no EPUB is stored for
                 it -- distinct from ``None``, which means the book does not.
-            InvalidEbookError: If the stored EPUB cannot be parsed.
+            InvalidEbookError: If the stored EPUB cannot be parsed, or the file
+                is too large to serve.
             PublicationResourceNotFoundError: If the publication lists no such
                 file.
         """

--- a/backend/src/application/web_reader/queries/publication_resource.py
+++ b/backend/src/application/web_reader/queries/publication_resource.py
@@ -1,0 +1,61 @@
+"""Read model for one file of a publication, served to the web reader.
+
+The manifest (M1.1) names every file the reader will ask for; this is the view
+that answers one of those asks. It is a dead end like any read model -- rendered
+into an HTTP response and never fed back into a command. See
+``docs/adr/0001-read-models-and-query-services.md``.
+"""
+
+from dataclasses import dataclass
+from typing import Protocol
+
+from src.domain.common.value_objects.ids import BookId, UserId
+
+
+@dataclass(frozen=True)
+class PublicationResourceView:
+    """One file of a publication, exactly as the EPUB stores it.
+
+    Attributes:
+        media_type: The media type the package document declares for this file,
+            and therefore the one the manifest lists for it. The bytes are
+            served under it unchanged.
+        content: The file's decompressed bytes, byte-for-byte what the EPUB
+            holds.
+        version: An opaque token identifying these exact bytes *within this
+            book*. It changes when the book's stored EPUB is replaced or when
+            the file's contents change, which is what makes it usable as an
+            HTTP entity tag. Not a hash of the content itself: it is derived
+            from the archive's own checksum, which is read from the central
+            directory rather than computed.
+    """
+
+    media_type: str
+    content: bytes
+    version: str
+
+
+class PublicationResourceQueryProtocol(Protocol):
+    """Port for reading one file out of a book's stored EPUB."""
+
+    async def get_publication_resource(
+        self, book_id: BookId, user_id: UserId, path: str
+    ) -> PublicationResourceView | None:
+        """Return one file of a user's publication, or ``None`` when they have no such book.
+
+        Args:
+            book_id: The book whose EPUB holds the file.
+            user_id: The user the book must belong to.
+            path: The file's path inside the EPUB container, relative to the
+                container root and **decoded** -- the manifest's percent-encoded
+                href with its encoding undone exactly once, which is the archive
+                member's own name.
+
+        Raises:
+            EbookFileNotFoundError: If the book exists but no EPUB is stored for
+                it -- distinct from ``None``, which means the book does not.
+            InvalidEbookError: If the stored EPUB cannot be parsed.
+            PublicationResourceNotFoundError: If the publication lists no such
+                file.
+        """
+        ...

--- a/backend/src/containers/root.py
+++ b/backend/src/containers/root.py
@@ -157,4 +157,5 @@ class RootContainer(containers.DeclarativeContainer):
     web_reader = providers.Container(
         WebReaderContainer,
         web_publication_query=shared.web_publication_query,
+        publication_resource_query=shared.publication_resource_query,
     )

--- a/backend/src/containers/shared.py
+++ b/backend/src/containers/shared.py
@@ -79,6 +79,9 @@ from src.infrastructure.semantic.queries.search_hydration_query import SearchHyd
 from src.infrastructure.semantic.queries.semantic_search_query import SemanticSearchQuery
 from src.infrastructure.semantic.repositories.embedding_repository import EmbeddingRepository
 from src.infrastructure.tagging.repositories import TagRepository
+from src.infrastructure.web_reader.queries.publication_resource_query import (
+    PublicationResourceQuery,
+)
 from src.infrastructure.web_reader.queries.web_publication_query import WebPublicationQuery
 from src.infrastructure.web_reader.services.xpoint_cfi_position_anchor_service import (
     XPointCfiPositionAnchorService,
@@ -242,6 +245,12 @@ class SharedContainer(containers.DeclarativeContainer):
     # alongside the session.
     web_publication_query = providers.Factory(
         WebPublicationQuery,
+        db=db,
+        file_repository=file_repository,
+        publication_parser=epub_parser_service,
+    )
+    publication_resource_query = providers.Factory(
+        PublicationResourceQuery,
         db=db,
         file_repository=file_repository,
         publication_parser=epub_parser_service,

--- a/backend/src/containers/web_reader.py
+++ b/backend/src/containers/web_reader.py
@@ -1,5 +1,8 @@
 from dependency_injector import containers, providers
 
+from src.application.web_reader.queries.get_publication_resource_use_case import (
+    GetPublicationResourceUseCase,
+)
 from src.application.web_reader.queries.get_web_publication_use_case import (
     GetWebPublicationUseCase,
 )
@@ -10,8 +13,14 @@ class WebReaderContainer(containers.DeclarativeContainer):
 
     # Dependencies from shared
     web_publication_query = providers.Dependency()
+    publication_resource_query = providers.Dependency()
 
     get_web_publication_use_case = providers.Factory(
         GetWebPublicationUseCase,
         web_publication_query=web_publication_query,
+    )
+
+    get_publication_resource_use_case = providers.Factory(
+        GetPublicationResourceUseCase,
+        publication_resource_query=publication_resource_query,
     )

--- a/backend/src/domain/web_reader/exceptions.py
+++ b/backend/src/domain/web_reader/exceptions.py
@@ -1,0 +1,18 @@
+"""Web reader domain exceptions."""
+
+from src.domain.common.exceptions import EntityNotFoundError
+
+
+class PublicationResourceNotFoundError(EntityNotFoundError):
+    """Raised when a publication does not contain the requested file.
+
+    Distinct from ``BookNotFoundError`` and ``EbookFileNotFoundError``: the book
+    is there, its EPUB is readable, and the path simply names nothing the
+    publication offers -- a stale href, a typo, or somebody probing for the
+    package document. All three answer 404, and keeping them apart is what lets
+    the logs tell a broken reader from a missing file.
+    """
+
+    def __init__(self, path: str) -> None:
+        super().__init__("Publication resource", path)
+        self.path = path

--- a/backend/src/infrastructure/web_reader/dependencies.py
+++ b/backend/src/infrastructure/web_reader/dependencies.py
@@ -1,0 +1,27 @@
+"""FastAPI dependencies shared by the web reader's routes."""
+
+from typing import Annotated
+
+from fastapi import Depends
+
+from src.domain.identity.entities.user import User
+from src.infrastructure.identity import get_current_user
+
+
+async def get_publication_reader(
+    user: Annotated[User, Depends(get_current_user)],
+) -> User:
+    """Authenticate whoever is reading a publication.
+
+    A Bearer token is the only credential today, and this adds nothing to it. It
+    exists as a seam rather than as a rule: M1.4 (#737) has to let a navigator's
+    iframe load resource URLs, which cannot carry an in-memory Bearer token, and
+    the candidate is a short-lived httpOnly publication cookie (ADR-0004,
+    *Pending*). Accepting a second credential is then an edit here, and every
+    web reader route -- manifest, resources, and the position list to come --
+    gains it together instead of one at a time.
+    """
+    return user
+
+
+PublicationReader = Annotated[User, Depends(get_publication_reader)]

--- a/backend/src/infrastructure/web_reader/queries/publication_resource_query.py
+++ b/backend/src/infrastructure/web_reader/queries/publication_resource_query.py
@@ -31,15 +31,33 @@ from src.infrastructure.web_reader.queries.stored_epub import StoredEpub, load_s
 # enough to stay readable in a log line or a browser's network panel.
 _VERSION_LENGTH = 32
 
-# The largest single file this will serve out of a publication. EPUB resources
-# are documents, styles, fonts and images: a chapter runs to kilobytes and even
-# a full-page scan in a fixed-layout book to a few megabytes, so this sits two
-# orders of magnitude above anything a real book contains and no legitimate
-# publication meets it. Audio and video are not EPUB resources and are not
-# planned. The parser's own cap is on the archive's *total* declared size, which
-# a single near-2-GiB member passes comfortably, so a per-member limit is what
-# stops one file from being the whole budget.
-MAX_RESOURCE_BYTES = 16 * 1024 * 1024
+# The largest single file this will serve out of a publication, derived from the
+# 50 MiB `MAX_EBOOK_SIZE` an upload may be.
+#
+# EPUB 3 carries audio, video, fonts and full-page images as well as documents,
+# so "a chapter is small" is no guide at all. What does bound a member is the
+# upload: every one of those formats is already compressed and stores at a ratio
+# near one, so a media member cannot be much larger than the archive that
+# carried it. Sitting above the upload cap therefore admits any member that
+# could have arrived as itself -- a 32 MiB comic page included -- while still
+# bounding what one request may hold.
+#
+# Only a member relying on real compression could exceed this, and that means
+# text: no publication has a 64 MiB XHTML document. The parser's own cap is on
+# the archive's *total* declared size, which one near-2-GiB member passes
+# comfortably, so a per-member limit is what stops one file being the whole
+# budget.
+MAX_RESOURCE_BYTES = 64 * 1024 * 1024
+
+# How much larger than its contents a compressed stream may plausibly be.
+# Deflate cannot meaningfully expand data: incompressible input falls back to
+# stored blocks, costing five bytes per 64 KiB block plus a small header. The
+# allowance is far looser than that -- a sixteenth, plus 256 bytes so tiny
+# members are not judged on rounding -- because its job is to catch a stream
+# orders of magnitude too big for what it claims to hold, not to police
+# encoders.
+_COMPRESSED_SLACK_DIVISOR = 16
+_COMPRESSED_SLACK_BYTES = 256
 
 
 class PublicationResourceQuery:
@@ -95,12 +113,18 @@ class PublicationResourceQuery:
                 # rather than an unhandled KeyError.
                 raise PublicationResourceNotFoundError(path) from None
 
+            # Whether this member may be served at all is settled first: a
+            # precondition narrows a request that would otherwise succeed
+            # (RFC 9110 §13.2), so it must not turn a refusal into "your copy is
+            # current" and leave a reader trusting a file it can never fetch.
+            # Both this and the version come from the archive's directory, so
+            # neither costs a decompression.
+            check_member_is_servable(entry)
+
             version = _version(stored, path)
-            # Answered before anything is decompressed. The version is made of
-            # what the archive's directory already says, so a reader that
-            # already holds this file costs a parse and nothing more -- which is
-            # the difference between a cheap conditional request and one that
-            # inflates a member in full only to discard it.
+            # Answered before anything is decompressed, which is the difference
+            # between a cheap conditional request and one that inflates a member
+            # in full only to discard it.
             if ANY_VERSION in known_versions or version in known_versions:
                 return PublicationResourceView(media_type=media_type, content=None, version=version)
             content = read_bounded_member(archive, entry)
@@ -133,29 +157,35 @@ def _media_types_by_member(publication: ParsedPublication) -> dict[str, str]:
     }
 
 
-def read_bounded_member(archive: zipfile.ZipFile, entry: zipfile.ZipInfo) -> bytes:
-    """Read one member without letting it decide how much memory that takes.
+def check_member_is_servable(entry: zipfile.ZipInfo) -> None:
+    """Decide from the central directory alone whether a member may be served.
 
-    Two things are needed, because the declared size is both the only cheap
-    signal and a claim the archive makes about itself:
+    Both questions are answered without decompressing anything, which is what
+    lets this run before a conditional request is considered -- a precondition
+    narrows a request that would otherwise succeed and must not rescue one that
+    would not.
 
-    - **The cap refuses an honest declaration for free.** A member declaring
-      more than :data:`MAX_RESOURCE_BYTES` is turned away without opening it.
-    - **The bounded read contains a dishonest one.** ``ZipFile.read()`` returns
-      no more than the declared size but does not *work* within it: measured on
-      CPython 3.13, reading a member that declares 10 bytes and really inflates
-      to 200 MB returns 10 bytes after allocating 437 MiB, because the
-      decompressor is handed an unbounded output limit and only the result is
-      truncated. ``open(entry).read(n)`` passes ``n`` down as the decompressor's
-      output limit, so asking for no more than the declaration bounds the work
-      as well as the answer -- the same member then costs 53 KiB.
+    The **cap** turns away an honest declaration over
+    :data:`MAX_RESOURCE_BYTES`.
 
-    A member that inflates past what it declared fails its CRC-32, which
-    ``zipfile`` raises as ``BadZipFile``; that is a broken publication rather
-    than a server fault, so it reads as one.
+    The **plausibility check** turns away a dishonest one. A member that really
+    inflates past what it declared normally fails its CRC-32, but that check is
+    forgeable: a crafted member whose stored checksum equals the CRC of its own
+    truncated prefix passes it, and would then be served silently short. The
+    compressed size is the tell. Deflate cannot meaningfully expand data, so a
+    stream far larger than the declaration could compress to is lying about one
+    of the two, and a member declaring eight bytes cannot honestly carry 200 KiB.
+
+    Residual risk, accepted knowingly: a member that overstates by only a little
+    -- within the slack -- still slips through with a forged prefix CRC, and is
+    served truncated. What remains is an integrity fault confined to one file of
+    a book, in an archive its own owner uploaded and only its owner can read;
+    memory stays bounded either way. Closing it completely would mean
+    decompressing every member to measure it, which is the cost this whole path
+    exists to avoid.
 
     Raises:
-        InvalidEbookError: If the member is over the cap, or is not readable.
+        InvalidEbookError: If the member is over the cap or misdescribes itself.
     """
     if entry.file_size > MAX_RESOURCE_BYTES:
         raise InvalidEbookError(
@@ -163,6 +193,38 @@ def read_bounded_member(archive: zipfile.ZipFile, entry: zipfile.ZipInfo) -> byt
             f"{MAX_RESOURCE_BYTES} limit",
             "epub",
         )
+    plausible = (
+        entry.file_size + entry.file_size // _COMPRESSED_SLACK_DIVISOR + _COMPRESSED_SLACK_BYTES
+    )
+    if entry.compress_size > plausible:
+        raise InvalidEbookError(
+            f"resource {entry.filename!r} declares {entry.file_size} bytes but carries a "
+            f"compressed stream of {entry.compress_size}",
+            "epub",
+        )
+
+
+def read_bounded_member(archive: zipfile.ZipFile, entry: zipfile.ZipInfo) -> bytes:
+    """Read one member without letting it decide how much memory that takes.
+
+    ``ZipFile.read()`` returns no more than the declared size but does not
+    *work* within it: measured on CPython 3.13, reading a member that declares
+    10 bytes and really inflates to 200 MB returns 10 bytes after allocating
+    437 MiB, because the decompressor is handed an unbounded output limit and
+    only the result is truncated. ``open(entry).read(n)`` passes ``n`` down as
+    that limit, so asking for no more than the declaration bounds the work as
+    well as the answer -- the same member then costs 53 KiB.
+
+    Call :func:`check_member_is_servable` first; this trusts the declaration to
+    be one worth reading up to.
+
+    A member that inflates past what it declared fails its CRC-32, which
+    ``zipfile`` raises as ``BadZipFile``; that is a broken publication rather
+    than a server fault, so it reads as one.
+
+    Raises:
+        InvalidEbookError: If the member is not readable.
+    """
     try:
         with archive.open(entry) as member:
             return member.read(entry.file_size + 1)

--- a/backend/src/infrastructure/web_reader/queries/publication_resource_query.py
+++ b/backend/src/infrastructure/web_reader/queries/publication_resource_query.py
@@ -103,7 +103,7 @@ class PublicationResourceQuery:
             # inflates a member in full only to discard it.
             if ANY_VERSION in known_versions or version in known_versions:
                 return PublicationResourceView(media_type=media_type, content=None, version=version)
-            content = _read_bounded(archive, entry)
+            content = read_bounded_member(archive, entry)
 
         return PublicationResourceView(media_type=media_type, content=content, version=version)
 
@@ -133,7 +133,7 @@ def _media_types_by_member(publication: ParsedPublication) -> dict[str, str]:
     }
 
 
-def _read_bounded(archive: zipfile.ZipFile, entry: zipfile.ZipInfo) -> bytes:
+def read_bounded_member(archive: zipfile.ZipFile, entry: zipfile.ZipInfo) -> bytes:
     """Read one member without letting it decide how much memory that takes.
 
     Two things are needed, because the declared size is both the only cheap

--- a/backend/src/infrastructure/web_reader/queries/publication_resource_query.py
+++ b/backend/src/infrastructure/web_reader/queries/publication_resource_query.py
@@ -18,14 +18,28 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from src.application.library.protocols.file_repository import FileRepositoryProtocol
 from src.application.web_reader.protocols.publication_parser import PublicationParserProtocol
 from src.application.web_reader.publications import ParsedPublication
-from src.application.web_reader.queries.publication_resource import PublicationResourceView
+from src.application.web_reader.queries.publication_resource import (
+    ANY_VERSION,
+    PublicationResourceView,
+)
 from src.domain.common.value_objects.ids import BookId, UserId
+from src.domain.library.exceptions import InvalidEbookError
 from src.domain.web_reader.exceptions import PublicationResourceNotFoundError
 from src.infrastructure.web_reader.queries.stored_epub import StoredEpub, load_stored_epub
 
 # Long enough that two files of one book cannot collide by accident, short
 # enough to stay readable in a log line or a browser's network panel.
 _VERSION_LENGTH = 32
+
+# The largest single file this will serve out of a publication. EPUB resources
+# are documents, styles, fonts and images: a chapter runs to kilobytes and even
+# a full-page scan in a fixed-layout book to a few megabytes, so this sits two
+# orders of magnitude above anything a real book contains and no legitimate
+# publication meets it. Audio and video are not EPUB resources and are not
+# planned. The parser's own cap is on the archive's *total* declared size, which
+# a single near-2-GiB member passes comfortably, so a per-member limit is what
+# stops one file from being the whole budget.
+MAX_RESOURCE_BYTES = 16 * 1024 * 1024
 
 
 class PublicationResourceQuery:
@@ -42,13 +56,14 @@ class PublicationResourceQuery:
         self.publication_parser = publication_parser
 
     async def get_publication_resource(
-        self, book_id: BookId, user_id: UserId, path: str
+        self, book_id: BookId, user_id: UserId, path: str, known_versions: frozenset[str]
     ) -> PublicationResourceView | None:
         """Return one file of a user's publication, or ``None`` when they have no such book.
 
         Raises:
             EbookFileNotFoundError: If the book exists but no EPUB is stored for it.
-            InvalidEbookError: If the stored EPUB cannot be parsed.
+            InvalidEbookError: If the stored EPUB cannot be parsed, or the file is
+                too large to serve.
             PublicationResourceNotFoundError: If the publication lists no such file.
         """
         stored = await load_stored_epub(self.db, self.file_repository, book_id, user_id)
@@ -57,9 +72,11 @@ class PublicationResourceQuery:
         # Parsing the publication and reading a member are both blocking and
         # both CPU-bound, so they share one hop off the event loop rather than
         # stalling every other request in the process for the duration.
-        return await asyncio.to_thread(self._read_member, stored, path)
+        return await asyncio.to_thread(self._read_member, stored, path, known_versions)
 
-    def _read_member(self, stored: StoredEpub, path: str) -> PublicationResourceView:
+    def _read_member(
+        self, stored: StoredEpub, path: str, known_versions: frozenset[str]
+    ) -> PublicationResourceView:
         """Find the requested file in the parsed publication and read it out of the archive."""
         publication = self.publication_parser.parse_publication(stored.content)
         media_type = _media_types_by_member(publication).get(path)
@@ -77,13 +94,18 @@ class PublicationResourceQuery:
                 # what the parser lists and what the archive holds is a 404
                 # rather than an unhandled KeyError.
                 raise PublicationResourceNotFoundError(path) from None
-            content = archive.read(entry)
 
-        return PublicationResourceView(
-            media_type=media_type,
-            content=content,
-            version=_version(stored.file_name, entry.CRC),
-        )
+            version = _version(stored, path)
+            # Answered before anything is decompressed. The version is made of
+            # what the archive's directory already says, so a reader that
+            # already holds this file costs a parse and nothing more -- which is
+            # the difference between a cheap conditional request and one that
+            # inflates a member in full only to discard it.
+            if ANY_VERSION in known_versions or version in known_versions:
+                return PublicationResourceView(media_type=media_type, content=None, version=version)
+            content = _read_bounded(archive, entry)
+
+        return PublicationResourceView(media_type=media_type, content=content, version=version)
 
 
 def _media_types_by_member(publication: ParsedPublication) -> dict[str, str]:
@@ -111,17 +133,71 @@ def _media_types_by_member(publication: ParsedPublication) -> dict[str, str]:
     }
 
 
-def _version(file_name: str, crc: int) -> str:
-    """Derive a resource's opaque version from the book's file and the member's checksum.
+def _read_bounded(archive: zipfile.ZipFile, entry: zipfile.ZipInfo) -> bytes:
+    """Read one member without letting it decide how much memory that takes.
 
-    The archive's own CRC-32 comes from the central directory, so no member is
-    decompressed to answer a conditional request that will not need its bytes.
-    A CRC is far too weak to be a content address, which is exactly why the
-    stored file name is mixed in: within one book two files with the same
-    contents are the same resource, and replacing the book's EPUB changes every
-    version at once even where a member survived byte-identical.
+    Two things are needed, because the declared size is both the only cheap
+    signal and a claim the archive makes about itself:
 
-    Hashing rather than concatenating keeps the storage file name off the wire,
-    an entity tag being something the client sees and echoes back.
+    - **The cap refuses an honest declaration for free.** A member declaring
+      more than :data:`MAX_RESOURCE_BYTES` is turned away without opening it.
+    - **The bounded read contains a dishonest one.** ``ZipFile.read()`` returns
+      no more than the declared size but does not *work* within it: measured on
+      CPython 3.13, reading a member that declares 10 bytes and really inflates
+      to 200 MB returns 10 bytes after allocating 437 MiB, because the
+      decompressor is handed an unbounded output limit and only the result is
+      truncated. ``open(entry).read(n)`` passes ``n`` down as the decompressor's
+      output limit, so asking for no more than the declaration bounds the work
+      as well as the answer -- the same member then costs 53 KiB.
+
+    A member that inflates past what it declared fails its CRC-32, which
+    ``zipfile`` raises as ``BadZipFile``; that is a broken publication rather
+    than a server fault, so it reads as one.
+
+    Raises:
+        InvalidEbookError: If the member is over the cap, or is not readable.
     """
-    return hashlib.sha256(f"{file_name}\0{crc}".encode()).hexdigest()[:_VERSION_LENGTH]
+    if entry.file_size > MAX_RESOURCE_BYTES:
+        raise InvalidEbookError(
+            f"resource {entry.filename!r} declares {entry.file_size} bytes, over the "
+            f"{MAX_RESOURCE_BYTES} limit",
+            "epub",
+        )
+    try:
+        with archive.open(entry) as member:
+            return member.read(entry.file_size + 1)
+    except (OSError, zipfile.BadZipFile, EOFError) as e:
+        raise InvalidEbookError(f"resource {entry.filename!r} cannot be read: {e!s}", "epub") from e
+
+
+def _version(stored: StoredEpub, path: str) -> str:
+    """Derive a resource's opaque version from the archive it came from and its path.
+
+    An entity tag has to identify the bytes being served, and within one
+    publication only two things bear on that: which archive it is, and which
+    member of it. So the recipe is a digest of the archive's own bytes, the
+    member's path, and the name the book is stored under.
+
+    The archive digest is doing the real work, and the alternatives do not.
+    Neither the member's CRC-32 nor its declared size identifies anything: two
+    empty files share a CRC, and forging a CRC-32 at a fixed length is
+    arithmetic rather than search, so a replaced member can present the same
+    path, size and checksum over different content. Nor can the stored file name
+    stand in for the archive, because a re-upload deliberately reuses it (see
+    ``_upload_epub``) -- there is no cheap field on the book row that reliably
+    changes when the bytes behind that name do. Hashing the archive is the one
+    signal that always does, and it costs a pass over bytes already in memory,
+    against a full EPUB parse this request is paying anyway.
+
+    The stored file name is mixed in as well, so that re-uploading the identical
+    EPUB under a fresh name still re-tags. That direction only over-invalidates,
+    which is the safe way to be wrong.
+
+    The limit worth stating: this identifies the *archive*, not the member's
+    decompressed bytes. Making it the latter would mean decompressing every
+    member on every conditional request -- exactly the cost the 304 path exists
+    to avoid -- for no gain, since equal archives serve equal members.
+    """
+    archive_digest = hashlib.sha256(stored.content).hexdigest()
+    identity = f"{stored.file_name}\0{archive_digest}\0{path}"
+    return hashlib.sha256(identity.encode()).hexdigest()[:_VERSION_LENGTH]

--- a/backend/src/infrastructure/web_reader/queries/publication_resource_query.py
+++ b/backend/src/infrastructure/web_reader/queries/publication_resource_query.py
@@ -1,0 +1,127 @@
+"""Query adapter serving one file out of a book's stored EPUB.
+
+The publication is parsed per request, exactly as the manifest endpoint parses
+it, because the parse is what says which files the publication *has* and what
+each one is. Holding the parse in a per-book cache is deliberately deferred to
+the measurement in #745 (ADR-0004 §4); until then the two endpoints pay the same
+cost in the same way rather than one of them growing a private shortcut.
+"""
+
+import asyncio
+import hashlib
+import zipfile
+from io import BytesIO
+from urllib.parse import unquote
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.application.library.protocols.file_repository import FileRepositoryProtocol
+from src.application.web_reader.protocols.publication_parser import PublicationParserProtocol
+from src.application.web_reader.publications import ParsedPublication
+from src.application.web_reader.queries.publication_resource import PublicationResourceView
+from src.domain.common.value_objects.ids import BookId, UserId
+from src.domain.web_reader.exceptions import PublicationResourceNotFoundError
+from src.infrastructure.web_reader.queries.stored_epub import StoredEpub, load_stored_epub
+
+# Long enough that two files of one book cannot collide by accident, short
+# enough to stay readable in a log line or a browser's network panel.
+_VERSION_LENGTH = 32
+
+
+class PublicationResourceQuery:
+    """Serves one file of a book's publication, byte-for-byte as the EPUB holds it."""
+
+    def __init__(
+        self,
+        db: AsyncSession,
+        file_repository: FileRepositoryProtocol,
+        publication_parser: PublicationParserProtocol,
+    ) -> None:
+        self.db = db
+        self.file_repository = file_repository
+        self.publication_parser = publication_parser
+
+    async def get_publication_resource(
+        self, book_id: BookId, user_id: UserId, path: str
+    ) -> PublicationResourceView | None:
+        """Return one file of a user's publication, or ``None`` when they have no such book.
+
+        Raises:
+            EbookFileNotFoundError: If the book exists but no EPUB is stored for it.
+            InvalidEbookError: If the stored EPUB cannot be parsed.
+            PublicationResourceNotFoundError: If the publication lists no such file.
+        """
+        stored = await load_stored_epub(self.db, self.file_repository, book_id, user_id)
+        if stored is None:
+            return None
+        # Parsing the publication and reading a member are both blocking and
+        # both CPU-bound, so they share one hop off the event loop rather than
+        # stalling every other request in the process for the duration.
+        return await asyncio.to_thread(self._read_member, stored, path)
+
+    def _read_member(self, stored: StoredEpub, path: str) -> PublicationResourceView:
+        """Find the requested file in the parsed publication and read it out of the archive."""
+        publication = self.publication_parser.parse_publication(stored.content)
+        media_type = _media_types_by_member(publication).get(path)
+        if media_type is None:
+            raise PublicationResourceNotFoundError(path)
+
+        with zipfile.ZipFile(BytesIO(stored.content)) as archive:
+            try:
+                entry = archive.getinfo(path)
+            except KeyError:
+                # A backstop, not an expected path: the parser reads every
+                # manifest item, so a package document naming a file the
+                # container does not hold fails the whole publication before
+                # this point. It stands so that any future divergence between
+                # what the parser lists and what the archive holds is a 404
+                # rather than an unhandled KeyError.
+                raise PublicationResourceNotFoundError(path) from None
+            content = archive.read(entry)
+
+        return PublicationResourceView(
+            media_type=media_type,
+            content=content,
+            version=_version(stored.file_name, entry.CRC),
+        )
+
+
+def _media_types_by_member(publication: ParsedPublication) -> dict[str, str]:
+    """Map each file the publication offers to the media type declared for it.
+
+    Membership in this map is the whole access rule, and it is why no separate
+    traversal guard is needed here. The keys come from the reading order and the
+    resources -- the two lists the manifest publishes -- so the package
+    document, ``META-INF/``, the ``mimetype`` member and anything else the
+    archive happens to carry are simply absent, as is any path the parser
+    already dropped for climbing out of the container. A request naming one of
+    those, absolute or relative, finds nothing and is a 404 rather than a served
+    file.
+
+    The manifest's hrefs are percent-encoded container-root paths, so decoding
+    one exactly once gives back the archive member's own name -- which is also
+    what the route hands us, ASGI having decoded the URL path exactly once. A
+    file whose name really does contain a percent sign therefore round-trips:
+    ``chapter%20one.xhtml`` is published as ``chapter%2520one.xhtml`` and comes
+    back as itself, not as ``chapter one.xhtml``.
+    """
+    return {
+        unquote(resource.href): resource.media_type
+        for resource in (*publication.reading_order, *publication.resources)
+    }
+
+
+def _version(file_name: str, crc: int) -> str:
+    """Derive a resource's opaque version from the book's file and the member's checksum.
+
+    The archive's own CRC-32 comes from the central directory, so no member is
+    decompressed to answer a conditional request that will not need its bytes.
+    A CRC is far too weak to be a content address, which is exactly why the
+    stored file name is mixed in: within one book two files with the same
+    contents are the same resource, and replacing the book's EPUB changes every
+    version at once even where a member survived byte-identical.
+
+    Hashing rather than concatenating keeps the storage file name off the wire,
+    an entity tag being something the client sees and echoes back.
+    """
+    return hashlib.sha256(f"{file_name}\0{crc}".encode()).hexdigest()[:_VERSION_LENGTH]

--- a/backend/src/infrastructure/web_reader/queries/stored_epub.py
+++ b/backend/src/infrastructure/web_reader/queries/stored_epub.py
@@ -1,0 +1,64 @@
+"""Getting at the EPUB behind a book row, shared by the web reader's query adapters.
+
+Every web reader view is served out of the book's stored EPUB rather than out of
+Postgres, so each adapter starts the same way: one row that says whether the
+caller may see this book and which file holds it, then the file itself. That
+opening is here so the manifest and the resource endpoint cannot drift on who
+may read what.
+"""
+
+from dataclasses import dataclass
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.application.library.protocols.file_repository import FileRepositoryProtocol
+from src.domain.common.value_objects.ids import BookId, UserId
+from src.domain.library.exceptions import EbookFileNotFoundError
+from src.infrastructure.library.orm.book_model import Book as BookORM
+
+
+@dataclass(frozen=True)
+class StoredEpub:
+    """A book's EPUB, with the little the book row itself contributes.
+
+    Attributes:
+        title: The library's title for the book, which stands in when the
+            package document states none.
+        file_name: The name the EPUB is stored under. Part of a resource's
+            entity tag, so that replacing a book's file invalidates every
+            cached resource of it at once.
+        content: The EPUB file's bytes.
+    """
+
+    title: str
+    file_name: str
+    content: bytes
+
+
+async def load_stored_epub(
+    db: AsyncSession,
+    file_repository: FileRepositoryProtocol,
+    book_id: BookId,
+    user_id: UserId,
+) -> StoredEpub | None:
+    """Load the EPUB stored for a user's book.
+
+    Returns:
+        The stored EPUB, or ``None`` when the user has no such book.
+
+    Raises:
+        EbookFileNotFoundError: If the book exists but no EPUB is stored for it.
+    """
+    stmt = select(BookORM.title, BookORM.ebook_file).where(
+        BookORM.id == book_id.value,
+        BookORM.user_id == user_id.value,
+    )
+    row = (await db.execute(stmt)).first()
+    if row is None:
+        return None
+
+    content = await file_repository.get_epub(row.ebook_file) if row.ebook_file else None
+    if not content:
+        raise EbookFileNotFoundError(book_id.value)
+    return StoredEpub(title=row.title, file_name=row.ebook_file, content=content)

--- a/backend/src/infrastructure/web_reader/queries/web_publication_query.py
+++ b/backend/src/infrastructure/web_reader/queries/web_publication_query.py
@@ -1,10 +1,12 @@
 """Query adapter for the Web Publication Manifest view.
 
 The one row Postgres holds for this view is the book itself -- which answers
-whether the caller may see it, and which EPUB to open. Everything the manifest
-renders comes out of that EPUB, so the adapter is constructed with the file
-store and the parser as well as the session, the way ``ReadingSessionQuery``
-takes the file store to read a session's text back out of a book.
+whether the caller may see it, and which EPUB to open, and which
+:func:`~src.infrastructure.web_reader.queries.stored_epub.load_stored_epub`
+reads. Everything the manifest renders comes out of that EPUB, so the adapter is
+constructed with the file store and the parser as well as the session, the way
+``ReadingSessionQuery`` takes the file store to read a session's text back out
+of a book.
 
 Nothing here decides anything: the EPUB's own package document is the authority
 on the reading order, and the only substitution the adapter makes is the stored
@@ -14,15 +16,13 @@ title, and only when the package document states none.
 import asyncio
 from dataclasses import replace
 
-from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.application.library.protocols.file_repository import FileRepositoryProtocol
 from src.application.web_reader.protocols.publication_parser import PublicationParserProtocol
 from src.application.web_reader.publications import ParsedPublication
 from src.domain.common.value_objects.ids import BookId, UserId
-from src.domain.library.exceptions import EbookFileNotFoundError
-from src.infrastructure.library.orm.book_model import Book as BookORM
+from src.infrastructure.web_reader.queries.stored_epub import load_stored_epub
 
 
 class WebPublicationQuery:
@@ -47,25 +47,19 @@ class WebPublicationQuery:
             EbookFileNotFoundError: If the book exists but no EPUB is stored for it.
             InvalidEbookError: If the stored EPUB cannot be parsed.
         """
-        stmt = select(BookORM.title, BookORM.ebook_file).where(
-            BookORM.id == book_id.value,
-            BookORM.user_id == user_id.value,
-        )
-        row = (await self.db.execute(stmt)).first()
-        if row is None:
+        stored = await load_stored_epub(self.db, self.file_repository, book_id, user_id)
+        if stored is None:
             return None
-
-        content = await self.file_repository.get_epub(row.ebook_file) if row.ebook_file else None
-        if not content:
-            raise EbookFileNotFoundError(book_id.value)
 
         # Parsing an EPUB is CPU-bound and proportional to the book, so it runs
         # off the event loop: this is a plain GET a reader issues on every open,
         # and a large publication parsed inline would stall every other request
         # in the process for the duration.
-        publication = await asyncio.to_thread(self.publication_parser.parse_publication, content)
+        publication = await asyncio.to_thread(
+            self.publication_parser.parse_publication, stored.content
+        )
         if publication.metadata.title:
             return publication
         # An EPUB with no dc:title is invalid but does occur, and a manifest
         # without one is unrenderable, so the library's title stands in.
-        return replace(publication, metadata=replace(publication.metadata, title=row.title))
+        return replace(publication, metadata=replace(publication.metadata, title=stored.title))

--- a/backend/src/infrastructure/web_reader/routers/readium.py
+++ b/backend/src/infrastructure/web_reader/routers/readium.py
@@ -17,6 +17,7 @@ from src.application.web_reader.queries.get_publication_resource_use_case import
 from src.application.web_reader.queries.get_web_publication_use_case import (
     GetWebPublicationUseCase,
 )
+from src.application.web_reader.queries.publication_resource import ANY_VERSION
 from src.core import container
 from src.infrastructure.common.di import inject_use_case
 from src.infrastructure.web_reader.dependencies import PublicationReader
@@ -120,10 +121,15 @@ async def get_readium_resource(
         book_id=book_id,
         user_id=current_user.id.value,
         path=path,
+        known_versions=_known_versions(request.headers.get("if-none-match")),
     )
-    etag = f'"{resource.version}"'
-    headers = {"ETag": etag, "Cache-Control": RESOURCE_CACHE_CONTROL}
-    if _already_holds(request.headers.get("if-none-match"), etag):
+    headers = {
+        "ETag": f'"{resource.version}"',
+        "Cache-Control": RESOURCE_CACHE_CONTROL,
+    }
+    # No content means the caller's copy is current -- and, because it was asked
+    # up front, means the file was never decompressed to find that out.
+    if resource.content is None:
         return Response(status_code=status.HTTP_304_NOT_MODIFIED, headers=headers)
     # Content-Type goes in the headers rather than through `media_type`, which
     # would append `; charset=utf-8` to every `text/*` type. The bytes are
@@ -152,23 +158,23 @@ def _servable_media_type(declared: str) -> str:
     return declared if _MEDIA_TYPE.fullmatch(declared) else FALLBACK_MEDIA_TYPE
 
 
-def _already_holds(if_none_match: str | None, etag: str) -> bool:
-    """Decide whether a conditional request may be answered with 304.
+def _known_versions(if_none_match: str | None) -> frozenset[str]:
+    """Read the versions a caller says it already holds out of ``If-None-Match``.
 
-    RFC 9110 §13.1.2: ``*`` matches any current representation, and a list of
-    tags is compared weakly, so ``W/"x"`` and ``"x"`` are the same version of
-    the same file.
+    They are handed to the read, rather than compared against what comes back,
+    so that a file the caller already has is never decompressed to answer that
+    it has it.
+
+    RFC 9110 §13.1.2: ``*`` stands for any current representation, and the tags
+    are compared weakly, so ``W/"x"`` and ``"x"`` name the same version. Unwrapping
+    them here leaves the read with plain version strings and no HTTP syntax.
     """
     if not if_none_match:
-        return False
-    if if_none_match.strip() == "*":
-        return True
-    return any(_strong(tag.strip()) == _strong(etag) for tag in if_none_match.split(","))
-
-
-def _strong(entity_tag: str) -> str:
-    """Drop a weak validator's prefix, leaving the tag itself."""
-    return entity_tag.removeprefix("W/")
+        return frozenset()
+    tags = [tag.strip() for tag in if_none_match.split(",")]
+    if ANY_VERSION in tags:
+        return frozenset({ANY_VERSION})
+    return frozenset(tag.removeprefix("W/").strip('"') for tag in tags)
 
 
 def _manifest(publication: ParsedPublication, self_href: str) -> WebPublicationManifest:

--- a/backend/src/infrastructure/web_reader/routers/readium.py
+++ b/backend/src/infrastructure/web_reader/routers/readium.py
@@ -55,6 +55,10 @@ RESOURCE_CACHE_CONTROL = "private"
 _MEDIA_TYPE = re.compile(r"[A-Za-z0-9][A-Za-z0-9!#$&^_.+-]*/[A-Za-z0-9][A-Za-z0-9!#$&^_.+-]*")
 FALLBACK_MEDIA_TYPE = "application/octet-stream"
 
+# An entity-tag as RFC 9110 §8.8.3 spells one: an optionally `W/`-prefixed
+# quoted string, whose content is any visible character but the quote itself.
+_ENTITY_TAG = re.compile(r'(?:W/)?"(?P<version>[\x21\x23-\x7e]*)"')
+
 
 class WebpubJSONResponse(JSONResponse):
     """JSON served as ``application/webpub+json``, which is what a navigator looks for."""
@@ -165,16 +169,27 @@ def _known_versions(if_none_match: str | None) -> frozenset[str]:
     so that a file the caller already has is never decompressed to answer that
     it has it.
 
-    RFC 9110 §13.1.2: ``*`` stands for any current representation, and the tags
-    are compared weakly, so ``W/"x"`` and ``"x"`` name the same version. Unwrapping
-    them here leaves the read with plain version strings and no HTTP syntax.
+    ``*`` stands for any current representation (RFC 9110 §13.1.2), and only on
+    its own -- mixed with tags it is not a header the grammar defines.
+
+    Everything else is read as the grammar spells it (§8.8.3): an entity-tag is
+    a quoted string, optionally prefixed ``W/``, and the comparison for a GET is
+    weak, so ``W/"x"`` and ``"x"`` name the same version. Anything that is not
+    an entity-tag is dropped rather than repaired -- unwrapping optional quotes
+    would let a bare token match, and answering 304 to a validator the standard
+    does not define means telling a reader its copy is current on no authority.
+    Dropping it serves the file, which is the harmless way to be unsure.
+
+    A tag may itself contain a comma, which splitting cannot honour; such a tag
+    matches nothing and the file is served. Ours are hexadecimal, so this costs
+    a revalidation only to a client echoing a tag it did not get from here.
     """
     if not if_none_match:
         return frozenset()
-    tags = [tag.strip() for tag in if_none_match.split(",")]
-    if ANY_VERSION in tags:
+    if if_none_match.strip() == ANY_VERSION:
         return frozenset({ANY_VERSION})
-    return frozenset(tag.removeprefix("W/").strip('"') for tag in tags)
+    parsed = (_ENTITY_TAG.fullmatch(tag.strip()) for tag in if_none_match.split(","))
+    return frozenset(tag.group("version") for tag in parsed if tag is not None)
 
 
 def _manifest(publication: ParsedPublication, self_href: str) -> WebPublicationManifest:

--- a/backend/src/infrastructure/web_reader/routers/readium.py
+++ b/backend/src/infrastructure/web_reader/routers/readium.py
@@ -1,8 +1,8 @@
-"""API router serving the Readium Web Publication Manifest."""
+"""API router serving the Readium Web Publication Manifest and the files it names."""
 
-from typing import Annotated
+import re
 
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Depends, Request, Response
 from fastapi.responses import JSONResponse
 from starlette import status
 
@@ -11,13 +11,15 @@ from src.application.web_reader.publications import (
     PublicationResource,
     TocEntry,
 )
+from src.application.web_reader.queries.get_publication_resource_use_case import (
+    GetPublicationResourceUseCase,
+)
 from src.application.web_reader.queries.get_web_publication_use_case import (
     GetWebPublicationUseCase,
 )
 from src.core import container
-from src.domain.identity import User
 from src.infrastructure.common.di import inject_use_case
-from src.infrastructure.identity import get_current_user
+from src.infrastructure.web_reader.dependencies import PublicationReader
 from src.infrastructure.web_reader.schemas.readium_schemas import (
     POSITION_LIST_REL,
     WEBPUB_MEDIA_TYPE,
@@ -42,6 +44,16 @@ POSITION_LIST_HREF = "positions.json"
 # href, so the entry keeps its title and points at the manifest itself.
 UNLINKED_TOC_HREF = "#"
 
+# A publication is one user's book, so a shared cache must not hold it. Within
+# the browser's own cache the entity tag does the revalidating, and there is no
+# max-age: a book's file can be replaced under it at any time.
+RESOURCE_CACHE_CONTROL = "private"
+
+# A media type as RFC 9110 §8.3.1 writes one, with no parameters, which is all
+# an EPUB's package document ever declares.
+_MEDIA_TYPE = re.compile(r"[A-Za-z0-9][A-Za-z0-9!#$&^_.+-]*/[A-Za-z0-9][A-Za-z0-9!#$&^_.+-]*")
+FALLBACK_MEDIA_TYPE = "application/octet-stream"
+
 
 class WebpubJSONResponse(JSONResponse):
     """JSON served as ``application/webpub+json``, which is what a navigator looks for."""
@@ -58,7 +70,7 @@ class WebpubJSONResponse(JSONResponse):
 async def get_readium_manifest(
     book_id: int,
     request: Request,
-    current_user: Annotated[User, Depends(get_current_user)],
+    current_user: PublicationReader,
     use_case: GetWebPublicationUseCase = Depends(
         inject_use_case(container.web_reader.get_web_publication_use_case)
     ),
@@ -72,6 +84,91 @@ async def get_readium_manifest(
     return WebpubJSONResponse(
         content=manifest.model_dump(mode="json", by_alias=True, exclude_none=True)
     )
+
+
+@router.get(
+    "/books/{book_id}/resources/{path:path}",
+    response_class=Response,
+    status_code=status.HTTP_200_OK,
+    responses={
+        status.HTTP_200_OK: {
+            "content": {"*/*": {"schema": {"type": "string", "format": "binary"}}},
+            "description": "The file, under the media type the publication declares for it.",
+        },
+        status.HTTP_304_NOT_MODIFIED: {"description": "The caller already holds this version."},
+    },
+)
+async def get_readium_resource(
+    book_id: int,
+    path: str,
+    request: Request,
+    current_user: PublicationReader,
+    use_case: GetPublicationResourceUseCase = Depends(
+        inject_use_case(container.web_reader.get_publication_resource_use_case)
+    ),
+) -> Response:
+    """Get one file of a book's publication, unchanged.
+
+    ``path`` is a manifest href with the ``resources/`` prefix stripped, so it
+    arrives here as the container-root path the reading order or the resource
+    list published -- decoded once by ASGI, which is the archive member's own
+    name. Only the files the manifest names are reachable; the package document
+    and ``META-INF/`` are not part of the publication and answer 404 like any
+    other path the manifest does not list.
+    """
+    resource = await use_case.get_publication_resource(
+        book_id=book_id,
+        user_id=current_user.id.value,
+        path=path,
+    )
+    etag = f'"{resource.version}"'
+    headers = {"ETag": etag, "Cache-Control": RESOURCE_CACHE_CONTROL}
+    if _already_holds(request.headers.get("if-none-match"), etag):
+        return Response(status_code=status.HTTP_304_NOT_MODIFIED, headers=headers)
+    # Content-Type goes in the headers rather than through `media_type`, which
+    # would append `; charset=utf-8` to every `text/*` type. The bytes are
+    # served unchanged and an EPUB's documents declare their own encoding, so
+    # the type the package document stated is the honest one to send.
+    #
+    # The whole file is read rather than streamed. Its bytes are already in
+    # memory -- the EPUB was loaded whole to be parsed at all -- so streaming
+    # would add chunking around a buffer that exists either way, and would only
+    # start paying off once resources are served without parsing the
+    # publication first (#745).
+    content_type = _servable_media_type(resource.media_type)
+    return Response(content=resource.content, headers=headers | {"Content-Type": content_type})
+
+
+def _servable_media_type(declared: str) -> str:
+    """Keep a package document's media type out of the response unless it is one.
+
+    The type is copied from a file the user uploaded, so it reaches here as
+    arbitrary text. Anything but a plain ``type/subtype`` is replaced rather
+    than echoed: a value carrying a newline would smuggle a second header into
+    the response, and one carrying a character outside Latin-1 would fail to
+    encode at all. A publication that mislabels a file this way still serves,
+    under the type a browser will not act on.
+    """
+    return declared if _MEDIA_TYPE.fullmatch(declared) else FALLBACK_MEDIA_TYPE
+
+
+def _already_holds(if_none_match: str | None, etag: str) -> bool:
+    """Decide whether a conditional request may be answered with 304.
+
+    RFC 9110 §13.1.2: ``*`` matches any current representation, and a list of
+    tags is compared weakly, so ``W/"x"`` and ``"x"`` are the same version of
+    the same file.
+    """
+    if not if_none_match:
+        return False
+    if if_none_match.strip() == "*":
+        return True
+    return any(_strong(tag.strip()) == _strong(etag) for tag in if_none_match.split(","))
+
+
+def _strong(entity_tag: str) -> str:
+    """Drop a weak validator's prefix, leaving the tag itself."""
+    return entity_tag.removeprefix("W/")
 
 
 def _manifest(publication: ParsedPublication, self_href: str) -> WebPublicationManifest:

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -338,6 +338,22 @@ async def test_user(db_session: AsyncSession) -> User:
     return user
 
 
+@pytest.fixture
+async def other_user(db_session: AsyncSession, test_user: User) -> User:
+    """Somebody who is not the authenticated user, for the isolation case.
+
+    Every endpoint gets one: a dropped ``user_id`` filter is this app's worst
+    realistic bug class, and only a test that owns a second user's data catches
+    it.
+    """
+    stranger = User(email="stranger@example.com", hashed_password="x")
+    db_session.add(stranger)
+    await db_session.commit()
+    await db_session.refresh(stranger)
+    assert stranger.id != test_user.id
+    return stranger
+
+
 def contract_checked_queue() -> AsyncMock:
     """A fake job queue that checks each enqueue against the real SAQ task.
 

--- a/backend/tests/test_readium_manifest.py
+++ b/backend/tests/test_readium_manifest.py
@@ -569,18 +569,12 @@ class TestManifestAccess:
         self,
         client: AsyncClient,
         db_session: AsyncSession,
-        test_user: User,
+        other_user: User,
         storage_dir: Path,
     ) -> None:
         """Should answer 404 for a readable EPUB belonging to somebody else."""
-        stranger = User(email="stranger@example.com", hashed_password="x")
-        db_session.add(stranger)
-        await db_session.commit()
-        await db_session.refresh(stranger)
-        assert stranger.id != test_user.id
-
         their_book = await create_test_book(
-            db_session=db_session, user_id=stranger.id, title="Not Yours"
+            db_session=db_session, user_id=other_user.id, title="Not Yours"
         )
         await store_epub(db_session, their_book, storage_dir, fixture_bytes("minimal.epub"))
 

--- a/backend/tests/test_readium_manifest.py
+++ b/backend/tests/test_readium_manifest.py
@@ -87,13 +87,20 @@ def build_epub(
     spine: str,
     nav_links: str,
     files: tuple[str, ...] = (),
+    bodies: dict[str, bytes] | None = None,
+    compression: int = zipfile.ZIP_STORED,
 ) -> bytes:
     """Assemble an EPUB by hand, so an adversarial one reads as such in the diff.
 
     The fixture files on disk are ordinary books; these are the shapes a hostile
     or broken publication takes, and writing the OPF out here is what makes the
     attack visible next to the assertion about it.
+
+    Every name in ``files`` gets a placeholder document unless ``bodies`` gives
+    it content of its own, which is what lets a test pin the exact bytes of one
+    member.
     """
+    bodies = bodies or {}
     package = (
         '<?xml version="1.0" encoding="UTF-8"?>\n'
         '<package xmlns="http://www.idpf.org/2007/opf" version="3.0" unique-identifier="i">\n'
@@ -117,7 +124,7 @@ def build_epub(
     )
 
     out = BytesIO()
-    with zipfile.ZipFile(out, "w") as archive:
+    with zipfile.ZipFile(out, "w", compression) as archive:
         archive.writestr(zipfile.ZipInfo("mimetype"), "application/epub+zip", zipfile.ZIP_STORED)
         archive.writestr(
             "META-INF/container.xml",
@@ -130,7 +137,7 @@ def build_epub(
         archive.writestr("content.opf", package)
         archive.writestr("nav.xhtml", nav)
         for name in files:
-            archive.writestr(name, document)
+            archive.writestr(name, bodies.get(name, document.encode()))
     return out.getvalue()
 
 

--- a/backend/tests/test_readium_resources.py
+++ b/backend/tests/test_readium_resources.py
@@ -94,6 +94,21 @@ def crc32_twin(payload: bytes) -> bytes:
     raise AssertionError("no CRC-32 collision found")
 
 
+# Two resources that are both empty, and so share a CRC-32 of zero. Anything
+# that tells them apart has to be reading more than the checksum.
+TWIN_EMPTY_MEMBERS_EPUB = build_epub(
+    manifest_items=(
+        '<item id="c1" href="c1.xhtml" media-type="application/xhtml+xml"/>'
+        '<item id="a" href="a.css" media-type="text/css"/>'
+        '<item id="b" href="b.css" media-type="text/css"/>'
+    ),
+    spine='<itemref idref="c1"/>',
+    nav_links='<li><a href="c1.xhtml">One</a></li>',
+    files=("c1.xhtml", "a.css", "b.css"),
+    bodies={"a.css": b"", "b.css": b""},
+)
+
+
 def understating_epub(member: str, real_size: int) -> bytes:
     """An EPUB whose one resource inflates far past the size it declares.
 
@@ -361,22 +376,7 @@ class TestTheEtagIdentifiesTheBytes:
         alone is the same tag for both. A reader that had fetched one would then
         be told its copy of the *other* was current.
         """
-        await store_epub(
-            db_session,
-            test_book,
-            storage_dir,
-            build_epub(
-                manifest_items=(
-                    '<item id="c1" href="c1.xhtml" media-type="application/xhtml+xml"/>'
-                    '<item id="a" href="a.css" media-type="text/css"/>'
-                    '<item id="b" href="b.css" media-type="text/css"/>'
-                ),
-                spine='<itemref idref="c1"/>',
-                nav_links='<li><a href="c1.xhtml">One</a></li>',
-                files=("c1.xhtml", "a.css", "b.css"),
-                bodies={"a.css": b"", "b.css": b""},
-            ),
-        )
+        await store_epub(db_session, test_book, storage_dir, TWIN_EMPTY_MEMBERS_EPUB)
 
         first = await client.get(resource_url(test_book, "a.css"))
         second = await client.get(resource_url(test_book, "b.css"))
@@ -392,22 +392,7 @@ class TestTheEtagIdentifiesTheBytes:
         storage_dir: Path,
     ) -> None:
         """Should not answer 304 to a tag that was issued for a different file."""
-        await store_epub(
-            db_session,
-            test_book,
-            storage_dir,
-            build_epub(
-                manifest_items=(
-                    '<item id="c1" href="c1.xhtml" media-type="application/xhtml+xml"/>'
-                    '<item id="a" href="a.css" media-type="text/css"/>'
-                    '<item id="b" href="b.css" media-type="text/css"/>'
-                ),
-                spine='<itemref idref="c1"/>',
-                nav_links='<li><a href="c1.xhtml">One</a></li>',
-                files=("c1.xhtml", "a.css", "b.css"),
-                bodies={"a.css": b"", "b.css": b""},
-            ),
-        )
+        await store_epub(db_session, test_book, storage_dir, TWIN_EMPTY_MEMBERS_EPUB)
         for_a = (await client.get(resource_url(test_book, "a.css"))).headers["etag"]
 
         response = await client.get(
@@ -494,12 +479,13 @@ class TestDecompressionIsBounded:
         test_book: Book,
         storage_dir: Path,
     ) -> None:
-        """Should not inflate a member that lies its way past the cap.
+        """Should refuse a member that lies about its size rather than serve it.
 
-        The declared size is what the cap can check for free, so a bomb declares
-        a small one. Reading no more than the declaration is what keeps the lie
-        from costing anything: the member here really inflates to a megabyte
-        from an archive of a few hundred bytes.
+        This is the outcome only. What the endpoint spends getting there is not
+        visible from out here, because the shared parser reads every manifest
+        item before this endpoint sees one -- see
+        ``tests/unit/infrastructure/web_reader/test_publication_resource_query.py``
+        for the assertion about the bytes this endpoint's own read allocates.
         """
         await store_epub(
             db_session, test_book, storage_dir, understating_epub("big.css", 1024 * 1024)

--- a/backend/tests/test_readium_resources.py
+++ b/backend/tests/test_readium_resources.py
@@ -13,7 +13,9 @@ Only the files the manifest lists are reachable. The package document,
 publication, and the endpoint must not serve them.
 """
 
+import struct
 import zipfile
+import zlib
 from collections.abc import AsyncGenerator
 from io import BytesIO
 from pathlib import Path
@@ -23,6 +25,7 @@ from httpx import ASGITransport, AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 from starlette import status
 
+from src.infrastructure.web_reader.queries import publication_resource_query
 from src.main import app
 from src.models import Book, User
 from tests.conftest import create_test_book
@@ -48,6 +51,72 @@ def member_bytes(epub_content: bytes, name: str) -> bytes:
     """What the archive really holds under ``name``, to compare a response against."""
     with zipfile.ZipFile(BytesIO(epub_content)) as archive:
         return archive.read(name)
+
+
+def crc32_twin(payload: bytes) -> bytes:
+    """Different bytes of the same length with the same CRC-32.
+
+    CRC-32 is affine over GF(2) -- ``crc(x) = A(x) ^ crc(0)`` for a linear
+    ``A`` -- so two equal-length messages collide exactly when their difference
+    lies in ``A``'s kernel. Thirty-three single-bit differences are necessarily
+    dependent in a 32-bit space, so eliminating them against each other finds a
+    kernel vector to XOR in. Forging one is this cheap, which is the whole point
+    of the tests below: a CRC is a transmission check, never an identity.
+    """
+    length = len(payload)
+    assert length >= 5, "needs five bytes to hold thirty-three differing bits"
+    zero = zlib.crc32(bytes(length))
+    pivots: dict[int, tuple[int, int]] = {}
+
+    for bit in range(33):
+        probe = bytearray(length)
+        probe[bit // 8] |= 1 << (bit % 8)
+        delta = zlib.crc32(bytes(probe)) ^ zero
+        used = 1 << bit
+        while delta:
+            high = delta.bit_length() - 1
+            if high not in pivots:
+                pivots[high] = (delta, used)
+                break
+            other_delta, other_used = pivots[high]
+            delta ^= other_delta
+            used ^= other_used
+        else:
+            mask = bytearray(length)
+            for i in range(33):
+                if used >> i & 1:
+                    mask[i // 8] ^= 1 << (i % 8)
+            twin = bytes(b ^ m for b, m in zip(payload, mask, strict=True))
+            assert twin != payload
+            assert zlib.crc32(twin) == zlib.crc32(payload)
+            return twin
+
+    raise AssertionError("no CRC-32 collision found")
+
+
+def understating_epub(member: str, real_size: int) -> bytes:
+    """An EPUB whose one resource inflates far past the size it declares.
+
+    Both the local header and the central directory are rewritten, so nothing
+    short of decompressing the member can tell how big it really is. This is the
+    shape a decompression bomb takes once a size cap exists to get past.
+    """
+    epub = bytearray(
+        build_epub(
+            manifest_items=(
+                '<item id="c1" href="c1.xhtml" media-type="application/xhtml+xml"/>'
+                '<item id="big" href="big.css" media-type="text/css"/>'
+            ),
+            spine='<itemref idref="c1"/>',
+            nav_links='<li><a href="c1.xhtml">One</a></li>',
+            files=("c1.xhtml", member),
+            bodies={member: b"A" * real_size},
+            compression=zipfile.ZIP_DEFLATED,
+        )
+    )
+    for signature, offset in ((b"PK\x03\x04", 22), (b"PK\x01\x02", 24)):
+        struct.pack_into("<I", epub, epub.rfind(signature) + offset, 8)
+    return bytes(epub)
 
 
 @pytest.fixture
@@ -274,6 +343,195 @@ class TestConditionalRequests:
 
         assert response.status_code == status.HTTP_200_OK
         assert response.content
+
+
+class TestTheEtagIdentifiesTheBytes:
+    """An entity tag has to name the representation, not merely a checksum of it."""
+
+    async def test_two_empty_members_do_not_share_an_etag(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        test_book: Book,
+        storage_dir: Path,
+    ) -> None:
+        """Should tell two files apart even when their contents check out the same.
+
+        Two empty files have the same CRC-32, so a tag built from the checksum
+        alone is the same tag for both. A reader that had fetched one would then
+        be told its copy of the *other* was current.
+        """
+        await store_epub(
+            db_session,
+            test_book,
+            storage_dir,
+            build_epub(
+                manifest_items=(
+                    '<item id="c1" href="c1.xhtml" media-type="application/xhtml+xml"/>'
+                    '<item id="a" href="a.css" media-type="text/css"/>'
+                    '<item id="b" href="b.css" media-type="text/css"/>'
+                ),
+                spine='<itemref idref="c1"/>',
+                nav_links='<li><a href="c1.xhtml">One</a></li>',
+                files=("c1.xhtml", "a.css", "b.css"),
+                bodies={"a.css": b"", "b.css": b""},
+            ),
+        )
+
+        first = await client.get(resource_url(test_book, "a.css"))
+        second = await client.get(resource_url(test_book, "b.css"))
+
+        assert first.status_code == second.status_code == status.HTTP_200_OK
+        assert first.headers["etag"] != second.headers["etag"]
+
+    async def test_one_members_etag_does_not_satisfy_another(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        test_book: Book,
+        storage_dir: Path,
+    ) -> None:
+        """Should not answer 304 to a tag that was issued for a different file."""
+        await store_epub(
+            db_session,
+            test_book,
+            storage_dir,
+            build_epub(
+                manifest_items=(
+                    '<item id="c1" href="c1.xhtml" media-type="application/xhtml+xml"/>'
+                    '<item id="a" href="a.css" media-type="text/css"/>'
+                    '<item id="b" href="b.css" media-type="text/css"/>'
+                ),
+                spine='<itemref idref="c1"/>',
+                nav_links='<li><a href="c1.xhtml">One</a></li>',
+                files=("c1.xhtml", "a.css", "b.css"),
+                bodies={"a.css": b"", "b.css": b""},
+            ),
+        )
+        for_a = (await client.get(resource_url(test_book, "a.css"))).headers["etag"]
+
+        response = await client.get(
+            resource_url(test_book, "b.css"), headers={"If-None-Match": for_a}
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+
+    async def test_a_replacement_member_with_a_forged_crc_still_retags(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        test_book: Book,
+        storage_dir: Path,
+    ) -> None:
+        """Should re-tag a replaced EPUB even when the member looks identical.
+
+        A re-upload keeps the storage filename, so the name cannot say the bytes
+        changed. Nor can the member's own central-directory record: forging a
+        CRC-32 at a fixed length is arithmetic, so a replacement can present the
+        same path, the same declared size and the same checksum over different
+        content. Serving the old bytes from a reader's cache for as long as it
+        keeps them is the failure this rules out.
+        """
+        original = b"body{color:red}"
+        twin = crc32_twin(original)
+
+        def epub_with(style: bytes) -> bytes:
+            return build_epub(
+                manifest_items=(
+                    '<item id="c1" href="c1.xhtml" media-type="application/xhtml+xml"/>'
+                    '<item id="s" href="style.css" media-type="text/css"/>'
+                ),
+                spine='<itemref idref="c1"/>',
+                nav_links='<li><a href="c1.xhtml">One</a></li>',
+                files=("c1.xhtml", "style.css"),
+                bodies={"style.css": style},
+            )
+
+        await store_epub(db_session, test_book, storage_dir, epub_with(original))
+        before = await client.get(resource_url(test_book, "style.css"))
+
+        # The same storage filename, as a real re-upload would reuse.
+        await store_epub(db_session, test_book, storage_dir, epub_with(twin))
+        after = await client.get(resource_url(test_book, "style.css"))
+
+        assert before.content == original
+        assert after.content == twin
+        assert after.content != before.content
+        assert after.headers["etag"] != before.headers["etag"]
+
+        stale = await client.get(
+            resource_url(test_book, "style.css"),
+            headers={"If-None-Match": before.headers["etag"]},
+        )
+        assert stale.status_code == status.HTTP_200_OK
+        assert stale.content == twin
+
+
+class TestDecompressionIsBounded:
+    """A publication is a file the user uploaded, so its members are not read on trust."""
+
+    async def test_refuses_a_member_larger_than_the_cap(
+        self,
+        client: AsyncClient,
+        nested_toc_book: Book,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Should turn away an oversized member rather than decompress it.
+
+        The cap is lowered rather than the fixture inflated: a real member big
+        enough to trip the limit would only make the test slow.
+        """
+        monkeypatch.setattr(publication_resource_query, "MAX_RESOURCE_BYTES", 10)
+
+        response = await client.get(resource_url(nested_toc_book, CHAPTER_1))
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    async def test_refuses_a_member_that_understates_its_size(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        test_book: Book,
+        storage_dir: Path,
+    ) -> None:
+        """Should not inflate a member that lies its way past the cap.
+
+        The declared size is what the cap can check for free, so a bomb declares
+        a small one. Reading no more than the declaration is what keeps the lie
+        from costing anything: the member here really inflates to a megabyte
+        from an archive of a few hundred bytes.
+        """
+        await store_epub(
+            db_session, test_book, storage_dir, understating_epub("big.css", 1024 * 1024)
+        )
+
+        response = await client.get(resource_url(test_book, "big.css"))
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert len(response.content) < 1024
+
+    async def test_a_conditional_request_decompresses_nothing(
+        self,
+        client: AsyncClient,
+        nested_toc_book: Book,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Should answer 304 without reading the member at all.
+
+        Everything the tag is made of comes from the archive's directory, so a
+        reader that already holds a file should cost no decompression. Dropping
+        the cap to nothing is what makes that observable: any attempt to read
+        the member would be refused, so a 304 can only mean none was made.
+        """
+        etag = (await client.get(resource_url(nested_toc_book, CHAPTER_1))).headers["etag"]
+        monkeypatch.setattr(publication_resource_query, "MAX_RESOURCE_BYTES", 0)
+
+        response = await client.get(
+            resource_url(nested_toc_book, CHAPTER_1), headers={"If-None-Match": etag}
+        )
+
+        assert response.status_code == status.HTTP_304_NOT_MODIFIED
+        assert response.content == b""
 
 
 class TestOnlyPublicationFilesAreReachable:

--- a/backend/tests/test_readium_resources.py
+++ b/backend/tests/test_readium_resources.py
@@ -505,12 +505,17 @@ class TestDecompressionIsBounded:
         """Should answer 304 without reading the member at all.
 
         Everything the tag is made of comes from the archive's directory, so a
-        reader that already holds a file should cost no decompression. Dropping
-        the cap to nothing is what makes that observable: any attempt to read
-        the member would be refused, so a 304 can only mean none was made.
+        reader that already holds a file should cost no decompression. Only the
+        ordering separates the two from outside, so the spy is the assertion.
         """
         etag = (await client.get(resource_url(nested_toc_book, CHAPTER_1))).headers["etag"]
-        monkeypatch.setattr(publication_resource_query, "MAX_RESOURCE_BYTES", 0)
+        reads: list[str] = []
+
+        def refuse(archive: object, entry: zipfile.ZipInfo) -> bytes:
+            reads.append(entry.filename)
+            raise AssertionError("decompressed a member to answer a conditional request")
+
+        monkeypatch.setattr(publication_resource_query, "read_bounded_member", refuse)
 
         response = await client.get(
             resource_url(nested_toc_book, CHAPTER_1), headers={"If-None-Match": etag}
@@ -518,6 +523,60 @@ class TestDecompressionIsBounded:
 
         assert response.status_code == status.HTTP_304_NOT_MODIFIED
         assert response.content == b""
+        assert reads == []
+
+    async def test_the_size_policy_outranks_a_precondition(
+        self,
+        client: AsyncClient,
+        nested_toc_book: Book,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Should refuse an unservable member even to a caller that would take a 304.
+
+        A precondition narrows a request that would otherwise succeed (RFC 9110
+        §13.2). It cannot make one succeed that would not, so ``If-None-Match: *``
+        must not turn a refusal into "your copy is current" -- which would leave
+        a reader believing a file it can never fetch is up to date.
+        """
+        monkeypatch.setattr(publication_resource_query, "MAX_RESOURCE_BYTES", 10)
+
+        response = await client.get(
+            resource_url(nested_toc_book, CHAPTER_1), headers={"If-None-Match": "*"}
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    @pytest.mark.parametrize(
+        "template",
+        [
+            "{version}",
+            "W/{version}",
+            '"{version}',
+            '{version}"',
+            "'{version}'",
+        ],
+    )
+    async def test_a_malformed_validator_does_not_match(
+        self, client: AsyncClient, nested_toc_book: Book, template: str
+    ) -> None:
+        """Should serve the file when the validator is not an entity-tag.
+
+        RFC 9110 §8.8.3 spells an entity-tag as an optionally ``W/``-prefixed
+        *quoted* string. Unwrapping optional quotes instead of reading the
+        grammar would let a bare token match, so a client that dropped the
+        quotes would be told its copy was current on the strength of a header
+        the standard does not define.
+        """
+        etag = (await client.get(resource_url(nested_toc_book, CHAPTER_1))).headers["etag"]
+        malformed = template.format(version=etag.strip('"'))
+        assert malformed != etag
+
+        response = await client.get(
+            resource_url(nested_toc_book, CHAPTER_1), headers={"If-None-Match": malformed}
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.content
 
 
 class TestOnlyPublicationFilesAreReachable:

--- a/backend/tests/test_readium_resources.py
+++ b/backend/tests/test_readium_resources.py
@@ -1,0 +1,418 @@
+"""Tests for the endpoint serving a publication's own files to the web reader.
+
+The paths asked for here are the manifest's hrefs with ``resources/`` stripped,
+because that is exactly how a navigator reaches them: it resolves each href
+against the manifest URL and fetches what comes out. So the fixtures are the
+manifest's fixtures, and a name that survives the round trip through the URL is
+the point rather than a detail -- ``nested_toc.epub`` carries a space and
+non-ASCII letters, and ``LITERAL_PERCENT_EPUB`` carries a real percent sign,
+which is the one name that a decode too many turns into a different file.
+
+Only the files the manifest lists are reachable. The package document,
+``META-INF/`` and the archive's ``mimetype`` member are in every EPUB and in no
+publication, and the endpoint must not serve them.
+"""
+
+import zipfile
+from collections.abc import AsyncGenerator
+from io import BytesIO
+from pathlib import Path
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+from starlette import status
+
+from src.main import app
+from src.models import Book, User
+from tests.conftest import create_test_book
+from tests.test_readium_manifest import (
+    LITERAL_PERCENT_EPUB,
+    build_epub,
+    fixture_bytes,
+    store_epub,
+)
+
+CHAPTER_1 = "EPUB/text/chapter%201.xhtml"
+CHAPTER_AANI = "EPUB/text/luku-%C3%A4%C3%A4ni.xhtml"
+STYLESHEET = "EPUB/styles/main.css"
+COVER_ART = "EPUB/images/cover%20art.png"
+
+
+def resource_url(book: Book, href: str) -> str:
+    """The URL a navigator resolves for a manifest href, ``resources/`` and all."""
+    return f"/api/v1/readium/books/{book.id}/resources/{href}"
+
+
+def member_bytes(epub_content: bytes, name: str) -> bytes:
+    """What the archive really holds under ``name``, to compare a response against."""
+    with zipfile.ZipFile(BytesIO(epub_content)) as archive:
+        return archive.read(name)
+
+
+@pytest.fixture
+async def anonymous_client() -> AsyncGenerator[AsyncClient, None]:
+    """A client with no authentication override, to see what the endpoint demands."""
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as unauthenticated:
+        yield unauthenticated
+
+
+@pytest.fixture
+async def nested_toc_book(db_session: AsyncSession, test_book: Book, storage_dir: Path) -> Book:
+    """A book whose EPUB has awkward file names, styles and an image."""
+    await store_epub(db_session, test_book, storage_dir, fixture_bytes("nested_toc.epub"))
+    return test_book
+
+
+class TestServingPublicationFiles:
+    """What GET /api/v1/readium/books/{id}/resources/{path} returns for a real book."""
+
+    async def test_serves_a_chapter_unchanged(
+        self, client: AsyncClient, nested_toc_book: Book
+    ) -> None:
+        """Should return the archive's own bytes under the declared media type."""
+        response = await client.get(resource_url(nested_toc_book, CHAPTER_1))
+
+        assert response.status_code == status.HTTP_200_OK, response.text
+        assert response.content == member_bytes(
+            fixture_bytes("nested_toc.epub"), "EPUB/text/chapter 1.xhtml"
+        )
+        assert b"<html" in response.content
+        assert response.headers["content-type"] == "application/xhtml+xml"
+        assert response.headers["cache-control"] == "private"
+
+    async def test_serves_a_stylesheet(self, client: AsyncClient, nested_toc_book: Book) -> None:
+        """Should serve a supporting resource, not only the reading order."""
+        response = await client.get(resource_url(nested_toc_book, STYLESHEET))
+
+        assert response.status_code == status.HTTP_200_OK, response.text
+        assert response.headers["content-type"] == "text/css"
+        assert response.content == member_bytes(
+            fixture_bytes("nested_toc.epub"), "EPUB/styles/main.css"
+        )
+
+    async def test_serves_a_png_byte_for_byte(
+        self, client: AsyncClient, nested_toc_book: Book
+    ) -> None:
+        """Should not re-encode binary content on its way out."""
+        response = await client.get(resource_url(nested_toc_book, COVER_ART))
+
+        assert response.status_code == status.HTTP_200_OK, response.text
+        assert response.headers["content-type"] == "image/png"
+        assert response.content.startswith(b"\x89PNG\r\n\x1a\n")
+        assert response.content == member_bytes(
+            fixture_bytes("nested_toc.epub"), "EPUB/images/cover art.png"
+        )
+
+    async def test_serves_a_name_with_non_ascii_letters(
+        self, client: AsyncClient, nested_toc_book: Book
+    ) -> None:
+        """Should reach a UTF-8 file name through its percent-encoded href."""
+        response = await client.get(resource_url(nested_toc_book, CHAPTER_AANI))
+
+        assert response.status_code == status.HTTP_200_OK, response.text
+        assert response.content == member_bytes(
+            fixture_bytes("nested_toc.epub"), "EPUB/text/luku-ääni.xhtml"
+        )
+
+    async def test_serves_a_file_whose_name_contains_a_percent_sign(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        test_book: Book,
+        storage_dir: Path,
+    ) -> None:
+        """Should decode the path exactly once, reaching the file that exists.
+
+        The publication's one chapter is really named ``chapter%20one.xhtml``,
+        so the manifest publishes ``chapter%2520one.xhtml``. Decoding that twice
+        would name ``chapter one.xhtml``, which no EPUB here contains -- the
+        request would 404 while the manifest kept advertising the href.
+        """
+        await store_epub(db_session, test_book, storage_dir, LITERAL_PERCENT_EPUB)
+
+        response = await client.get(resource_url(test_book, "chapter%2520one.xhtml"))
+
+        assert response.status_code == status.HTTP_200_OK, response.text
+        assert response.headers["content-type"] == "application/xhtml+xml"
+        assert response.content == member_bytes(LITERAL_PERCENT_EPUB, "chapter%20one.xhtml")
+
+    async def test_the_manifests_hrefs_all_resolve(
+        self, client: AsyncClient, nested_toc_book: Book
+    ) -> None:
+        """Should serve every file the manifest names, with the type it named.
+
+        A manifest that advertises an href this endpoint will not serve is the
+        failure the two of them can only have together, so the manifest is what
+        drives the requests rather than a list copied out of it.
+        """
+        manifest = (
+            await client.get(f"/api/v1/readium/books/{nested_toc_book.id}/manifest.json")
+        ).json()
+        links = manifest["readingOrder"] + manifest["resources"]
+        assert len(links) == 5
+
+        for link in links:
+            href = link["href"].removeprefix("resources/")
+            response = await client.get(resource_url(nested_toc_book, href))
+
+            assert response.status_code == status.HTTP_200_OK, link["href"]
+            assert response.headers["content-type"] == link["type"], link["href"]
+            assert response.content, link["href"]
+
+
+class TestConditionalRequests:
+    """The entity tag, and what a reader that already holds a file is told."""
+
+    async def test_the_etag_is_stable_across_requests(
+        self, client: AsyncClient, nested_toc_book: Book
+    ) -> None:
+        """Should tag the same bytes the same way, or no cache can ever hit."""
+        first = await client.get(resource_url(nested_toc_book, CHAPTER_1))
+        second = await client.get(resource_url(nested_toc_book, CHAPTER_1))
+
+        assert first.headers["etag"] == second.headers["etag"]
+        assert first.headers["etag"].startswith('"')
+
+    async def test_different_files_get_different_etags(
+        self, client: AsyncClient, nested_toc_book: Book
+    ) -> None:
+        """Should not tag two files of one book alike, or one would mask the other."""
+        chapter = await client.get(resource_url(nested_toc_book, CHAPTER_1))
+        stylesheet = await client.get(resource_url(nested_toc_book, STYLESHEET))
+
+        assert chapter.headers["etag"] != stylesheet.headers["etag"]
+
+    async def test_a_matching_if_none_match_is_answered_304(
+        self, client: AsyncClient, nested_toc_book: Book
+    ) -> None:
+        """Should send the headers and no body when the caller's copy is current."""
+        first = await client.get(resource_url(nested_toc_book, CHAPTER_1))
+        etag = first.headers["etag"]
+
+        response = await client.get(
+            resource_url(nested_toc_book, CHAPTER_1), headers={"If-None-Match": etag}
+        )
+
+        assert response.status_code == status.HTTP_304_NOT_MODIFIED
+        assert response.content == b""
+        assert response.headers["etag"] == etag
+        assert response.headers["cache-control"] == "private"
+
+    async def test_a_weak_validator_still_matches(
+        self, client: AsyncClient, nested_toc_book: Book
+    ) -> None:
+        """Should compare tags weakly, as RFC 9110 requires for a GET."""
+        first = await client.get(resource_url(nested_toc_book, CHAPTER_1))
+
+        response = await client.get(
+            resource_url(nested_toc_book, CHAPTER_1),
+            headers={"If-None-Match": f"W/{first.headers['etag']}"},
+        )
+
+        assert response.status_code == status.HTTP_304_NOT_MODIFIED
+
+    async def test_a_stale_if_none_match_is_answered_with_the_file(
+        self, client: AsyncClient, nested_toc_book: Book
+    ) -> None:
+        """Should serve the file when the caller holds some other version."""
+        response = await client.get(
+            resource_url(nested_toc_book, CHAPTER_1),
+            headers={"If-None-Match": '"not-the-one-we-serve"'},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.content
+
+    async def test_the_etag_changes_when_the_stored_file_changes(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        test_book: Book,
+        storage_dir: Path,
+    ) -> None:
+        """Should re-tag a file whose contents are unchanged but whose book's EPUB is not.
+
+        A CRC alone would call these one resource: the chapter is byte-identical
+        in both files. Replacing a book's EPUB has to invalidate what a reader
+        cached for it, so the stored file's name is part of the tag.
+        """
+        await store_epub(
+            db_session, test_book, storage_dir, fixture_bytes("nested_toc.epub"), "first.epub"
+        )
+        before = await client.get(resource_url(test_book, CHAPTER_1))
+
+        await store_epub(
+            db_session, test_book, storage_dir, fixture_bytes("nested_toc.epub"), "second.epub"
+        )
+        after = await client.get(resource_url(test_book, CHAPTER_1))
+
+        assert before.status_code == after.status_code == status.HTTP_200_OK
+        assert after.content == before.content
+        assert after.headers["etag"] != before.headers["etag"]
+
+    async def test_the_stale_etag_no_longer_matches(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        test_book: Book,
+        storage_dir: Path,
+    ) -> None:
+        """Should send the file rather than 304 to a reader holding the old book's tag."""
+        await store_epub(
+            db_session, test_book, storage_dir, fixture_bytes("nested_toc.epub"), "first.epub"
+        )
+        stale = (await client.get(resource_url(test_book, CHAPTER_1))).headers["etag"]
+
+        await store_epub(
+            db_session, test_book, storage_dir, fixture_bytes("nested_toc.epub"), "second.epub"
+        )
+        response = await client.get(
+            resource_url(test_book, CHAPTER_1), headers={"If-None-Match": stale}
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.content
+
+
+class TestOnlyPublicationFilesAreReachable:
+    """What the endpoint refuses, which is everything the manifest does not name."""
+
+    @pytest.mark.parametrize(
+        ("path", "why"),
+        [
+            ("EPUB/package.opf", "the package document is not part of the publication"),
+            ("META-INF/container.xml", "container metadata is not part of the publication"),
+            ("mimetype", "the archive's own marker is not part of the publication"),
+            ("EPUB/text/nowhere.xhtml", "no such member"),
+            ("", "the resource root is not a file"),
+        ],
+    )
+    async def test_a_path_the_manifest_does_not_list_is_not_found(
+        self, client: AsyncClient, nested_toc_book: Book, path: str, why: str
+    ) -> None:
+        """Should serve only what the manifest advertises, whatever else the zip holds."""
+        response = await client.get(resource_url(nested_toc_book, path))
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND, why
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "..%2F..%2Fmanifest.json",
+            "..%2F..%2F..%2F..%2Fetc%2Fpasswd",
+            "%2Fetc%2Fpasswd",
+            "/etc/passwd",
+            "EPUB%2F..%2F..%2Fmanifest.json",
+        ],
+    )
+    async def test_a_path_climbing_out_of_the_container_is_not_found(
+        self, client: AsyncClient, nested_toc_book: Book, path: str
+    ) -> None:
+        """Should never resolve a path outside the publication, encoded or not.
+
+        The membership check is the guard: the manifest's hrefs are already
+        known not to escape the container, so nothing that escapes can be in the
+        list, and there is no second normalisation step to get wrong.
+        """
+        response = await client.get(resource_url(nested_toc_book, path))
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND, response.text
+        assert b"root:" not in response.content
+
+    async def test_a_media_type_that_is_not_one_is_not_echoed_back(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        test_book: Book,
+        storage_dir: Path,
+    ) -> None:
+        """Should not put a package document's text into a header unaltered.
+
+        The media type is copied from a file the user uploaded. A value with a
+        newline in it would smuggle a second header into the response, so
+        anything that is not a plain ``type/subtype`` is replaced by one the
+        browser will not act on.
+        """
+        await store_epub(
+            db_session,
+            test_book,
+            storage_dir,
+            build_epub(
+                manifest_items=(
+                    '<item id="c1" href="c1.xhtml" media-type="text/html&#10;Set-Cookie: pwned=1"/>'
+                ),
+                spine='<itemref idref="c1"/>',
+                nav_links='<li><a href="c1.xhtml">One</a></li>',
+                files=("c1.xhtml",),
+            ),
+        )
+
+        response = await client.get(resource_url(test_book, "c1.xhtml"))
+
+        assert response.status_code == status.HTTP_200_OK, response.text
+        assert response.headers["content-type"] == "application/octet-stream"
+        assert "set-cookie" not in response.headers
+
+
+class TestResourceAccess:
+    """Who may read a publication's files, and what happens when there are none."""
+
+    async def test_requires_authentication(
+        self, anonymous_client: AsyncClient, nested_toc_book: Book
+    ) -> None:
+        """Should reject an unauthenticated request rather than serve the file."""
+        response = await anonymous_client.get(resource_url(nested_toc_book, CHAPTER_1))
+
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED, response.text
+
+    async def test_another_users_book_is_not_found(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        other_user: User,
+        storage_dir: Path,
+    ) -> None:
+        """Should answer 404 for a readable file belonging to somebody else."""
+        their_book = await create_test_book(
+            db_session=db_session, user_id=other_user.id, title="Not Yours"
+        )
+        await store_epub(db_session, their_book, storage_dir, fixture_bytes("nested_toc.epub"))
+
+        response = await client.get(resource_url(their_book, CHAPTER_1))
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert b"<html" not in response.content
+
+    async def test_unknown_book_is_not_found(self, client: AsyncClient) -> None:
+        """Should answer 404 for a book id that exists for nobody."""
+        response = await client.get(
+            f"/api/v1/readium/books/99999/resources/{CHAPTER_1}",
+        )
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    async def test_book_without_an_epub_is_not_found(
+        self, client: AsyncClient, test_book: Book
+    ) -> None:
+        """Should answer 404 when the book was never given a file to read."""
+        assert test_book.ebook_file is None
+
+        response = await client.get(resource_url(test_book, CHAPTER_1))
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    async def test_unreadable_epub_is_rejected(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        test_book: Book,
+        storage_dir: Path,
+    ) -> None:
+        """Should fail the request rather than answer 404 for a book it cannot parse."""
+        await store_epub(db_session, test_book, storage_dir, b"not an epub at all")
+
+        response = await client.get(resource_url(test_book, CHAPTER_1))
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST

--- a/backend/tests/unit/infrastructure/web_reader/test_publication_resource_query.py
+++ b/backend/tests/unit/infrastructure/web_reader/test_publication_resource_query.py
@@ -11,9 +11,12 @@ import tracemalloc
 import zipfile
 from io import BytesIO
 
+import pytest
+
 from src.domain.library.exceptions import InvalidEbookError
 from src.infrastructure.web_reader.queries.publication_resource_query import (
     MAX_RESOURCE_BYTES,
+    check_member_is_servable,
     read_bounded_member,
 )
 
@@ -61,13 +64,11 @@ def test_reads_an_ordinary_member_whole() -> None:
 
 
 def test_refuses_a_member_declaring_more_than_the_cap() -> None:
-    """Should turn away an honest oversized declaration without opening the member."""
+    """Should turn away an honest oversized declaration from the directory alone."""
     archive = archive_with("big.css", b"A" * 64, declared=MAX_RESOURCE_BYTES + 1)
 
-    outcome, peak = peak_bytes_reading(archive, "big.css")
-
-    assert isinstance(outcome, InvalidEbookError)
-    assert peak < 1024 * 1024, "opened a member it had already decided to refuse"
+    with pytest.raises(InvalidEbookError, match="over the"):
+        check_member_is_servable(archive.getinfo("big.css"))
 
 
 def test_a_member_that_understates_its_size_is_not_inflated() -> None:
@@ -103,15 +104,48 @@ def test_the_bound_is_the_declaration_not_the_cap() -> None:
     assert peak < MAX_RESOURCE_BYTES // 4
 
 
+def test_a_member_the_size_of_a_whole_upload_is_servable() -> None:
+    """Should serve anything an upload could legitimately have contained.
+
+    EPUB 3 carries audio, video, fonts and fixed-layout page images, and those
+    formats are already compressed, so they store at a ratio near one: a member
+    of them can be as large as the upload cap and no larger. A cap that turned
+    away a 32 MiB comic page would break a real book, and the manifest would go
+    on advertising the href it refused.
+    """
+    archive = archive_with("page.jpg", b"A" * 64, declared=32 * 1024 * 1024)
+
+    check_member_is_servable(archive.getinfo("page.jpg"))
+
+
+def test_refuses_a_member_whose_compressed_stream_is_too_big_to_be_honest() -> None:
+    """Should reject a declaration the compressed stream contradicts.
+
+    A crafted member can survive the CRC check by making the stored checksum
+    match its own truncated prefix, and would then be served silently short. The
+    compressed size is the tell that costs nothing to read: deflate cannot
+    meaningfully expand data, so a member declaring eight bytes cannot honestly
+    carry a 200 KiB stream.
+    """
+    archive = archive_with("bomb.css", b"A" * (1024 * 1024), declared=8)
+
+    with pytest.raises(InvalidEbookError, match="compressed"):
+        check_member_is_servable(archive.getinfo("bomb.css"))
+
+
+def test_an_ordinary_small_member_survives_the_plausibility_check() -> None:
+    """Should leave room for the overhead deflate adds to a file that will not shrink."""
+    body = b"\x00\x01\x02\x03\x04"
+
+    check_member_is_servable(archive_with("tiny.bin", body).getinfo("tiny.bin"))
+
+
 def test_a_member_declaring_exactly_the_cap_is_served() -> None:
     """Should refuse only what is strictly over the cap, pinning the boundary.
 
     Paired with the test above, this is what separates ``>`` from ``>=`` -- a
     limit that turned away the size it advertises would be a different limit.
     """
-    body = b"A" * 64
-    archive = archive_with("edge.css", body, declared=MAX_RESOURCE_BYTES)
+    archive = archive_with("edge.css", b"A" * 64, declared=MAX_RESOURCE_BYTES)
 
-    content, _ = peak_bytes_reading(archive, "edge.css")
-
-    assert content == body
+    check_member_is_servable(archive.getinfo("edge.css"))

--- a/backend/tests/unit/infrastructure/web_reader/test_publication_resource_query.py
+++ b/backend/tests/unit/infrastructure/web_reader/test_publication_resource_query.py
@@ -1,0 +1,117 @@
+"""How much a hostile archive can make the resource endpoint allocate.
+
+The endpoint tests assert what a request answers. This one asserts what reading
+a member *costs*, which no status code can show and which is the whole point of
+the bound: a member's declared size is a claim the archive makes about itself,
+and ``zipfile`` honours it for the result while ignoring it for the work.
+"""
+
+import struct
+import tracemalloc
+import zipfile
+from io import BytesIO
+
+from src.domain.library.exceptions import InvalidEbookError
+from src.infrastructure.web_reader.queries.publication_resource_query import (
+    MAX_RESOURCE_BYTES,
+    read_bounded_member,
+)
+
+BOMB_SIZE = 64 * 1024 * 1024
+
+
+def archive_with(name: str, body: bytes, declared: int | None = None) -> zipfile.ZipFile:
+    """One deflated member, optionally rewritten to declare a size it does not have.
+
+    Both the local header and the central directory are patched, so nothing
+    short of decompressing the member can tell how big it really is.
+    """
+    out = BytesIO()
+    with zipfile.ZipFile(out, "w", zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr(name, body)
+    raw = bytearray(out.getvalue())
+    if declared is not None:
+        for signature, offset in ((b"PK\x03\x04", 22), (b"PK\x01\x02", 24)):
+            struct.pack_into("<I", raw, raw.find(signature) + offset, declared)
+    return zipfile.ZipFile(BytesIO(bytes(raw)))
+
+
+def peak_bytes_reading(archive: zipfile.ZipFile, name: str) -> tuple[object, int]:
+    """Read a member and report what the read peaked at, outcome and all."""
+    entry = archive.getinfo(name)
+    tracemalloc.start()
+    try:
+        try:
+            outcome: object = read_bounded_member(archive, entry)
+        except InvalidEbookError as e:
+            outcome = e
+        peak = tracemalloc.get_traced_memory()[1]
+    finally:
+        tracemalloc.stop()
+    return outcome, peak
+
+
+def test_reads_an_ordinary_member_whole() -> None:
+    """Should return the member's bytes unchanged when nothing is wrong with it."""
+    body = b"body{color:red}" * 100
+
+    content, _ = peak_bytes_reading(archive_with("main.css", body), "main.css")
+
+    assert content == body
+
+
+def test_refuses_a_member_declaring_more_than_the_cap() -> None:
+    """Should turn away an honest oversized declaration without opening the member."""
+    archive = archive_with("big.css", b"A" * 64, declared=MAX_RESOURCE_BYTES + 1)
+
+    outcome, peak = peak_bytes_reading(archive, "big.css")
+
+    assert isinstance(outcome, InvalidEbookError)
+    assert peak < 1024 * 1024, "opened a member it had already decided to refuse"
+
+
+def test_a_member_that_understates_its_size_is_not_inflated() -> None:
+    """Should read no more than the member claims, so a lie costs nothing.
+
+    ``ZipFile.read()`` would truncate the *result* to the declared eight bytes
+    while handing the decompressor an unbounded output limit, allocating the
+    real size first -- measured at 437 MiB for a 200 MB member declaring ten
+    bytes. Reading through ``open(entry).read(declared + 1)`` passes the bound
+    down to the decompressor, which is what makes the lie cheap to catch.
+    """
+    archive = archive_with("bomb.css", b"A" * BOMB_SIZE, declared=8)
+
+    outcome, peak = peak_bytes_reading(archive, "bomb.css")
+
+    # The member fails its CRC-32 once the declared bytes run out, which is a
+    # broken publication rather than a server fault.
+    assert isinstance(outcome, InvalidEbookError)
+    assert peak < BOMB_SIZE // 8, f"inflated the member: {peak / 1024 / 1024:.0f} MiB"
+
+
+def test_the_bound_is_the_declaration_not_the_cap() -> None:
+    """Should not allocate the whole cap to read a small member.
+
+    Reading ``MAX_RESOURCE_BYTES`` at a time would bound the damage but pay the
+    ceiling on every request; the declaration is the tighter bound and the one
+    that makes an understating bomb cost almost nothing.
+    """
+    archive = archive_with("bomb.css", b"A" * BOMB_SIZE, declared=8)
+
+    _, peak = peak_bytes_reading(archive, "bomb.css")
+
+    assert peak < MAX_RESOURCE_BYTES // 4
+
+
+def test_a_member_declaring_exactly_the_cap_is_served() -> None:
+    """Should refuse only what is strictly over the cap, pinning the boundary.
+
+    Paired with the test above, this is what separates ``>`` from ``>=`` -- a
+    limit that turned away the size it advertises would be a different limit.
+    """
+    body = b"A" * 64
+    archive = archive_with("edge.css", body, declared=MAX_RESOURCE_BYTES)
+
+    content, _ = peak_bytes_reading(archive, "edge.css")
+
+    assert content == body

--- a/frontend/src/api/generated/readium/readium.ts
+++ b/frontend/src/api/generated/readium/readium.ts
@@ -153,3 +153,134 @@ export function useGetReadiumManifest<
 
   return withQueryKey(query, queryOptions.queryKey);
 }
+
+/**
+ * Get one file of a book's publication, unchanged.
+ *
+ * ``path`` is a manifest href with the ``resources/`` prefix stripped, so it
+ * arrives here as the container-root path the reading order or the resource
+ * list published -- decoded once by ASGI, which is the archive member's own
+ * name. Only the files the manifest names are reachable; the package document
+ * and ``META-INF/`` are not part of the publication and answer 404 like any
+ * other path the manifest does not list.
+ * @summary Get Readium Resource
+ */
+export const getReadiumResource = (bookId: number, path: string, signal?: AbortSignal) => {
+  return axiosInstance<Blob>({
+    url: `/api/v1/readium/books/${bookId}/resources/${path}`,
+    method: 'GET',
+    responseType: 'blob',
+    signal,
+  });
+};
+
+export const getGetReadiumResourceQueryKey = (bookId: number, path: string) => {
+  return [`/api/v1/readium/books/${bookId}/resources/${path}`] as const;
+};
+
+export const getGetReadiumResourceQueryOptions = <
+  TData = Awaited<ReturnType<typeof getReadiumResource>>,
+  TError = void | HTTPValidationError,
+>(
+  bookId: number,
+  path: string,
+  options?: {
+    query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof getReadiumResource>>, TError, TData>>;
+  }
+) => {
+  const { query: queryOptions } = options ?? {};
+
+  const queryKey = queryOptions?.queryKey ?? getGetReadiumResourceQueryKey(bookId, path);
+
+  const queryFn: QueryFunction<Awaited<ReturnType<typeof getReadiumResource>>> = ({ signal }) =>
+    getReadiumResource(bookId, path, signal);
+
+  return {
+    queryKey,
+    queryFn,
+    enabled: bookId !== null && bookId !== undefined && path !== null && path !== undefined,
+    ...queryOptions,
+  } as UseQueryOptions<Awaited<ReturnType<typeof getReadiumResource>>, TError, TData> & {
+    queryKey: DataTag<QueryKey, TData, TError>;
+  };
+};
+
+export type GetReadiumResourceQueryResult = NonNullable<
+  Awaited<ReturnType<typeof getReadiumResource>>
+>;
+export type GetReadiumResourceQueryError = void | HTTPValidationError;
+
+export function useGetReadiumResource<
+  TData = Awaited<ReturnType<typeof getReadiumResource>>,
+  TError = void | HTTPValidationError,
+>(
+  bookId: number,
+  path: string,
+  options: {
+    query: Partial<UseQueryOptions<Awaited<ReturnType<typeof getReadiumResource>>, TError, TData>> &
+      Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof getReadiumResource>>,
+          TError,
+          Awaited<ReturnType<typeof getReadiumResource>>
+        >,
+        'initialData'
+      >;
+  },
+  queryClient?: QueryClient
+): DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+export function useGetReadiumResource<
+  TData = Awaited<ReturnType<typeof getReadiumResource>>,
+  TError = void | HTTPValidationError,
+>(
+  bookId: number,
+  path: string,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getReadiumResource>>, TError, TData>
+    > &
+      Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof getReadiumResource>>,
+          TError,
+          Awaited<ReturnType<typeof getReadiumResource>>
+        >,
+        'initialData'
+      >;
+  },
+  queryClient?: QueryClient
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+export function useGetReadiumResource<
+  TData = Awaited<ReturnType<typeof getReadiumResource>>,
+  TError = void | HTTPValidationError,
+>(
+  bookId: number,
+  path: string,
+  options?: {
+    query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof getReadiumResource>>, TError, TData>>;
+  },
+  queryClient?: QueryClient
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+/**
+ * @summary Get Readium Resource
+ */
+
+export function useGetReadiumResource<
+  TData = Awaited<ReturnType<typeof getReadiumResource>>,
+  TError = void | HTTPValidationError,
+>(
+  bookId: number,
+  path: string,
+  options?: {
+    query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof getReadiumResource>>, TError, TData>>;
+  },
+  queryClient?: QueryClient
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+  const queryOptions = getGetReadiumResourceQueryOptions(bookId, path, options);
+
+  const query = useQuery(queryOptions, queryClient) as UseQueryResult<TData, TError> & {
+    queryKey: DataTag<QueryKey, TData, TError>;
+  };
+
+  return withQueryKey(query, queryOptions.queryKey);
+}


### PR DESCRIPTION
Fixes #735 (M1.2, epic #729/#733).

`GET /api/v1/readium/books/{book_id}/resources/{path:path}` — serves one EPUB zip member byte-for-byte:

- Membership in the parsed manifest's `readingOrder ∪ resources` **is** the access rule (the #734 parser already rejects container-escaping hrefs), so OPF/`META-INF`/traversal requests 404 with no second normalization step to get wrong.
- Media type from the manifest, sanitized to `type/subtype` (closes a header-injection hole via hostile package documents) and served without Starlette's charset append.
- `ETag = sha256(stored_file_name ∥ sha256(archive_bytes) ∥ member_path)[:32]`, weak `If-None-Match` per RFC 9110 with proper entity-tag parsing; conditional evaluated from central-directory data after the size policy, so a 304 decompresses nothing. `Cache-Control: private`.
- Hardening from two adversarial review rounds: 64 MiB member cap (derived from `MAX_EBOOK_SIZE`; media stores at ratio ≈ 1, so anything real fits), bounded reads via `open()` (CPython's `ZipFile.read()` measured allocating 437 MiB for a 199 KiB understating archive before truncating), compress-size plausibility check against understated declarations, documented residual.
- New `get_publication_reader` auth dependency shared by both readium routes — M1.4's publication cookie becomes one local change.
- jscpd ratchet lowered 2.55 → 2.45.

Found during review and filed separately: **#773** — pre-existing ebooklib parse-time decompression bomb affecting both readium endpoints; this branch's guards are defence-in-depth, not that fix.

Checks: 1159 backend tests passed; pyright 0 errors; lint-imports 5 kept / 0 broken; jscpd 2.1%. Every review-round fix pinned by mutation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)