### PR TITLE
fix(frontend): keep the Host header intact through the dev proxy

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -8,7 +8,15 @@ import path from 'path';
 // local development has to match. The target is the backend `make dev-app`
 // starts; point it elsewhere here rather than setting VITE_API_URL, which
 // gives up same origin along with the proxy.
-const apiProxy = { '/api': 'http://localhost:8000' };
+// `changeOrigin` must stay false. Vite rewrites the Host header by
+// default, so the backend builds the manifest's `self` link (str(request.url))
+// as http://localhost:8000/... — Readium resolves every resource href against
+// that link, which sends the navigator's fetches and the blob document's <base>
+// cross-origin, past the proxy, where the SameSite cookie and same-origin
+// iframe scripting the reader depends on both stop working.
+const apiProxy = {
+  '/api': { target: 'http://localhost:8000', changeOrigin: false },
+};
 
 // https://vite.dev/config/
 export default defineConfig({


### PR DESCRIPTION
Found by the M2.1 spike (#740): with Vite's `changeOrigin` rewriting the `Host` header, the backend builds the manifest `self` link from `str(request.url)` as `http://localhost:8000/...`, and Readium resolves every resource href and the blob document's `<base>` against it — sending the reader's fetches cross-origin past the proxy, where the SameSite publication cookie and same-origin iframe scripting both stop working.

One line: `changeOrigin: false` (with the reasoning in a comment so it isn't "simplified" away later). Type-check clean; behavior verified live in the spike — the whole M1 surface (session, manifest, positions, resources with 304s) runs green through the proxy with the reader rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)