### PR TITLE
fix: parse publications from structure, not content

### DIFF
--- a/backend/src/infrastructure/common/zip_members.py
+++ b/backend/src/infrastructure/common/zip_members.py
@@ -1,0 +1,42 @@
+"""Reading one member of a zip archive without letting the archive decide the cost.
+
+An EPUB is a file its owner uploaded, so every declaration in it is a claim
+rather than a fact, and ``zipfile`` honours a declaration for the *result* of a
+read while ignoring it for the *work*. Both the web reader's resource endpoint
+and the publication parser read members of an archive on those terms, so the
+read that respects them lives here rather than in either of them.
+"""
+
+import zipfile
+
+from src.domain.library.exceptions import InvalidEbookError
+
+
+def read_bounded_member(archive: zipfile.ZipFile, entry: zipfile.ZipInfo) -> bytes:
+    """Read one member without letting it decide how much memory that takes.
+
+    ``ZipFile.read()`` returns no more than the declared size but does not
+    *work* within it: measured on CPython 3.13, reading a member that declares
+    10 bytes and really inflates to 200 MB returns 10 bytes after allocating
+    437 MiB, because the decompressor is handed an unbounded output limit and
+    only the result is truncated. ``open(entry).read(n)`` passes ``n`` down as
+    that limit, so asking for no more than the declaration bounds the work as
+    well as the answer -- the same member then costs 53 KiB.
+
+    Check the declaration itself first -- with
+    :func:`~src.infrastructure.web_reader.queries.publication_resource_query.check_member_is_servable`
+    for a member being served, or against the parser's own cap for a structural
+    document; this trusts the declaration to be one worth reading up to.
+
+    A member that inflates past what it declared fails its CRC-32, which
+    ``zipfile`` raises as ``BadZipFile``; that is a broken publication rather
+    than a server fault, so it reads as one.
+
+    Raises:
+        InvalidEbookError: If the member is not readable.
+    """
+    try:
+        with archive.open(entry) as member:
+            return member.read(entry.file_size + 1)
+    except (OSError, zipfile.BadZipFile, EOFError) as e:
+        raise InvalidEbookError(f"resource {entry.filename!r} cannot be read: {e!s}", "epub") from e

--- a/backend/src/infrastructure/library/services/epub_parser_service.py
+++ b/backend/src/infrastructure/library/services/epub_parser_service.py
@@ -3,6 +3,7 @@
 # pyright: reportPrivateUsage=false
 
 import logging
+import mimetypes
 import posixpath
 import struct
 import zipfile
@@ -31,6 +32,20 @@ logger = logging.getLogger(__name__)
 CONTAINER_PATH = "META-INF/container.xml"
 _CONTAINER_NS = "urn:oasis:names:tc:opendocument:xmlns:container"
 _OPF_NS = "http://www.idpf.org/2007/opf"
+_DC_NS = "http://purl.org/dc/elements/1.1/"
+_NCX_NS = "http://www.daisy.org/z3986/2005/ncx/"
+
+_XHTML_MEDIA_TYPE = "application/xhtml+xml"
+_NCX_MEDIA_TYPE = "application/x-dtbncx+xml"
+_FALLBACK_MEDIA_TYPE = "application/octet-stream"
+# Publishers write this one often enough that every reader corrects it.
+_MEDIA_TYPE_CORRECTIONS = {"image/jpg": "image/jpeg"}
+
+# The manifest property naming the EPUB 3 navigation document.
+_NAV_PROPERTY = "nav"
+
+# What ``unique-identifier`` defaults to when the package document states none.
+_DEFAULT_IDENTIFIER_ID = "id"
 
 # EPUB spells the Readium layout property two ways: once for the publication, as
 # a `rendition:layout` metadata value, and per spine item, as an itemref
@@ -137,23 +152,71 @@ def _extract_toc_hierarchy(
     return entries
 
 
-class _PackageDocument(NamedTuple):
-    """The parts of the OPF that ebooklib parses and then throws away.
+class _ManifestItem(NamedTuple):
+    """One ``<item>`` of the package document's manifest.
 
-    ebooklib reports manifest file names relative to the package document and
-    drops spine itemref properties entirely, so a manifest built from it alone
-    could name neither the right file nor its layout.
+    Attributes:
+        item_id: The manifest ``id``, ``""`` for an item that states none -- such
+            an item can never be named by a spine ``itemref``.
+        file_name: The item's path relative to the package document, decoded
+            exactly once (see :func:`_container_href`).
+        media_type: The declared media type, corrected or guessed when the
+            package document leaves it out.
+        properties: The manifest properties, split on whitespace.
+    """
+
+    item_id: str
+    file_name: str
+    media_type: str
+    properties: tuple[str, ...]
+
+
+class _NavPoint(NamedTuple):
+    """One line of a navigation document or NCX, with the lines nested under it.
+
+    The intermediate between the two navigation formats and :class:`TocEntry`:
+    an href here is still written as the document wrote it -- percent-encoded,
+    possibly carrying a fragment -- and is resolved against the container root
+    only in :func:`_toc_entries`.
+
+    Attributes:
+        title: The entry's text, ``""`` for an entry that states none.
+        href: Where it points, ``""`` for a heading that links nowhere.
+        children: The entries nested below this one, in reading order.
+    """
+
+    title: str
+    href: str
+    children: tuple["_NavPoint", ...]
+
+
+class _PackageDocument(NamedTuple):
+    """The OPF, read directly rather than through a library that reads the book.
+
+    Everything a manifest needs is stated *in* the package document; nothing
+    about it requires reading the files it names. Keeping that true is the point
+    of this type: a publication is resolved from three small documents -- the
+    container, the OPF, and one navigation document -- however much content the
+    archive holds (#773).
 
     Attributes:
         directory: The package document's directory inside the container, ``""``
             when the OPF sits at the container root.
+        metadata: What the package says about the book itself.
+        items: The manifest, in document order.
+        spine: The reading order as ``idref``\\ s, dangling ones included.
         default_layout: The publication-wide ``rendition:layout``, if stated.
         layout_by_idref: Per-spine-item layout overrides, keyed by manifest id.
+        ncx_id: The manifest id the spine's ``toc`` attribute names, if any.
     """
 
     directory: str
+    metadata: PublicationMetadata
+    items: tuple[_ManifestItem, ...]
+    spine: tuple[str, ...]
     default_layout: PublicationLayout | None
     layout_by_idref: dict[str, PublicationLayout]
+    ncx_id: str | None
 
 
 def _declared_entry_count(epub_content: bytes) -> int | None:
@@ -248,8 +311,14 @@ def _reject_oversized_archive(archive: zipfile.ZipFile) -> None:
         )
 
 
-def _read_package_document(epub_content: bytes) -> _PackageDocument:
-    """Read the OPF straight out of the container for what ebooklib does not keep.
+def _read_publication(epub_content: bytes) -> tuple[_PackageDocument, tuple[_NavPoint, ...]]:
+    """Read a publication's structure, decompressing only the documents that hold it.
+
+    Three members are read and no others: ``META-INF/container.xml``, the
+    package document it names, and the navigation document (or NCX) the package
+    names in turn. Sizes and names come from the central directory, which costs
+    nothing to consult, so what a publication costs to resolve is a property of
+    its structure rather than of its content.
 
     Raises:
         InvalidEbookError: If the archive is implausibly large, or the container
@@ -264,17 +333,125 @@ def _read_package_document(epub_content: bytes) -> _PackageDocument:
             opf_path = rootfile.get("full-path") if rootfile is not None else None
             if not opf_path:
                 raise InvalidEbookError("container.xml names no package document", "epub")
-            package = etree.fromstring(archive.read(opf_path))
+            package = _package_document(
+                etree.fromstring(archive.read(opf_path)), posixpath.dirname(opf_path)
+            )
+            return package, _read_navigation(archive, package)
     except InvalidEbookError:
         raise
     except Exception as e:
         raise InvalidEbookError(f"unreadable package document: {e!s}", "epub") from e
 
+
+def _package_document(package: etree._Element, directory: str) -> _PackageDocument:
+    """Read everything a manifest is made of out of one parsed OPF."""
+    spine = package.find(f"{{{_OPF_NS}}}spine")
     return _PackageDocument(
-        directory=posixpath.dirname(opf_path),
+        directory=directory,
+        metadata=_metadata(package),
+        items=_manifest_items(package),
+        spine=tuple(
+            idref
+            for itemref in _children(spine, f"{{{_OPF_NS}}}itemref")
+            if (idref := itemref.get("idref"))
+        ),
         default_layout=_default_layout(package),
         layout_by_idref=_layout_overrides(package),
+        ncx_id=spine.get("toc") if spine is not None else None,
     )
+
+
+def _children(parent: etree._Element | None, tag: str) -> Iterable[etree._Element]:
+    """The matching child elements of an element that may not be there.
+
+    Matching by tag rather than walking every child is what keeps a comment or a
+    processing instruction -- whose ``tag`` is not a string at all -- from being
+    read as an element of the publication.
+    """
+    return parent.iterfind(tag) if parent is not None else ()
+
+
+def _manifest_items(package: etree._Element) -> tuple[_ManifestItem, ...]:
+    """Read the manifest, dropping any item that names no file at all."""
+    items: list[_ManifestItem] = []
+
+    for element in _children(package.find(f"{{{_OPF_NS}}}manifest"), f"{{{_OPF_NS}}}item"):
+        href = element.get("href")
+        if not href:
+            logger.warning(f"Dropped manifest item naming no file: {element.get('id')!r}")
+            continue
+        # Decoded exactly once, here, so that every later step works with the
+        # file's real name -- the same reason `_container_href` encodes once.
+        file_name = unquote(href)
+        items.append(
+            _ManifestItem(
+                item_id=element.get("id") or "",
+                file_name=file_name,
+                media_type=_media_type(element.get("media-type"), file_name),
+                properties=tuple((element.get("properties") or "").split()),
+            )
+        )
+
+    return tuple(items)
+
+
+def _media_type(declared: str | None, file_name: str) -> str:
+    """The media type to publish for a manifest item.
+
+    A publication is expected to declare one, and what it declares is what the
+    manifest carries. An item that leaves it out is broken EPUB rather than an
+    unservable file, so the extension answers instead -- a resource with no type
+    at all could not be served under one.
+    """
+    if declared:
+        return _MEDIA_TYPE_CORRECTIONS.get(declared, declared)
+    return mimetypes.guess_type(file_name.lower())[0] or _FALLBACK_MEDIA_TYPE
+
+
+def _metadata(package: etree._Element) -> PublicationMetadata:
+    """Read the Dublin Core metadata the manifest publishes."""
+    values: dict[str, list[tuple[str | None, str | None]]] = {}
+
+    for element in _children(package.find(f"{{{_OPF_NS}}}metadata"), f"{{{_DC_NS}}}*"):
+        name = element.tag.rpartition("}")[2]
+        values.setdefault(name, []).append((element.text, element.get("id")))
+
+    return PublicationMetadata(
+        title=_first_metadata(values, "title"),
+        author=_first_metadata(values, "creator"),
+        language=_first_metadata(values, "language"),
+        identifier=_identifier(package, values.get("identifier", [])),
+    )
+
+
+def _first_metadata(
+    values: dict[str, list[tuple[str | None, str | None]]], name: str
+) -> str | None:
+    """Return the first Dublin Core value for ``name``, or ``None`` if it is empty."""
+    entries = values.get(name)
+    return entries[0][0] if entries and entries[0][0] else None
+
+
+def _identifier(
+    package: etree._Element, identifiers: list[tuple[str | None, str | None]]
+) -> str | None:
+    """Return the ``dc:identifier`` the package's ``unique-identifier`` names.
+
+    A publication that names none, or names one it does not carry, still has an
+    identity worth publishing, so the first identifier stands in. What it must
+    never be is invented: a manifest whose identifier changed between two
+    requests for the same file would make every reader's stored state name a
+    different book each time it looked.
+    """
+    unique_id = package.get("unique-identifier") or _DEFAULT_IDENTIFIER_ID
+    for _value, element_id in identifiers:
+        if element_id:
+            unique_id = element_id
+
+    named = [value for value, element_id in identifiers if element_id == unique_id and value]
+    if named:
+        return named[-1]
+    return identifiers[0][0] if identifiers and identifiers[0][0] else None
 
 
 def _default_layout(package: etree._Element) -> PublicationLayout | None:
@@ -323,7 +500,7 @@ def _container_href(opf_dir: str, file_path: str) -> str | None:
 
 
 def _document_href(opf_dir: str, href: str) -> str | None:
-    """Resolve a navigation link's href, which ebooklib leaves exactly as written.
+    """Resolve a navigation link's href, which is kept exactly as written.
 
     Unlike a manifest file name, this arrives still encoded, so it is decoded
     once here and re-encoded by :func:`_container_href`. The escape check runs
@@ -336,8 +513,146 @@ def _document_href(opf_dir: str, href: str) -> str | None:
     return f"{resolved}#{quote(unquote(fragment), safe='')}" if fragment else resolved
 
 
+def _read_navigation(archive: zipfile.ZipFile, package: _PackageDocument) -> tuple[_NavPoint, ...]:
+    """Read the publication's table of contents, from the nav document or the NCX.
+
+    EPUB 3 states it in a navigation document and EPUB 2 in an NCX; a
+    publication carrying both is read from the nav document, which is the one
+    its own version defines. Either way this is one member, and the only member
+    of the publication's content that resolving its structure reads.
+
+    A table of contents that cannot be read costs the table of contents and not
+    the book: the reading order is what a reader opens, and a publication whose
+    navigation is missing or malformed is still one a reader can page through.
+    """
+    source = _navigation_source(package)
+    if source is None:
+        return ()
+
+    member = posixpath.normpath(posixpath.join(package.directory, source.file_name))
+    try:
+        document = archive.read(member)
+        if source.base_path is None:
+            return _parse_ncx(document)
+        return _parse_nav(document, source.base_path)
+    except Exception as e:
+        logger.warning(f"Publication navigation {member!r} could not be read: {e!s}")
+        return ()
+
+
+class _NavigationSource(NamedTuple):
+    """The member a publication's table of contents is written in.
+
+    Attributes:
+        file_name: The member's path relative to the package document.
+        base_path: The directory its links resolve against, ``None`` for an NCX
+            -- whose sources resolve against the package document itself.
+    """
+
+    file_name: str
+    base_path: str | None
+
+
+def _navigation_source(package: _PackageDocument) -> _NavigationSource | None:
+    """Find the navigation document, or the NCX the spine falls back to."""
+    for item in package.items:
+        if item.media_type == _XHTML_MEDIA_TYPE and _NAV_PROPERTY in item.properties:
+            return _NavigationSource(item.file_name, posixpath.dirname(item.file_name))
+
+    for item in package.items:
+        if package.ncx_id and item.item_id == package.ncx_id:
+            return _NavigationSource(item.file_name, None)
+
+    return None
+
+
+def _parse_nav(document: bytes, base_path: str) -> tuple[_NavPoint, ...]:
+    """Read an EPUB 3 navigation document's ``toc`` nav into nav points.
+
+    Parsed as HTML rather than as XML because that is what a navigation document
+    is served and rendered as, and a book whose nav is not well-formed XML still
+    navigates in a browser.
+    """
+    root = etree.fromstring(document, etree.HTMLParser(encoding="utf-8"))
+    navs = cast(list[etree._Element], root.xpath("//nav[@*='toc']"))
+    if not navs:
+        logger.warning("Navigation document states no table of contents")
+        return ()
+    ordered_list = navs[0].find("ol")
+    return _nav_points(ordered_list, base_path) if ordered_list is not None else ()
+
+
+def _nav_points(ordered_list: etree._Element, base_path: str) -> tuple[_NavPoint, ...]:
+    """Walk one ``<ol>`` of a navigation document, and the lists nested in it.
+
+    An entry with a nested list is titled by its first child whatever that is --
+    a link, or the ``<span>`` a heading that links nowhere is written as. An
+    entry that is neither a link nor a heading over other entries names nothing
+    and is left out.
+    """
+    points: list[_NavPoint] = []
+
+    for item in ordered_list.findall("li"):
+        sublist = item.find("ol")
+        link = item.find("a")
+        href = link.get("href") if link is not None else None
+        if sublist is not None:
+            title = _text_content(item[0]) if len(item) else ""
+            points.append(
+                _NavPoint(title, _nav_href(base_path, href), _nav_points(sublist, base_path))
+            )
+        elif link is not None and href:
+            points.append(_NavPoint(_text_content(link), _nav_href(base_path, href), ()))
+
+    return tuple(points)
+
+
+def _nav_href(base_path: str, href: str | None) -> str:
+    """Resolve a navigation link against the navigation document's own directory.
+
+    The result stays percent-encoded as the document wrote it;
+    :func:`_document_href` decodes it once, later and exactly once.
+    """
+    return posixpath.normpath(posixpath.join(base_path, href)) if href else ""
+
+
+def _text_content(element: etree._Element) -> str:
+    """All the text under an element, as an HTML renderer would show it."""
+    return "".join(cast(Iterable[str], element.itertext()))
+
+
+def _parse_ncx(document: bytes) -> tuple[_NavPoint, ...]:
+    """Read an EPUB 2 NCX's ``navMap`` into nav points.
+
+    An NCX ``content`` source is relative to the NCX itself, which the EPUB 2
+    specification requires to sit beside the package document -- so the sources
+    are left as written, to be resolved against the package document's directory
+    like every other href here.
+    """
+    nav_map = etree.fromstring(document).find(f"{{{_NCX_NS}}}navMap")
+    return _ncx_points(nav_map) if nav_map is not None else ()
+
+
+def _ncx_points(parent: etree._Element) -> tuple[_NavPoint, ...]:
+    """Walk one NCX element's ``navPoint`` children, and the points nested in them."""
+    points: list[_NavPoint] = []
+
+    for point in parent.iterfind(f"{{{_NCX_NS}}}navPoint"):
+        label = point.find(f"{{{_NCX_NS}}}navLabel/{{{_NCX_NS}}}text")
+        content = point.find(f"{{{_NCX_NS}}}content")
+        points.append(
+            _NavPoint(
+                title=(label.text or "") if label is not None else "",
+                href=(content.get("src") or "") if content is not None else "",
+                children=_ncx_points(point),
+            )
+        )
+
+    return tuple(points)
+
+
 def _resources(
-    items: Iterable[Any],
+    items: Iterable[_ManifestItem],
     opf_dir: str,
     layouts: dict[str, PublicationLayout | None],
 ) -> tuple[PublicationResource, ...]:
@@ -353,66 +668,51 @@ def _resources(
     for item in items:
         href = _container_href(opf_dir, item.file_name)
         if href is None:
-            logger.warning(f"Dropped manifest item pointing outside the publication: {item.id!r}")
+            logger.warning(
+                f"Dropped manifest item pointing outside the publication: {item.item_id!r}"
+            )
             continue
         resources.append(
             PublicationResource(
                 href=href,
                 media_type=item.media_type,
-                layout=layouts.get(item.id),
+                layout=layouts.get(item.item_id),
             )
         )
 
     return tuple(resources)
 
 
-def _toc_entries(toc_items: list[Any], opf_dir: str) -> tuple[TocEntry, ...]:
-    """Walk ebooklib's TOC tree into nested :class:`TocEntry` values.
+def _toc_entries(points: Iterable[_NavPoint], opf_dir: str) -> tuple[TocEntry, ...]:
+    """Render nav points as nested :class:`TocEntry` values.
 
     Unlike :func:`_extract_toc_hierarchy`, which flattens for chapter storage,
     this keeps the nesting a manifest's ``toc`` renders and keeps the href rather
     than resolving it to an xpointer.
     """
-    entries: list[TocEntry] = []
-
-    for item in toc_items:
-        if isinstance(item, tuple):
-            section = item[0]
-            children = _toc_entries(item[1] if len(item) > 1 else [], opf_dir)
-            title = getattr(section, "title", None)
-            if title is None:
-                # Untitled section: its children rise to the enclosing level.
-                entries.extend(children)
-                continue
-            entries.append(
-                TocEntry(title=title, href=_entry_href(section, opf_dir), children=children)
-            )
-        elif hasattr(item, "title"):
-            entries.append(TocEntry(title=item.title, href=_entry_href(item, opf_dir)))
-
-    return tuple(entries)
+    return tuple(
+        TocEntry(
+            title=point.title,
+            href=_entry_href(point.href, opf_dir),
+            children=_toc_entries(point.children, opf_dir),
+        )
+        for point in points
+    )
 
 
-def _entry_href(item: Any, opf_dir: str) -> str | None:  # noqa: ANN401
-    """Resolve a TOC item's href, or ``None`` for a heading that links nowhere.
+def _entry_href(href: str, opf_dir: str) -> str | None:
+    """Resolve a TOC entry's href, or ``None`` for a heading that links nowhere.
 
     An href that escapes the container is treated as linking nowhere rather than
     dropping the entry, so a hostile or broken link costs its own line's
     navigation and not the nesting of everything under it.
     """
-    href = getattr(item, "href", None)
     if not href:
         return None
     resolved = _document_href(opf_dir, href)
     if resolved is None:
         logger.warning(f"Dropped TOC href pointing outside the publication: {href!r}")
     return resolved
-
-
-def _first_metadata(book: Any, name: str) -> str | None:  # noqa: ANN401
-    """Return the first non-empty Dublin Core value for ``name``."""
-    values = book.get_metadata("DC", name)
-    return values[0][0] if values and values[0][0] else None
 
 
 class EpubParserService:
@@ -526,15 +826,11 @@ class EpubParserService:
                 document is missing or unparseable, or its spine names nothing
                 the publication contains.
         """
-        package = _read_package_document(epub_content)
-        try:
-            book = epub.read_epub(BytesIO(epub_content))
-        except Exception as e:
-            raise InvalidEbookError(f"cannot be read: {e!s}", "epub") from e
+        package, navigation = _read_publication(epub_content)
 
-        items_by_id = {item.id: item for item in book.get_items()}
-        spine_ids = [idref for idref, _linear in book.spine if idref in items_by_id]
-        if dangling := len(book.spine) - len(spine_ids):
+        items_by_id = {item.item_id: item for item in package.items}
+        spine_ids = [idref for idref in package.spine if idref in items_by_id]
+        if dangling := len(package.spine) - len(spine_ids):
             logger.warning(f"Spine names {dangling} item(s) missing from the manifest")
 
         reading_order = _resources(
@@ -550,7 +846,7 @@ class EpubParserService:
 
         in_spine = set(spine_ids)
         resources = _resources(
-            (item for item in book.get_items() if item.id not in in_spine),
+            (item for item in package.items if item.item_id not in in_spine),
             package.directory,
             {},
         )
@@ -560,15 +856,10 @@ class EpubParserService:
             f"{len(resources)} resources"
         )
         return ParsedPublication(
-            metadata=PublicationMetadata(
-                title=_first_metadata(book, "title"),
-                author=_first_metadata(book, "creator"),
-                language=_first_metadata(book, "language"),
-                identifier=book.uid or _first_metadata(book, "identifier"),
-            ),
+            metadata=package.metadata,
             reading_order=reading_order,
             resources=resources,
-            toc=_toc_entries(book.toc, package.directory),
+            toc=_toc_entries(navigation, package.directory),
         )
 
     @trims_memory

--- a/backend/src/infrastructure/library/services/epub_parser_service.py
+++ b/backend/src/infrastructure/library/services/epub_parser_service.py
@@ -7,7 +7,7 @@ import mimetypes
 import posixpath
 import struct
 import zipfile
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from io import BytesIO
 from typing import Any, NamedTuple, cast
 from urllib.parse import quote, unquote
@@ -26,6 +26,7 @@ from src.application.web_reader.publications import (
 from src.domain.library.entities.chapter import TocChapter
 from src.domain.library.exceptions import InvalidEbookError
 from src.infrastructure.common.memory import trims_memory
+from src.infrastructure.common.zip_members import read_bounded_member
 
 logger = logging.getLogger(__name__)
 
@@ -43,9 +44,6 @@ _MEDIA_TYPE_CORRECTIONS = {"image/jpg": "image/jpeg"}
 
 # The manifest property naming the EPUB 3 navigation document.
 _NAV_PROPERTY = "nav"
-
-# What ``unique-identifier`` defaults to when the package document states none.
-_DEFAULT_IDENTIFIER_ID = "id"
 
 # EPUB spells the Readium layout property two ways: once for the publication, as
 # a `rendition:layout` metadata value, and per spine item, as an itemref
@@ -65,6 +63,23 @@ _LAYOUT_BY_ITEMREF_PROPERTY = {
 # EPUB runs to a few hundred megabytes across a few thousand files.
 MAX_PUBLICATION_ENTRIES = 10_000
 MAX_PUBLICATION_UNCOMPRESSED_BYTES = 2 * 1024**3
+
+# The largest container, package or navigation document this will read.
+#
+# The total above bounds the archive; this bounds each of the three members the
+# parse actually decompresses, which is what the total cannot do -- 2 GiB of
+# declared content is an ordinary illustrated library, and a single 2 GiB OPF is
+# a bomb wearing the only file the parse cannot skip.
+#
+# Derived from the entry cap rather than picked: a package document lists one
+# `<item>` per member, and at a generous 200 bytes an item, the largest manifest
+# admitted here -- `MAX_PUBLICATION_ENTRIES` -- writes about 2 MB. A navigation
+# document is the same shape and no denser: one line per entry. Eight times that
+# leaves room for the outliers this must not turn away, an anthology's
+# thousand-entry table of contents included, while sitting well under the
+# `MAX_RESOURCE_BYTES` cap on a member that is merely served -- a document the
+# parse must hold to answer at all is not the place for the loosest limit.
+MAX_STRUCTURAL_DOCUMENT_BYTES = 16 * 1024 * 1024
 
 # Offsets into the zip trailer records, from APPNOTE.TXT sections 4.3.14-4.3.16.
 # Read by hand because the count has to be known before `zipfile` opens the file.
@@ -318,29 +333,64 @@ def _read_publication(epub_content: bytes) -> tuple[_PackageDocument, tuple[_Nav
     package document it names, and the navigation document (or NCX) the package
     names in turn. Sizes and names come from the central directory, which costs
     nothing to consult, so what a publication costs to resolve is a property of
-    its structure rather than of its content.
+    its structure rather than of its content -- and each of the three is read
+    under :func:`_read_structural_document`, so being one of them is not a way
+    to be read on trust.
 
     Raises:
         InvalidEbookError: If the archive is implausibly large, or the container
-            or its package document is missing or unparseable.
+            or its package document is missing, oversized or unparseable.
     """
     _reject_overfull_archive(epub_content)
     try:
         with zipfile.ZipFile(BytesIO(epub_content)) as archive:
             _reject_oversized_archive(archive)
-            container = etree.fromstring(archive.read(CONTAINER_PATH))
+            container = etree.fromstring(_read_structural_document(archive, CONTAINER_PATH))
             rootfile = container.find(f".//{{{_CONTAINER_NS}}}rootfile")
             opf_path = rootfile.get("full-path") if rootfile is not None else None
             if not opf_path:
                 raise InvalidEbookError("container.xml names no package document", "epub")
             package = _package_document(
-                etree.fromstring(archive.read(opf_path)), posixpath.dirname(opf_path)
+                etree.fromstring(_read_structural_document(archive, opf_path)),
+                posixpath.dirname(opf_path),
             )
             return package, _read_navigation(archive, package)
     except InvalidEbookError:
         raise
     except Exception as e:
         raise InvalidEbookError(f"unreadable package document: {e!s}", "epub") from e
+
+
+def _read_structural_document(archive: zipfile.ZipFile, name: str) -> bytes:
+    """Read one of the documents a publication's structure is written in.
+
+    The declaration is checked before the read and enforced during it, in that
+    order, because neither does the other's job: the cap turns away a member
+    that honestly says it is too big, and the bounded read stops a member that
+    lies from inflating anyway. Without the second, a member declaring eight
+    bytes and holding two gigabytes passes the cap and then costs the two
+    gigabytes -- ``ZipFile.read()`` truncates the result to the declaration and
+    hands the decompressor no limit at all.
+
+    Raises:
+        InvalidEbookError: If the member is over the cap, unreadable, or carries
+            more than it declared.
+    """
+    entry = archive.getinfo(posixpath.normpath(name))
+    if entry.file_size > MAX_STRUCTURAL_DOCUMENT_BYTES:
+        raise InvalidEbookError(
+            f"{entry.filename!r} declares {entry.file_size} bytes, over the "
+            f"{MAX_STRUCTURAL_DOCUMENT_BYTES} limit",
+            "epub",
+        )
+
+    document = read_bounded_member(archive, entry)
+    if len(document) > entry.file_size:
+        raise InvalidEbookError(
+            f"{entry.filename!r} carries more than the {entry.file_size} bytes it declares",
+            "epub",
+        )
+    return document
 
 
 def _package_document(package: etree._Element, directory: str) -> _PackageDocument:
@@ -437,20 +487,23 @@ def _identifier(
 ) -> str | None:
     """Return the ``dc:identifier`` the package's ``unique-identifier`` names.
 
-    A publication that names none, or names one it does not carry, still has an
-    identity worth publishing, so the first identifier stands in. What it must
-    never be is invented: a manifest whose identifier changed between two
-    requests for the same file would make every reader's stored state name a
-    different book each time it looked.
-    """
-    unique_id = package.get("unique-identifier") or _DEFAULT_IDENTIFIER_ID
-    for _value, element_id in identifiers:
-        if element_id:
-            unique_id = element_id
+    The designation is the whole point of the attribute: a book commonly carries
+    several identifiers -- an ISBN, a UUID, a vendor's own -- and the package
+    says which one *is* the publication. Position among them says nothing, so
+    neither the first nor the last will do.
 
-    named = [value for value, element_id in identifiers if element_id == unique_id and value]
-    if named:
-        return named[-1]
+    A publication that designates none, or designates one it does not carry,
+    still has an identity worth publishing, so the first identifier stands in.
+    What it must never be is invented: a manifest whose identifier changed
+    between two requests for the same file would make every reader's stored
+    state name a different book each time it looked.
+    """
+    unique_id = package.get("unique-identifier")
+    designated = next(
+        (value for value, element_id in identifiers if element_id == unique_id and value), None
+    )
+    if designated is not None:
+        return designated
     return identifiers[0][0] if identifiers and identifiers[0][0] else None
 
 
@@ -524,17 +577,19 @@ def _read_navigation(archive: zipfile.ZipFile, package: _PackageDocument) -> tup
     A table of contents that cannot be read costs the table of contents and not
     the book: the reading order is what a reader opens, and a publication whose
     navigation is missing or malformed is still one a reader can page through.
+    A member that lies about its size is not merely broken, though, so the
+    refusal :func:`_read_structural_document` raises passes straight out --
+    degrading past a bomb would mean paying for it first.
     """
     source = _navigation_source(package)
     if source is None:
         return ()
 
-    member = posixpath.normpath(posixpath.join(package.directory, source.file_name))
+    member = posixpath.join(package.directory, source.file_name)
     try:
-        document = archive.read(member)
-        if source.base_path is None:
-            return _parse_ncx(document)
-        return _parse_nav(document, source.base_path)
+        return source.parse(_read_structural_document(archive, member), source.base_path)
+    except InvalidEbookError:
+        raise
     except Exception as e:
         logger.warning(f"Publication navigation {member!r} could not be read: {e!s}")
         return ()
@@ -545,23 +600,26 @@ class _NavigationSource(NamedTuple):
 
     Attributes:
         file_name: The member's path relative to the package document.
-        base_path: The directory its links resolve against, ``None`` for an NCX
-            -- whose sources resolve against the package document itself.
+        base_path: The directory its links resolve against -- its own, for both
+            formats, since a link is written relative to the document that
+            writes it and neither format has to sit beside the package document.
+        parse: The reader for the format it is written in.
     """
 
     file_name: str
-    base_path: str | None
+    base_path: str
+    parse: Callable[[bytes, str], tuple[_NavPoint, ...]]
 
 
 def _navigation_source(package: _PackageDocument) -> _NavigationSource | None:
     """Find the navigation document, or the NCX the spine falls back to."""
     for item in package.items:
         if item.media_type == _XHTML_MEDIA_TYPE and _NAV_PROPERTY in item.properties:
-            return _NavigationSource(item.file_name, posixpath.dirname(item.file_name))
+            return _NavigationSource(item.file_name, posixpath.dirname(item.file_name), _parse_nav)
 
     for item in package.items:
         if package.ncx_id and item.item_id == package.ncx_id:
-            return _NavigationSource(item.file_name, None)
+            return _NavigationSource(item.file_name, posixpath.dirname(item.file_name), _parse_ncx)
 
     return None
 
@@ -621,19 +679,20 @@ def _text_content(element: etree._Element) -> str:
     return "".join(cast(Iterable[str], element.itertext()))
 
 
-def _parse_ncx(document: bytes) -> tuple[_NavPoint, ...]:
+def _parse_ncx(document: bytes, base_path: str) -> tuple[_NavPoint, ...]:
     """Read an EPUB 2 NCX's ``navMap`` into nav points.
 
-    An NCX ``content`` source is relative to the NCX itself, which the EPUB 2
-    specification requires to sit beside the package document -- so the sources
-    are left as written, to be resolved against the package document's directory
-    like every other href here.
+    An NCX ``content`` source is relative to the NCX, which is a manifest item
+    like any other and need not sit beside the package document. Resolving one
+    anywhere but the NCX's own directory names a file the publication does not
+    hold, so a book whose NCX lives in a subdirectory would have a table of
+    contents pointing everywhere except at its own reading order.
     """
     nav_map = etree.fromstring(document).find(f"{{{_NCX_NS}}}navMap")
-    return _ncx_points(nav_map) if nav_map is not None else ()
+    return _ncx_points(nav_map, base_path) if nav_map is not None else ()
 
 
-def _ncx_points(parent: etree._Element) -> tuple[_NavPoint, ...]:
+def _ncx_points(parent: etree._Element, base_path: str) -> tuple[_NavPoint, ...]:
     """Walk one NCX element's ``navPoint`` children, and the points nested in them."""
     points: list[_NavPoint] = []
 
@@ -643,8 +702,8 @@ def _ncx_points(parent: etree._Element) -> tuple[_NavPoint, ...]:
         points.append(
             _NavPoint(
                 title=(label.text or "") if label is not None else "",
-                href=(content.get("src") or "") if content is not None else "",
-                children=_ncx_points(point),
+                href=_nav_href(base_path, content.get("src") if content is not None else None),
+                children=_ncx_points(point, base_path),
             )
         )
 

--- a/backend/src/infrastructure/web_reader/queries/publication_positions_query.py
+++ b/backend/src/infrastructure/web_reader/queries/publication_positions_query.py
@@ -129,9 +129,11 @@ def _servable_sizes(
     positions could only ever point somewhere a reader cannot go.
 
     A member the archive does not hold is left out and counted as empty, which
-    is the backstop the resource endpoint has for the same case: the parser
-    reads every manifest item, so a spine naming a file the container lacks
-    fails the publication long before this.
+    is what the resource endpoint does with the same case: the parser reads the
+    package document and not the files it names (#773), so a spine naming a file
+    the container lacks still produces a reading order. Such a resource is worth
+    the one position every resource is worth, and the endpoint that serves it
+    answers 404.
     """
     sizes: dict[str, int] = {}
     for resource in reading_order:

--- a/backend/src/infrastructure/web_reader/queries/publication_resource_query.py
+++ b/backend/src/infrastructure/web_reader/queries/publication_resource_query.py
@@ -20,7 +20,15 @@ from src.application.web_reader.queries.publication_resource import (
 from src.domain.common.value_objects.ids import BookId, UserId
 from src.domain.library.exceptions import InvalidEbookError
 from src.domain.web_reader.exceptions import PublicationResourceNotFoundError
+from src.infrastructure.common.zip_members import read_bounded_member
 from src.infrastructure.web_reader.queries.stored_epub import PublicationQuery, StoredEpub
+
+__all__ = [
+    "MAX_RESOURCE_BYTES",
+    "PublicationResourceQuery",
+    "check_member_is_servable",
+    "read_bounded_member",
+]
 
 # Long enough that two files of one book cannot collide by accident, short
 # enough to stay readable in a log line or a browser's network panel.
@@ -185,34 +193,6 @@ def check_member_is_servable(entry: zipfile.ZipInfo) -> None:
             f"compressed stream of {entry.compress_size}",
             "epub",
         )
-
-
-def read_bounded_member(archive: zipfile.ZipFile, entry: zipfile.ZipInfo) -> bytes:
-    """Read one member without letting it decide how much memory that takes.
-
-    ``ZipFile.read()`` returns no more than the declared size but does not
-    *work* within it: measured on CPython 3.13, reading a member that declares
-    10 bytes and really inflates to 200 MB returns 10 bytes after allocating
-    437 MiB, because the decompressor is handed an unbounded output limit and
-    only the result is truncated. ``open(entry).read(n)`` passes ``n`` down as
-    that limit, so asking for no more than the declaration bounds the work as
-    well as the answer -- the same member then costs 53 KiB.
-
-    Call :func:`check_member_is_servable` first; this trusts the declaration to
-    be one worth reading up to.
-
-    A member that inflates past what it declared fails its CRC-32, which
-    ``zipfile`` raises as ``BadZipFile``; that is a broken publication rather
-    than a server fault, so it reads as one.
-
-    Raises:
-        InvalidEbookError: If the member is not readable.
-    """
-    try:
-        with archive.open(entry) as member:
-            return member.read(entry.file_size + 1)
-    except (OSError, zipfile.BadZipFile, EOFError) as e:
-        raise InvalidEbookError(f"resource {entry.filename!r} cannot be read: {e!s}", "epub") from e
 
 
 def _version(stored: StoredEpub, path: str) -> str:

--- a/backend/src/infrastructure/web_reader/queries/publication_resource_query.py
+++ b/backend/src/infrastructure/web_reader/queries/publication_resource_query.py
@@ -88,12 +88,12 @@ class PublicationResourceQuery(PublicationQuery):
             try:
                 entry = archive.getinfo(path)
             except KeyError:
-                # A backstop, not an expected path: the parser reads every
-                # manifest item, so a package document naming a file the
-                # container does not hold fails the whole publication before
-                # this point. It stands so that any future divergence between
-                # what the parser lists and what the archive holds is a 404
-                # rather than an unhandled KeyError.
+                # Reachable, and the honest answer when it is: the parser reads
+                # the package document and not the files it names (#773), so a
+                # manifest naming a file the container does not hold yields a
+                # publication that lists a resource the archive lacks. Missing
+                # one file is not grounds for refusing the whole book, so the
+                # file that is not there is the one that is not found.
                 raise PublicationResourceNotFoundError(path) from None
 
             # Whether this member may be served at all is settled first: a

--- a/backend/tests/test_readium_manifest.py
+++ b/backend/tests/test_readium_manifest.py
@@ -353,8 +353,8 @@ class TestMalformedPublications:
     ) -> None:
         """Should name the file that exists, not the one its encoding decodes to.
 
-        ebooklib decodes manifest hrefs and leaves navigation hrefs as written,
-        so decoding both would turn the real file ``chapter%20one.xhtml`` into
+        The parser decodes a manifest href once and leaves a navigation href as
+        written, so decoding both would turn the real file ``chapter%20one.xhtml`` into
         ``chapter one.xhtml`` in the reading order while the TOC still named the
         real one -- two hrefs for one file, neither reachable in both places.
         """

--- a/backend/tests/test_readium_resources.py
+++ b/backend/tests/test_readium_resources.py
@@ -469,10 +469,10 @@ class TestDecompressionIsBounded:
         """Should refuse a member that lies about its size rather than serve it.
 
         This is the outcome only. What the endpoint spends getting there is not
-        visible from out here, because the shared parser reads every manifest
-        item before this endpoint sees one -- see
+        visible from out here -- see
         ``tests/unit/infrastructure/web_reader/test_publication_resource_query.py``
-        for the assertion about the bytes this endpoint's own read allocates.
+        for the assertion about the bytes this endpoint's own read allocates,
+        and ``TestParsePublicationCost`` for the parse that precedes it.
         """
         await store_epub(
             db_session, test_book, storage_dir, understating_epub("big.css", 1024 * 1024)

--- a/backend/tests/unit/infrastructure/library/services/test_epub_parser_service.py
+++ b/backend/tests/unit/infrastructure/library/services/test_epub_parser_service.py
@@ -2,16 +2,19 @@
 
 import io
 import struct
+import tracemalloc
 import zipfile
 from pathlib import Path
 
 import pytest
 from ebooklib import epub
 
+from src.application.web_reader.publications import ParsedPublication, TocEntry
 from src.infrastructure.library.services.epub_parser_service import (
     EpubParserService,
     _declared_entry_count,  # pyright: ignore[reportPrivateUsage]
 )
+from tests.test_readium_manifest import build_epub
 
 FAKE_IMAGE = b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR fake image bytes"
 
@@ -187,6 +190,269 @@ class TestExtractCoverFromOPFMeta:
         epub_path = _create_epub_without_cover(tmp_path)
         result = service.extract_cover(epub_path.read_bytes())
         assert result is None
+
+
+class TestParsePublicationCost:
+    """What resolving a publication's structure *costs*, which no manifest can show.
+
+    Every readium request parses the stored EPUB, so the parse decides what one
+    request may be made to allocate. The bytes it must read are the container,
+    the package document and the navigation document -- a few kilobytes of
+    structure -- and nothing about a manifest entry requires reading the file it
+    names. Reading them all is a per-request tax the size of the whole book on
+    an honest one, and unbounded amplification on a crafted one: this archive is
+    130 KB and its members inflate to 128 MiB (#773).
+    """
+
+    # Large enough that inflating the publication cannot hide inside the noise
+    # of a parse, small enough to build in a test.
+    BOMB_SIZE = 128 * 1024 * 1024
+
+    # A parse reads three small documents and builds a dataclass per manifest
+    # item, so its peak has nothing to do with how much content the archive
+    # holds. Loose enough not to fail on an interpreter's own allocations,
+    # tight enough that reading one member of any real book would break it.
+    PEAK_LIMIT = 8 * 1024 * 1024
+
+    @staticmethod
+    def _high_ratio_epub(size: int) -> bytes:
+        """A publication whose members really do inflate to ``size``, honestly declared.
+
+        Nothing here is a lie the size guards could catch: the central directory
+        states the real uncompressed length, which is well under the limit the
+        parser admits. The archive is simply very compressible, as a book of
+        repeated markup is.
+        """
+        return build_epub(
+            manifest_items=(
+                '<item id="c1" href="c1.xhtml" media-type="application/xhtml+xml"/>'
+                '<item id="big" href="big.css" media-type="text/css"/>'
+            ),
+            spine='<itemref idref="c1"/>',
+            nav_links='<li><a href="c1.xhtml">One</a></li>',
+            files=("c1.xhtml", "big.css"),
+            bodies={"big.css": b"A" * size},
+            compression=zipfile.ZIP_DEFLATED,
+        )
+
+    @staticmethod
+    def _peak_bytes_parsing(
+        service: EpubParserService, content: bytes
+    ) -> tuple[ParsedPublication, int]:
+        """Parse a publication and report what the parse peaked at."""
+        tracemalloc.start()
+        try:
+            publication = service.parse_publication(content)
+            peak = tracemalloc.get_traced_memory()[1]
+        finally:
+            tracemalloc.stop()
+        return publication, peak
+
+    def test_reads_the_structure_without_inflating_the_content(
+        self, service: EpubParserService
+    ) -> None:
+        """Should cost what the package and navigation documents weigh, not the book."""
+        content = self._high_ratio_epub(self.BOMB_SIZE)
+        assert len(content) < 256 * 1024, "the archive itself should be small"
+
+        publication, peak = self._peak_bytes_parsing(service, content)
+
+        # The publication is still resolved in full: the point is the cost, not
+        # a narrower answer.
+        assert [item.href for item in publication.reading_order] == ["c1.xhtml"]
+        assert [item.href for item in publication.resources] == ["nav.xhtml", "big.css"]
+        assert [entry.title for entry in publication.toc] == ["One"]
+        assert peak < self.PEAK_LIMIT, f"inflated the publication: {peak / 1024**2:.0f} MiB"
+
+
+def hand_built_epub(package: str, members: dict[str, str], opf_path: str = "content.opf") -> bytes:
+    """An EPUB assembled member by member, for shapes ``build_epub`` cannot take.
+
+    ``build_epub`` writes an EPUB 3 with a navigation document, which is the
+    shape nearly every assertion wants. These are the ones it is not: a book
+    navigated by an NCX, or one whose navigation is broken.
+    """
+    out = io.BytesIO()
+    with zipfile.ZipFile(out, "w") as archive:
+        archive.writestr(zipfile.ZipInfo("mimetype"), "application/epub+zip", zipfile.ZIP_STORED)
+        archive.writestr(
+            "META-INF/container.xml",
+            '<?xml version="1.0" encoding="UTF-8"?>'
+            '<container version="1.0" '
+            'xmlns="urn:oasis:names:tc:opendocument:xmlns:container"><rootfiles>'
+            f'<rootfile full-path="{opf_path}" '
+            'media-type="application/oebps-package+xml"/></rootfiles></container>',
+        )
+        archive.writestr(opf_path, package)
+        for name, body in members.items():
+            archive.writestr(name, body)
+    return out.getvalue()
+
+
+def package_document(metadata: str, manifest: str, spine: str, unique_id: str = "i") -> str:
+    """A package document, with the three parts a test varies written out."""
+    return (
+        '<?xml version="1.0" encoding="UTF-8"?>'
+        f'<package xmlns="http://www.idpf.org/2007/opf" version="3.0" '
+        f'unique-identifier="{unique_id}">'
+        f'<metadata xmlns:dc="http://purl.org/dc/elements/1.1/">{metadata}</metadata>'
+        f"<manifest>{manifest}</manifest>{spine}</package>"
+    )
+
+
+DC_METADATA = (
+    '<dc:identifier id="i">urn:uuid:hand-built</dc:identifier>'
+    "<dc:title>Hand Built</dc:title><dc:language>en</dc:language>"
+)
+CHAPTER = '<html xmlns="http://www.w3.org/1999/xhtml"><body><p>Hi there.</p></body></html>'
+NCX = (
+    '<?xml version="1.0" encoding="UTF-8"?>'
+    '<ncx xmlns="http://www.daisy.org/z3986/2005/ncx/" version="2005-1"><navMap>'
+    '<navPoint id="p1"><navLabel><text>Part One</text></navLabel>'
+    '<content src="c1.xhtml"/>'
+    '<navPoint id="p1a"><navLabel><text>Chapter One</text></navLabel>'
+    '<content src="c1.xhtml#sec1"/></navPoint>'
+    "</navPoint>"
+    '<navPoint id="p2"><navLabel><text>Appendix</text></navLabel>'
+    '<content src="c2.xhtml"/></navPoint>'
+    "</navMap></ncx>"
+)
+NAV_DOCUMENT = (
+    '<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops">'
+    '<body><nav epub:type="toc"><ol><li><a href="c1.xhtml">From the nav document</a></li>'
+    "</ol></nav></body></html>"
+)
+
+
+class TestPublicationNavigation:
+    """Where a publication's table of contents comes from.
+
+    EPUB 3 states it in a navigation document and EPUB 2 in an NCX, and a
+    library's catalogue holds both. Neither is reachable through the manifest
+    fixtures, which are all EPUB 3, and both are ordinary tree-walking over a
+    document -- the case the unit tier is for.
+    """
+
+    def test_reads_a_nested_table_of_contents_from_an_ncx(self, service: EpubParserService) -> None:
+        """Should navigate an EPUB 2, which has no navigation document at all."""
+        content = hand_built_epub(
+            package_document(
+                DC_METADATA,
+                '<item id="ncx" href="toc.ncx" media-type="application/x-dtbncx+xml"/>'
+                '<item id="c1" href="c1.xhtml" media-type="application/xhtml+xml"/>'
+                '<item id="c2" href="c2.xhtml" media-type="application/xhtml+xml"/>',
+                '<spine toc="ncx"><itemref idref="c1"/><itemref idref="c2"/></spine>',
+            ),
+            {"toc.ncx": NCX, "c1.xhtml": CHAPTER, "c2.xhtml": CHAPTER},
+        )
+
+        publication = service.parse_publication(content)
+
+        assert publication.toc == (
+            TocEntry(
+                title="Part One",
+                href="c1.xhtml",
+                children=(TocEntry(title="Chapter One", href="c1.xhtml#sec1"),),
+            ),
+            TocEntry(title="Appendix", href="c2.xhtml"),
+        )
+
+    def test_prefers_the_navigation_document_to_the_ncx(self, service: EpubParserService) -> None:
+        """Should read the navigation of the version the publication declares.
+
+        A publication carrying both is an EPUB 3 keeping an NCX for older
+        readers, and the two disagree often enough to matter: the NCX is the
+        copy that stops being maintained.
+        """
+        content = hand_built_epub(
+            package_document(
+                DC_METADATA,
+                '<item id="ncx" href="toc.ncx" media-type="application/x-dtbncx+xml"/>'
+                '<item id="nav" href="nav.xhtml" media-type="application/xhtml+xml" '
+                'properties="nav"/>'
+                '<item id="c1" href="c1.xhtml" media-type="application/xhtml+xml"/>',
+                '<spine toc="ncx"><itemref idref="c1"/></spine>',
+            ),
+            {"toc.ncx": NCX, "nav.xhtml": NAV_DOCUMENT, "c1.xhtml": CHAPTER},
+        )
+
+        publication = service.parse_publication(content)
+
+        assert [entry.title for entry in publication.toc] == ["From the nav document"]
+
+    def test_a_publication_whose_navigation_is_unreadable_still_opens(
+        self, service: EpubParserService
+    ) -> None:
+        """Should lose the table of contents rather than the book.
+
+        The reading order is what a reader opens; a navigation document that is
+        missing, malformed or states no ``toc`` costs the lines a reader jumps
+        by, and nothing else.
+        """
+        content = hand_built_epub(
+            package_document(
+                DC_METADATA,
+                '<item id="nav" href="nav.xhtml" media-type="application/xhtml+xml" '
+                'properties="nav"/>'
+                '<item id="c1" href="c1.xhtml" media-type="application/xhtml+xml"/>',
+                '<spine><itemref idref="c1"/></spine>',
+            ),
+            {"c1.xhtml": CHAPTER},
+        )
+
+        publication = service.parse_publication(content)
+
+        assert publication.toc == ()
+        assert [item.href for item in publication.reading_order] == ["c1.xhtml"]
+
+
+class TestPublicationIdentifier:
+    """Which ``dc:identifier`` a manifest publishes, and that it is the book's own.
+
+    A reader keys its stored state on the identifier, so one that moved between
+    two requests for the same book would scatter that state across identities
+    that never existed.
+    """
+
+    @staticmethod
+    def _epub_identified_by(metadata: str, unique_id: str = "i") -> bytes:
+        return hand_built_epub(
+            package_document(
+                metadata,
+                '<item id="c1" href="c1.xhtml" media-type="application/xhtml+xml"/>',
+                '<spine><itemref idref="c1"/></spine>',
+                unique_id=unique_id,
+            ),
+            {"c1.xhtml": CHAPTER},
+        )
+
+    def test_publishes_the_identifier_the_package_marks_unique(
+        self, service: EpubParserService
+    ) -> None:
+        """Should pick the named one out of several, not merely the first."""
+        content = self._epub_identified_by(
+            '<dc:identifier id="isbn">urn:isbn:9780000000001</dc:identifier>'
+            '<dc:identifier id="uuid">urn:uuid:0000</dc:identifier>',
+            unique_id="uuid",
+        )
+
+        assert service.parse_publication(content).metadata.identifier == "urn:uuid:0000"
+
+    def test_publishes_an_identifier_the_package_marks_as_nothing(
+        self, service: EpubParserService
+    ) -> None:
+        """Should still name the book when no identifier carries the marked id.
+
+        The identifier a broken package states is worth publishing; an invented
+        one is not, and a fresh one per request least of all.
+        """
+        content = self._epub_identified_by("<dc:identifier>urn:uuid:unmarked</dc:identifier>")
+
+        first = service.parse_publication(content).metadata.identifier
+        second = service.parse_publication(content).metadata.identifier
+
+        assert first == "urn:uuid:unmarked"
+        assert second == first
 
 
 class TestDeclaredEntryCount:

--- a/backend/tests/unit/infrastructure/library/services/test_epub_parser_service.py
+++ b/backend/tests/unit/infrastructure/library/services/test_epub_parser_service.py
@@ -10,11 +10,13 @@ import pytest
 from ebooklib import epub
 
 from src.application.web_reader.publications import ParsedPublication, TocEntry
+from src.domain.library.exceptions import InvalidEbookError
+from src.infrastructure.library.services import epub_parser_service
 from src.infrastructure.library.services.epub_parser_service import (
     EpubParserService,
     _declared_entry_count,  # pyright: ignore[reportPrivateUsage]
 )
-from tests.test_readium_manifest import build_epub
+from tests.test_readium_manifest import build_epub, with_declared_size
 
 FAKE_IMAGE = b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR fake image bytes"
 
@@ -265,15 +267,23 @@ class TestParsePublicationCost:
         assert peak < self.PEAK_LIMIT, f"inflated the publication: {peak / 1024**2:.0f} MiB"
 
 
-def hand_built_epub(package: str, members: dict[str, str], opf_path: str = "content.opf") -> bytes:
+def hand_built_epub(
+    package: str | bytes,
+    members: dict[str, str | bytes],
+    opf_path: str = "content.opf",
+    compression: int = zipfile.ZIP_STORED,
+) -> bytes:
     """An EPUB assembled member by member, for shapes ``build_epub`` cannot take.
 
     ``build_epub`` writes an EPUB 3 with a navigation document, which is the
     shape nearly every assertion wants. These are the ones it is not: a book
-    navigated by an NCX, or one whose navigation is broken.
+    navigated by an NCX, one whose navigation lives in another directory, or one
+    whose structure is a decompression bomb. ``members`` is written in order, so
+    a test can put the member it means to rewrite last -- which is the one
+    ``with_declared_size`` reaches.
     """
     out = io.BytesIO()
-    with zipfile.ZipFile(out, "w") as archive:
+    with zipfile.ZipFile(out, "w", compression) as archive:
         archive.writestr(zipfile.ZipInfo("mimetype"), "application/epub+zip", zipfile.ZIP_STORED)
         archive.writestr(
             "META-INF/container.xml",
@@ -322,6 +332,109 @@ NAV_DOCUMENT = (
     '<body><nav epub:type="toc"><ol><li><a href="c1.xhtml">From the nav document</a></li>'
     "</ol></nav></body></html>"
 )
+
+
+class TestStructuralDocumentsAreBounded:
+    """The three documents the parse *does* read are read on the same terms.
+
+    Not decompressing the content is only half the bound: a publication that
+    resolves from its container, its package document and its navigation is a
+    publication whose bomb goes in one of those three. Their declared sizes are
+    as attacker-controlled as any other member's, and ``ZipFile.read()`` honours
+    a declaration for the result while ignoring it for the work -- so the reads
+    have to be bounded by the declaration and the declaration by a cap.
+    """
+
+    BOMB_SIZE = 64 * 1024 * 1024
+
+    @staticmethod
+    def _outcome_and_peak(service: EpubParserService, content: bytes) -> tuple[object, int]:
+        """Parse a hostile publication and report the outcome and what it peaked at."""
+        tracemalloc.start()
+        try:
+            try:
+                outcome: object = service.parse_publication(content)
+            except InvalidEbookError as e:
+                outcome = e
+            peak = tracemalloc.get_traced_memory()[1]
+        finally:
+            tracemalloc.stop()
+        return outcome, peak
+
+    def test_a_package_document_that_understates_its_size_is_not_inflated(
+        self, service: EpubParserService
+    ) -> None:
+        """Should refuse a package document that lies, without inflating it first.
+
+        The OPF is read before anything is known about the publication, so a
+        member that declares eight bytes and inflates to 64 MiB puts the whole
+        bomb back through the one file the parse cannot skip.
+        """
+        # The package document is written last and nothing follows it, so this
+        # is the member `with_declared_size` rewrites.
+        content = with_declared_size(
+            hand_built_epub(b"A" * self.BOMB_SIZE, {}, compression=zipfile.ZIP_DEFLATED),
+            declared=8,
+        )
+
+        outcome, peak = self._outcome_and_peak(service, content)
+
+        assert isinstance(outcome, InvalidEbookError)
+        assert peak < self.BOMB_SIZE // 8, (
+            f"inflated the package document: {peak / 1024**2:.0f} MiB"
+        )
+
+    def test_a_navigation_document_that_understates_its_size_is_not_inflated(
+        self, service: EpubParserService
+    ) -> None:
+        """Should refuse a lying navigation document rather than degrade past it.
+
+        Navigation that cannot be read costs only the table of contents, which
+        is the right answer for a book that is merely broken. A member lying
+        about its size is not that, and swallowing it would inflate 64 MiB and
+        then serve the publication as though nothing had happened.
+        """
+        content = with_declared_size(
+            hand_built_epub(
+                package_document(
+                    DC_METADATA,
+                    '<item id="nav" href="nav.xhtml" media-type="application/xhtml+xml" '
+                    'properties="nav"/>'
+                    '<item id="c1" href="c1.xhtml" media-type="application/xhtml+xml"/>',
+                    '<spine><itemref idref="c1"/></spine>',
+                ),
+                {"c1.xhtml": CHAPTER, "nav.xhtml": b"A" * self.BOMB_SIZE},
+                compression=zipfile.ZIP_DEFLATED,
+            ),
+            declared=8,
+        )
+
+        outcome, peak = self._outcome_and_peak(service, content)
+
+        assert isinstance(outcome, InvalidEbookError)
+        assert peak < self.BOMB_SIZE // 8, f"inflated the navigation: {peak / 1024**2:.0f} MiB"
+
+    def test_refuses_a_package_document_larger_than_the_cap(
+        self, service: EpubParserService, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Should turn away an honest declaration over the cap, before reading it.
+
+        The cap is lowered rather than the fixture inflated: the guard reads the
+        declaration, so a real 16 MiB package document would only make the test
+        slow.
+        """
+        monkeypatch.setattr(epub_parser_service, "MAX_STRUCTURAL_DOCUMENT_BYTES", 1024)
+        content = hand_built_epub(
+            package_document(
+                DC_METADATA + f"<dc:description>{'x' * 4096}</dc:description>",
+                '<item id="c1" href="c1.xhtml" media-type="application/xhtml+xml"/>',
+                '<spine><itemref idref="c1"/></spine>',
+            ),
+            {"c1.xhtml": CHAPTER},
+        )
+
+        with pytest.raises(InvalidEbookError, match="over the"):
+            service.parse_publication(content)
 
 
 class TestPublicationNavigation:
@@ -380,6 +493,58 @@ class TestPublicationNavigation:
 
         assert [entry.title for entry in publication.toc] == ["From the nav document"]
 
+    @pytest.mark.parametrize(
+        ("navigation_item", "navigation"),
+        [
+            (
+                '<item id="ncx" href="nav/toc.ncx" media-type="application/x-dtbncx+xml"/>',
+                {
+                    "OPS/nav/toc.ncx": NCX.replace('src="c', 'src="../text/c'),
+                },
+            ),
+            (
+                '<item id="nav" href="nav/nav.xhtml" media-type="application/xhtml+xml" '
+                'properties="nav"/>',
+                {
+                    "OPS/nav/nav.xhtml": NAV_DOCUMENT.replace(
+                        'href="c1.xhtml"', 'href="../text/c1.xhtml"'
+                    ),
+                },
+            ),
+        ],
+        ids=["ncx", "nav"],
+    )
+    def test_resolves_a_link_against_the_directory_the_navigation_sits_in(
+        self,
+        service: EpubParserService,
+        navigation_item: str,
+        navigation: dict[str, str | bytes],
+    ) -> None:
+        """Should read ``../text/c1.xhtml`` from ``OPS/nav/`` as ``OPS/text/c1.xhtml``.
+
+        A navigation link is relative to the document that writes it, which is
+        not always the directory the package document sits in. Resolving it
+        anywhere else names a file the publication does not hold: the reading
+        order would say ``OPS/text/c1.xhtml`` while the table of contents said
+        ``text/c1.xhtml``, so every entry in it would lead nowhere.
+        """
+        content = hand_built_epub(
+            package_document(
+                DC_METADATA,
+                navigation_item
+                + '<item id="c1" href="text/c1.xhtml" media-type="application/xhtml+xml"/>'
+                + '<item id="c2" href="text/c2.xhtml" media-type="application/xhtml+xml"/>',
+                '<spine toc="ncx"><itemref idref="c1"/><itemref idref="c2"/></spine>',
+            ),
+            {**navigation, "OPS/text/c1.xhtml": CHAPTER, "OPS/text/c2.xhtml": CHAPTER},
+            opf_path="OPS/package.opf",
+        )
+
+        publication = service.parse_publication(content)
+
+        assert publication.toc[0].href == "OPS/text/c1.xhtml"
+        assert publication.reading_order[0].href == "OPS/text/c1.xhtml"
+
     def test_a_publication_whose_navigation_is_unreadable_still_opens(
         self, service: EpubParserService
     ) -> None:
@@ -429,14 +594,20 @@ class TestPublicationIdentifier:
     def test_publishes_the_identifier_the_package_marks_unique(
         self, service: EpubParserService
     ) -> None:
-        """Should pick the named one out of several, not merely the first."""
+        """Should pick the named one out of several, wherever in the list it sits.
+
+        The designated identifier is written first here and a second one after
+        it, because either ordering passes a rule that simply takes the first or
+        the last identifier it sees -- and only this ordering separates "the one
+        the package designates" from "the one that happens to be last".
+        """
         content = self._epub_identified_by(
             '<dc:identifier id="isbn">urn:isbn:9780000000001</dc:identifier>'
             '<dc:identifier id="uuid">urn:uuid:0000</dc:identifier>',
-            unique_id="uuid",
+            unique_id="isbn",
         )
 
-        assert service.parse_publication(content).metadata.identifier == "urn:uuid:0000"
+        assert service.parse_publication(content).metadata.identifier == "urn:isbn:9780000000001"
 
     def test_publishes_an_identifier_the_package_marks_as_nothing(
         self, service: EpubParserService


### PR DESCRIPTION
Fixes #773.

`parse_publication` no longer uses ebooklib — it reads exactly three members (container.xml, the OPF, the nav/NCX) with lxml; member sizes and CRCs come from the central directory. Measured on the hostile fixtures:

| Case | Before | After |
|---|---|---|
| 130 KB EPUB inflating to 128 MiB (content bomb) | 270 MiB peak | 150 KiB |
| 65 KB EPUB with a size-lying 64 MiB OPF | 141 MiB, parse succeeds | 0.1 MiB, 400 |

- Structural reads are bounded (`_read_structural_document`: declared-size cap → bounded decompression → overrun refusal; 16 MiB cap derived from what a 10,000-item manifest could plausibly write). `read_bounded_member` moved to `infrastructure/common/zip_members.py` for both readers.
- Real bugs ebooklib was hiding, fixed deliberately and pinned: a `dc:identifier` without `id` published a fresh uuid4 **per request**; `unique-identifier` resolution took the last identifier instead of the designated one; NCX hrefs resolved against the OPF's directory instead of the NCX's own; `properties="cover"` xhtml items lost their real href/id.
- Robustness: TOC failures now cost the TOC, not the book (matching `parse_toc`); missing `media-type` typed by extension; missing container members answer per-file 404 at the resource endpoint.
- Old-vs-new equivalence harness over 18 publications: byte-identical except the six documented intentional differences.

The readium request path (`manifest.json`, `resources/{path}`, `positions.json`) is now ebooklib-free. Still eager elsewhere, for follow-up sizing: `epub_text_extraction_service` (chapter-content endpoint + MCP tool — best next candidate), `epub_position_index_service` (sync uploads), and the upload-only paths.

Checks: 1219 backend tests; pyright 0 errors; lint-imports 5 kept / 0 broken; jscpd 2.04% (threshold 2.42). Two adversarial review rounds; every fix red-first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)