### PR TITLE
feat(frontend): in-browser EPUB reader on bare @readium/navigator

### DIFF
--- a/docs/adr/0004-web-reader-anchors.md
+++ b/docs/adr/0004-web-reader-anchors.md
@@ -348,3 +348,51 @@ every request.
 - **Any change to the plugin surface.** The KOReader plugin does not load
   publications, so no `koreader-plugin` minimum bump comes out of this
   amendment either.
+
+## Amendment 2: a publication's own scripts
+
+- **Date:** 2026-09-07
+- **Arises from:** #741 (M2.2), found in adversarial review of the reader route
+
+*Amendment 1* settled how an iframe load authenticates. It did not ask what the
+thing inside the iframe is allowed to do, and the answer turned out to be
+"everything".
+
+`@readium/navigator` frames each resource with
+`sandbox="allow-same-origin allow-scripts"` (`FrameManager.ts:28`) and the
+framed document is a `blob:` URL minted by the SPA — so the frame is
+**same-origin with the app**. The CSP the library injects into that document
+permits the content's own JavaScript outright:
+`script-src ${domains} blob: 'unsafe-inline'` (`FrameBlobBuilder.ts:5-21`). A
+`<script>` in an EPUB therefore ran with the reader's own privileges. This was
+not theoretical: a test fixture's `onload` handler reached
+`parent.document.body` and marked it.
+
+That matters because **Crossbill's books are uploaded by their owner from
+wherever they found them**. The library is not a trust boundary, and a
+downloaded EPUB is closer to a downloaded web page than to a document.
+
+**Decision: a publication's markup is disarmed before Readium ever frames it.**
+The `Publication`'s fetcher is ours, and Readium builds every frame from what
+that fetcher returns, so a wrapper around it (`publicationHardening.ts`) parses
+each HTML/XHTML resource, removes `<script>` elements, `on*` handlers and
+`javascript:` URLs, and prepends
+`script-src blob:; object-src 'none'; child-src 'none'`. CSP policies combine
+by intersection, so ours meets the library's at `blob:` — which is exactly the
+line between Readium's own injected scripts and the book's, since the former
+are injected as `<script src="blob:...">` (`Injector.ts`) and the latter never
+are.
+
+**Rejected: dropping `allow-scripts`.** Readium injects `css-selector-generator`
+into every document (`epubInjectables.ts`), and that is what turns a browser
+selection into a Locator — §2's write path, and the ground M3 and M4 stand on.
+Removing script execution from the frame removes the anchors with it.
+
+**Rejected: dropping `allow-same-origin`.** An opaque-origin frame cannot be
+scripted by its parent at all, which is how the navigator drives it.
+
+**Residual, accepted for now.** This is a mitigation, not a sandbox: the frame
+is still same-origin, so anything that does get script running there has the
+page. Scripted EPUB content does not work, which is the intended trade. The
+architectural fix is to serve publication resources from a separate origin;
+Readium's blob-URL design makes that awkward and it is not M2.2's to do.

--- a/docs/adr/0004-web-reader-anchors.md
+++ b/docs/adr/0004-web-reader-anchors.md
@@ -78,6 +78,21 @@ The reverse direction exists too: a selection made in the browser produces a
 locator, which is converted **to an `XPointRange`** before anything is written.
 The write path stores xpointers whichever reader the reader used.
 
+**Ground truth corrected, 2026-09-07 (M2.1/#740, M2.2/#741).** The note in
+*Context* above — that everything about highlights is ours to build — is right
+about **thorium-web** and wrong about the toolkit underneath it. The Readium TS
+toolkit **does** ship a decoration layer: `EpubNavigator.applyDecorations(list,
+group)` and `registerDecorationObserver(group, observer)` are public API on the
+navigator, `@readium/decorator` supplies the styles and the diffing, and the
+decorator module is injected into every publication frame. `@edrlab/thorium-web`
+simply never calls any of it. What is ours to build is therefore the
+*conversion* (xpointer → locator) and the *UI around a selection*, not the
+drawing: rendering a highlight is one call on a navigator we own, under a group
+name we reserve (`crossbill-highlights`,
+`frontend/src/components/reader/decorations.ts`). This narrows M3.2 rather than
+changing any decision above — the locator stays derived, and the decoration is
+drawn from it.
+
 ### 3. CFI is export only
 
 EPUB CFI is a **nice-to-have export format (M5.5), never stored and never on a

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,6 +27,8 @@
     "@mui/icons-material": "^9.3.1",
     "@mui/material": "^9.4.0",
     "@mui/x-date-pickers": "^9.12.0",
+    "@readium/navigator": "^2.8.2",
+    "@readium/shared": "^2.4.0",
     "@tanstack/react-query": "^5.101.4",
     "@tanstack/react-router": "^1.170.32",
     "axios": "^1.20.0",

--- a/frontend/src/components/reader/ReaderChrome.tsx
+++ b/frontend/src/components/reader/ReaderChrome.tsx
@@ -1,3 +1,4 @@
+import { chromeMarkerProps } from '@/components/reader/chromeMarker.ts';
 import type { ReaderPreferences } from '@/components/reader/readerPreferences.ts';
 import { ReaderSettings } from '@/components/reader/ReaderSettings.tsx';
 import { ChapterListIcon, CloseIcon, PaletteIcon } from '@/theme/Icons.tsx';
@@ -40,6 +41,7 @@ export const ReaderChrome = ({
   return (
     <Box
       component="header"
+      {...chromeMarkerProps}
       sx={{
         flex: '0 0 auto',
         borderBottom: 1,

--- a/frontend/src/components/reader/ReaderChrome.tsx
+++ b/frontend/src/components/reader/ReaderChrome.tsx
@@ -1,0 +1,95 @@
+import type { ReaderPreferences } from '@/components/reader/readerPreferences.ts';
+import { ReaderSettings } from '@/components/reader/ReaderSettings.tsx';
+import { ChapterListIcon, CloseIcon, PaletteIcon } from '@/theme/Icons.tsx';
+import { ICON_SIZE } from '@/theme/iconSizes.ts';
+import { Box, IconButton, Stack, Toolbar, Tooltip, Typography } from '@mui/material';
+import { useState } from 'react';
+
+interface ReaderChromeProps {
+  title: string;
+  /** "Page 12 of 340 · 4%", or nothing when the book publishes no position list. */
+  positionLabel: string | null;
+  onOpenToc: () => void;
+  onClose: () => void;
+  preferences: ReaderPreferences;
+  onPreferencesChange: (preferences: ReaderPreferences) => void;
+  fontSizeRange: [number, number];
+  fontSizeStep: number;
+}
+
+/**
+ * The bar above the page: where you are, how to get somewhere else, and how to
+ * leave.
+ *
+ * It carries no colours of its own. The reading theme decides what the page
+ * looks like, and a bar that stayed white above a dark page would be the
+ * brightest thing on the screen.
+ */
+export const ReaderChrome = ({
+  title,
+  positionLabel,
+  onOpenToc,
+  onClose,
+  preferences,
+  onPreferencesChange,
+  fontSizeRange,
+  fontSizeStep,
+}: ReaderChromeProps) => {
+  const [settingsAnchor, setSettingsAnchor] = useState<HTMLElement | null>(null);
+
+  return (
+    <Box
+      component="header"
+      sx={{
+        flex: '0 0 auto',
+        borderBottom: 1,
+        borderColor: 'divider',
+        color: 'inherit',
+      }}
+    >
+      <Toolbar variant="dense" sx={{ gap: 1 }}>
+        <Tooltip title="Contents">
+          <IconButton onClick={onOpenToc} aria-label="Contents" color="inherit">
+            <ChapterListIcon sx={{ fontSize: ICON_SIZE.ui }} />
+          </IconButton>
+        </Tooltip>
+
+        <Stack sx={{ flex: 1, minWidth: 0 }}>
+          <Typography variant="h6" component="h1" noWrap title={title}>
+            {title}
+          </Typography>
+          {positionLabel && (
+            <Typography variant="body2" noWrap sx={{ opacity: 0.7 }}>
+              {positionLabel}
+            </Typography>
+          )}
+        </Stack>
+
+        <Tooltip title="Appearance">
+          <IconButton
+            onClick={(event) => setSettingsAnchor(event.currentTarget)}
+            aria-label="Appearance"
+            color="inherit"
+          >
+            <PaletteIcon sx={{ fontSize: ICON_SIZE.ui }} />
+          </IconButton>
+        </Tooltip>
+
+        <Tooltip title="Close reader">
+          <IconButton onClick={onClose} aria-label="Close reader" color="inherit">
+            <CloseIcon sx={{ fontSize: ICON_SIZE.ui }} />
+          </IconButton>
+        </Tooltip>
+      </Toolbar>
+
+      <ReaderSettings
+        anchorEl={settingsAnchor}
+        onClose={() => setSettingsAnchor(null)}
+        preferences={preferences}
+        onChange={onPreferencesChange}
+        fontSizeRange={fontSizeRange}
+        fontSizeStep={fontSizeStep}
+      />
+    </Box>
+  );
+};

--- a/frontend/src/components/reader/ReaderSettings.tsx
+++ b/frontend/src/components/reader/ReaderSettings.tsx
@@ -1,3 +1,4 @@
+import { chromeMarkerProps } from '@/components/reader/chromeMarker.ts';
 import {
   READER_THEMES,
   READER_THEME_LABELS,
@@ -50,7 +51,7 @@ export const ReaderSettings = ({
     transformOrigin={{ vertical: 'top', horizontal: 'right' }}
     slotProps={{ paper: { sx: { p: 2.5, width: 280 } } }}
   >
-    <Stack spacing={3}>
+    <Stack spacing={3} {...chromeMarkerProps}>
       <Box>
         <Typography variant="h6" component="h2" gutterBottom>
           Font size

--- a/frontend/src/components/reader/ReaderSettings.tsx
+++ b/frontend/src/components/reader/ReaderSettings.tsx
@@ -1,0 +1,99 @@
+import {
+  READER_THEMES,
+  READER_THEME_LABELS,
+  type ReaderPreferences,
+  type ReaderThemeName,
+} from '@/components/reader/readerPreferences.ts';
+import {
+  Box,
+  Popover,
+  Slider,
+  Stack,
+  ToggleButton,
+  ToggleButtonGroup,
+  Typography,
+} from '@mui/material';
+
+interface ReaderSettingsProps {
+  anchorEl: HTMLElement | null;
+  onClose: () => void;
+  preferences: ReaderPreferences;
+  onChange: (preferences: ReaderPreferences) => void;
+  /** The range and step the navigator's own `EpubPreferencesEditor` reports for font size. */
+  fontSizeRange: [number, number];
+  fontSizeStep: number;
+}
+
+const asPercentage = (multiplier: number) => `${Math.round(multiplier * 100)}%`;
+
+/**
+ * The reader's appearance controls: how big the text is, and what colour the
+ * page is.
+ *
+ * Deliberately two settings. Readium exposes forty, and the ones worth having
+ * in a first reader are the two every e-reader opens with; the rest can be
+ * added once there is a reason to prefer one over the book's own typography.
+ */
+export const ReaderSettings = ({
+  anchorEl,
+  onClose,
+  preferences,
+  onChange,
+  fontSizeRange,
+  fontSizeStep,
+}: ReaderSettingsProps) => (
+  <Popover
+    open={anchorEl !== null}
+    anchorEl={anchorEl}
+    onClose={onClose}
+    anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+    transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+    slotProps={{ paper: { sx: { p: 2.5, width: 280 } } }}
+  >
+    <Stack spacing={3}>
+      <Box>
+        <Typography variant="h6" component="h2" gutterBottom>
+          Font size
+        </Typography>
+        <Stack direction="row" spacing={2} sx={{ alignItems: 'center' }}>
+          <Slider
+            aria-label="Font size"
+            value={preferences.fontSize}
+            min={fontSizeRange[0]}
+            max={fontSizeRange[1]}
+            step={fontSizeStep}
+            onChange={(_event, value) => onChange({ ...preferences, fontSize: value })}
+            valueLabelDisplay="off"
+          />
+          <Typography variant="body2" sx={{ minWidth: 48, textAlign: 'right' }}>
+            {asPercentage(preferences.fontSize)}
+          </Typography>
+        </Stack>
+      </Box>
+
+      <Box>
+        <Typography variant="h6" component="h2" gutterBottom>
+          Page colour
+        </Typography>
+        <ToggleButtonGroup
+          exclusive
+          fullWidth
+          size="small"
+          value={preferences.theme}
+          aria-label="Page colour"
+          onChange={(_event, value: ReaderThemeName | null) => {
+            // Null when the pressed button was already the active one; a
+            // reading theme is never "none", so that click means nothing.
+            if (value !== null) onChange({ ...preferences, theme: value });
+          }}
+        >
+          {READER_THEMES.map((name) => (
+            <ToggleButton key={name} value={name}>
+              {READER_THEME_LABELS[name]}
+            </ToggleButton>
+          ))}
+        </ToggleButtonGroup>
+      </Box>
+    </Stack>
+  </Popover>
+);

--- a/frontend/src/components/reader/ReaderShell.tsx
+++ b/frontend/src/components/reader/ReaderShell.tsx
@@ -1,3 +1,4 @@
+import { CHROME_MARKER } from '@/components/reader/chromeMarker.ts';
 import { HIGHLIGHT_DECORATION_GROUP } from '@/components/reader/decorations.ts';
 import { ReaderChrome } from '@/components/reader/ReaderChrome.tsx';
 import {
@@ -29,6 +30,16 @@ const DEFAULT_FONT_SIZE_BOUNDS: { range: [number, number]; step: number } = {
   range: [0.7, 4],
   step: 0.05,
 };
+
+/**
+ * How long a book gets to appear before the wait is called a failure.
+ *
+ * Generous, because it has to cover a large publication over a slow link on a
+ * cold server-side cache: the cost of being wrong here is a reader told to try
+ * again for a book that was about to render, which is worse than the extra
+ * wait.
+ */
+const BOOT_TIMEOUT_MS = 30_000;
 
 interface ReaderShellProps {
   bookId: number;
@@ -87,6 +98,10 @@ export const ReaderShell = ({ bookId, title, onClose }: ReaderShellProps) => {
   const [isPageVisible, setIsPageVisible] = useState(false);
   const [locator, setLocator] = useState<Locator | null>(null);
   const [isTocOpen, setIsTocOpen] = useState(false);
+  const [bootFailed, setBootFailed] = useState(false);
+  // Bumped to ask for the whole navigator again, which is the only meaningful
+  // retry: a half-built one has frames and blobs that have to go first.
+  const [bootAttempt, setBootAttempt] = useState(0);
   const [preferences, setPreferences] = useState<ReaderPreferences>(DEFAULT_READER_PREFERENCES);
   // Copied out of the navigator's own `EpubPreferencesEditor` once it exists,
   // rather than read off the instance while rendering: the editor is a live
@@ -101,8 +116,19 @@ export const ReaderShell = ({ bookId, title, onClose }: ReaderShellProps) => {
   // life without the navigator having to be rebuilt.
   const handleKeyDown = useCallback(
     (event: KeyboardEvent) => {
+      if (event.key !== 'ArrowRight' && event.key !== 'ArrowLeft') return;
+      // An arrow key belongs to whatever control is using it. On the font-size
+      // slider it is a font size, in the contents list it is the next chapter;
+      // it is only a page turn when the book itself has the keyboard. Chrome
+      // marks itself rather than being enumerated here, because the drawer and
+      // the popover are portalled out of this tree and a DOM ancestor check is
+      // the one test that still finds them. Events from inside a publication
+      // frame arrive from another document, where this matches nothing.
+      const target = event.target;
+      if (target instanceof Element && target.closest(`[${CHROME_MARKER}]`)) return;
+
       if (event.key === 'ArrowRight') goForward();
-      if (event.key === 'ArrowLeft') goBackward();
+      else goBackward();
     },
     [goForward, goBackward]
   );
@@ -201,17 +227,35 @@ export const ReaderShell = ({ bookId, title, onClose }: ReaderShellProps) => {
       const fontSize = epubNavigator.preferencesEditor.fontSize;
       setFontSizeBounds({ range: fontSize.supportedRange, step: fontSize.step });
       setLocator(epubNavigator.currentLocator);
+      clearTimeout(watchdog);
+    });
+
+    // A book that never arrives is indistinguishable, on screen, from one still
+    // arriving: the skeleton looks the same either way. The watchdog is what
+    // turns a load that has silently stopped — a hung fetch, a frame that never
+    // fires — into something the reader can see and act on.
+    const watchdog = setTimeout(() => {
+      if (!isStale()) setBootFailed(true);
+    }, BOOT_TIMEOUT_MS);
+
+    boot.catch(() => {
+      if (!isStale()) setBootFailed(true);
     });
 
     bootRef.current = boot.catch(() => undefined);
 
     return () => {
       teardown.abort();
+      clearTimeout(watchdog);
       setIsPageVisible(false);
       navigatorRef.current = null;
       // Chained rather than immediate: destroying a navigator that is still
-      // loading leaves its frames behind in the container.
+      // loading leaves its frames behind in the container. The `catch` comes
+      // first so that teardown runs after a boot that *failed* too — chaining
+      // it off `then` alone leaked a whole navigator, frames and blobs
+      // included, every time a load went wrong and the reader tried again.
       bootRef.current = boot
+        .catch(() => undefined)
         .then(() => epubNavigator?.destroy())
         .then(() => container?.remove())
         .catch(() => undefined);
@@ -220,7 +264,7 @@ export const ReaderShell = ({ bookId, title, onClose }: ReaderShellProps) => {
     // submitted to the live one below. Listing it would rebuild the reader,
     // and the book would jump back to page one on every font-size nudge.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isReady, publication, positions, theme, handleKeyDown]);
+  }, [isReady, publication, positions, theme, handleKeyDown, bootAttempt]);
 
   useEffect(() => {
     if (!isPageVisible) return;
@@ -256,6 +300,20 @@ export const ReaderShell = ({ bookId, title, onClose }: ReaderShellProps) => {
     return (
       <ReaderMessage onClose={onClose}>
         The reader could not start a session for this book. Please try again later.
+      </ReaderMessage>
+    );
+  }
+
+  if (bootFailed) {
+    return (
+      <ReaderMessage
+        onClose={onClose}
+        onRetry={() => {
+          setBootFailed(false);
+          setBootAttempt((attempt) => attempt + 1);
+        }}
+      >
+        This book could not be opened in the reader.
       </ReaderMessage>
     );
   }
@@ -362,10 +420,12 @@ const PageTurnButton = ({ edge, onClick }: PageTurnButtonProps) => (
 interface ReaderMessageProps {
   children: string;
   onClose: () => void;
+  /** Offered only where trying again could plausibly work. */
+  onRetry?: () => void;
 }
 
 /** The whole-viewport stand-in for a book that cannot be read. */
-const ReaderMessage = ({ children, onClose }: ReaderMessageProps) => (
+const ReaderMessage = ({ children, onClose, onRetry }: ReaderMessageProps) => (
   <Box
     sx={{
       position: 'fixed',
@@ -382,9 +442,16 @@ const ReaderMessage = ({ children, onClose }: ReaderMessageProps) => (
       <Typography variant="body1" sx={{ color: 'text.secondary' }}>
         {children}
       </Typography>
-      <Button variant="outlined" onClick={onClose}>
-        Back to book
-      </Button>
+      <Stack direction="row" spacing={2}>
+        <Button variant="outlined" onClick={onClose}>
+          Back to book
+        </Button>
+        {onRetry && (
+          <Button variant="contained" onClick={onRetry}>
+            Try again
+          </Button>
+        )}
+      </Stack>
     </Stack>
   </Box>
 );

--- a/frontend/src/components/reader/ReaderShell.tsx
+++ b/frontend/src/components/reader/ReaderShell.tsx
@@ -34,12 +34,16 @@ const DEFAULT_FONT_SIZE_BOUNDS: { range: [number, number]; step: number } = {
 /**
  * How long a book gets to appear before the wait is called a failure.
  *
- * Generous, because it has to cover a large publication over a slow link on a
- * cold server-side cache: the cost of being wrong here is a reader told to try
- * again for a book that was about to render, which is worse than the extra
- * wait.
+ * Only the frame-building phase is under this clock — the manifest and the
+ * position list are separate queries that have already answered — so it covers
+ * fetching a chapter or two and assembling their blobs. Generous for that, and
+ * short enough that a reader who is never getting a book is told rather than
+ * left watching a skeleton.
  */
-const BOOT_TIMEOUT_MS = 30_000;
+const BOOT_TIMEOUT_MS = 15_000;
+
+/** How long an abandoned navigator gets to tear itself down before it is dropped. */
+const DESTROY_TIMEOUT_MS = 2_000;
 
 interface ReaderShellProps {
   bookId: number;
@@ -88,7 +92,7 @@ const whenSized = (element: HTMLElement) =>
  */
 export const ReaderShell = ({ bookId, title, onClose }: ReaderShellProps) => {
   const theme = useTheme();
-  const sessionStatus = useReaderSession(bookId);
+  const { status: sessionStatus, isRenewing } = useReaderSession(bookId);
   const { status: publicationStatus, publication, positions } = useReaderPublication(bookId);
 
   const viewportRef = useRef<HTMLDivElement | null>(null);
@@ -111,12 +115,20 @@ export const ReaderShell = ({ bookId, title, onClose }: ReaderShellProps) => {
   const goForward = useCallback(() => navigatorRef.current?.goForward(true, () => {}), []);
   const goBackward = useCallback(() => navigatorRef.current?.goBackward(true, () => {}), []);
 
+  // Mirrored into a ref so the key handler can consult it without becoming a
+  // new function, which would mean rebinding every publication frame.
+  const isRenewingRef = useRef(false);
+  useEffect(() => {
+    isRenewingRef.current = isRenewing;
+  }, [isRenewing]);
+
   // Stable, because both page turns read the navigator out of a ref. That is
   // what lets the same handler be bound to each publication frame for its whole
   // life without the navigator having to be rebuilt.
   const handleKeyDown = useCallback(
     (event: KeyboardEvent) => {
       if (event.key !== 'ArrowRight' && event.key !== 'ArrowLeft') return;
+      if (isRenewingRef.current) return;
       // An arrow key belongs to whatever control is using it. On the font-size
       // slider it is a font size, in the contents list it is the next chapter;
       // it is only a page turn when the book itself has the keyboard. Chrome
@@ -155,8 +167,38 @@ export const ReaderShell = ({ bookId, title, onClose }: ReaderShellProps) => {
     // Read through a call rather than the property: a narrowed flag is not what
     // this is, and the compiler would happily prove a later check redundant.
     const isStale = () => teardown.signal.aborted;
+    // Disposal is tracked apart from staleness because the watchdog does both
+    // at once and the cleanup that follows must not do the second one twice.
+    const disposal = new AbortController();
+    const isDisposed = () => disposal.signal.aborted;
     let epubNavigator: EpubNavigator | null = null;
     let container: HTMLDivElement | null = null;
+
+    /**
+     * Takes the navigator and its container down without waiting on the boot
+     * that built them — which is the whole point, because the boot may be the
+     * thing that is stuck.
+     */
+    const dispose = async () => {
+      if (isDisposed()) return;
+      disposal.abort();
+      const abandoned = epubNavigator;
+      const node = container;
+      epubNavigator = null;
+      container = null;
+      if (navigatorRef.current === abandoned) navigatorRef.current = null;
+      if (abandoned) {
+        // A destroy can hang for the same reason a load did, and somebody is
+        // waiting on a fresh reader: give it a moment, then let it go.
+        await Promise.race([
+          Promise.resolve()
+            .then(() => abandoned.destroy())
+            .catch(() => undefined),
+          new Promise((resolve) => setTimeout(resolve, DESTROY_TIMEOUT_MS)),
+        ]);
+      }
+      node?.remove();
+    };
 
     const boot = bootRef.current.then(async () => {
       if (isStale()) return;
@@ -235,7 +277,17 @@ export const ReaderShell = ({ bookId, title, onClose }: ReaderShellProps) => {
     // turns a load that has silently stopped — a hung fetch, a frame that never
     // fires — into something the reader can see and act on.
     const watchdog = setTimeout(() => {
-      if (!isStale()) setBootFailed(true);
+      if (isStale()) return;
+      setBootFailed(true);
+      // The load is not coming back, and everything downstream of it is
+      // chained to a promise that will never settle — the teardown, and so the
+      // next attempt too. Abandon it here instead: the boot's remaining steps
+      // become no-ops, the queue gets a fresh start so "Try again" is not
+      // waiting behind the load that hung, and what was built comes down now
+      // rather than whenever that load decides to finish.
+      teardown.abort();
+      bootRef.current = Promise.resolve();
+      void dispose();
     }, BOOT_TIMEOUT_MS);
 
     boot.catch(() => {
@@ -249,6 +301,9 @@ export const ReaderShell = ({ bookId, title, onClose }: ReaderShellProps) => {
       clearTimeout(watchdog);
       setIsPageVisible(false);
       navigatorRef.current = null;
+      // Already abandoned by the watchdog, which left a fresh promise in the
+      // ref: chaining onto the hung boot again would put it straight back.
+      if (isDisposed()) return;
       // Chained rather than immediate: destroying a navigator that is still
       // loading leaves its frames behind in the container. The `catch` comes
       // first so that teardown runs after a boot that *failed* too — chaining
@@ -256,8 +311,7 @@ export const ReaderShell = ({ bookId, title, onClose }: ReaderShellProps) => {
       // included, every time a load went wrong and the reader tried again.
       bootRef.current = boot
         .catch(() => undefined)
-        .then(() => epubNavigator?.destroy())
-        .then(() => container?.remove())
+        .then(dispose)
         .catch(() => undefined);
     };
     // `preferences` is deliberately absent: it seeds the navigator here and is
@@ -343,8 +397,8 @@ export const ReaderShell = ({ bookId, title, onClose }: ReaderShellProps) => {
       />
 
       <Box sx={{ flex: 1, minHeight: 0, position: 'relative' }}>
-        <PageTurnButton edge="left" onClick={goBackward} />
-        <PageTurnButton edge="right" onClick={goForward} />
+        <PageTurnButton edge="left" onClick={goBackward} disabled={isRenewing} />
+        <PageTurnButton edge="right" onClick={goForward} disabled={isRenewing} />
 
         {/* The element the navigator measures. Its own container is created
             inside it once it has a box, and the frames Readium appends are
@@ -379,6 +433,27 @@ export const ReaderShell = ({ bookId, title, onClose }: ReaderShellProps) => {
             </Box>
           </Stack>
         )}
+
+        {/* The cookie behind every resource load has lapsed while the tab was
+            away. Turning a page now would ask for a chapter with a dead
+            credential and get a blank frame back, so the book is held — briefly,
+            and over the page rather than instead of it — until the replacement
+            lands. */}
+        {isPageVisible && isRenewing && (
+          <Stack
+            aria-live="polite"
+            sx={{
+              position: 'absolute',
+              inset: 0,
+              alignItems: 'center',
+              justifyContent: 'center',
+              backgroundColor: pageColors.background,
+              opacity: 0.9,
+            }}
+          >
+            <Typography variant="body2">Reconnecting...</Typography>
+          </Stack>
+        )}
       </Box>
 
       <TocDrawer
@@ -394,11 +469,13 @@ export const ReaderShell = ({ bookId, title, onClose }: ReaderShellProps) => {
 interface PageTurnButtonProps {
   edge: 'left' | 'right';
   onClick: () => void;
+  disabled: boolean;
 }
 
-const PageTurnButton = ({ edge, onClick }: PageTurnButtonProps) => (
+const PageTurnButton = ({ edge, onClick, disabled }: PageTurnButtonProps) => (
   <IconButton
     onClick={onClick}
+    disabled={disabled}
     color="inherit"
     aria-label={edge === 'left' ? 'Previous page' : 'Next page'}
     sx={{

--- a/frontend/src/components/reader/ReaderShell.tsx
+++ b/frontend/src/components/reader/ReaderShell.tsx
@@ -1,0 +1,390 @@
+import { HIGHLIGHT_DECORATION_GROUP } from '@/components/reader/decorations.ts';
+import { ReaderChrome } from '@/components/reader/ReaderChrome.tsx';
+import {
+  DEFAULT_READER_PREFERENCES,
+  readerPageColors,
+  toEpubPreferences,
+  type ReaderPreferences,
+} from '@/components/reader/readerPreferences.ts';
+import { TocDrawer } from '@/components/reader/TocDrawer.tsx';
+import { useReaderPublication } from '@/components/reader/useReaderPublication.ts';
+import { useReaderSession } from '@/components/reader/useReaderSession.ts';
+import { NextPageIcon, PreviousPageIcon } from '@/theme/Icons.tsx';
+import { ICON_SIZE } from '@/theme/iconSizes.ts';
+import { Box, Button, IconButton, Skeleton, Stack, Typography, useTheme } from '@mui/material';
+import { EpubNavigator } from '@readium/navigator';
+import type { Link, Locator } from '@readium/shared';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+/** Room in the margins for the page-turn buttons, so they never sit on the text. */
+const PAGE_TURN_GUTTER = 48;
+
+/**
+ * What the font-size control offers before there is a navigator to ask.
+ *
+ * Replaced by `EpubPreferencesEditor`'s own numbers as soon as one has loaded,
+ * which is before the settings popover can be opened at all.
+ */
+const DEFAULT_FONT_SIZE_BOUNDS: { range: [number, number]; step: number } = {
+  range: [0.7, 4],
+  step: 0.05,
+};
+
+interface ReaderShellProps {
+  bookId: number;
+  title: string;
+  onClose: () => void;
+}
+
+/** Resolves once the element has a real box, or immediately if it already has one. */
+const whenSized = (element: HTMLElement) =>
+  new Promise<void>((resolve) => {
+    if (element.clientWidth > 0 && element.clientHeight > 0) {
+      resolve();
+      return;
+    }
+    const observer = new ResizeObserver(() => {
+      if (element.clientWidth > 0 && element.clientHeight > 0) {
+        observer.disconnect();
+        resolve();
+      }
+    });
+    observer.observe(element);
+  });
+
+/**
+ * The reader itself: one `EpubNavigator`, the chrome around it, and the two
+ * credentials that let it read a book.
+ *
+ * Three things about the lifecycle are load-bearing.
+ *
+ * **The container is sized before the navigator sees it.** Readium gives its
+ * iframes `position: absolute` and no dimensions at all, and sizes the
+ * container from the *parent* it observes — so a navigator built against an
+ * unsized element renders every frame at the browser's default 300x150 and
+ * never recovers. The viewport below is a fixed, flex-sized element; the
+ * navigator's own container is created inside it only once it measures
+ * non-zero.
+ *
+ * **The navigator lives in a ref, never in state.** It is a mutable object
+ * with a DOM subtree under it; putting it in state would re-render the tree
+ * that owns that subtree on every page turn.
+ *
+ * **Boots are serialised.** React 19's StrictMode mounts effects twice, and
+ * `destroy()` is asynchronous: without chaining, the first navigator's
+ * teardown lands in the middle of the second one's load and takes its frames
+ * with it.
+ */
+export const ReaderShell = ({ bookId, title, onClose }: ReaderShellProps) => {
+  const theme = useTheme();
+  const sessionStatus = useReaderSession(bookId);
+  const { status: publicationStatus, publication, positions } = useReaderPublication(bookId);
+
+  const viewportRef = useRef<HTMLDivElement | null>(null);
+  const navigatorRef = useRef<EpubNavigator | null>(null);
+  const bootRef = useRef<Promise<unknown>>(Promise.resolve());
+
+  const [isPageVisible, setIsPageVisible] = useState(false);
+  const [locator, setLocator] = useState<Locator | null>(null);
+  const [isTocOpen, setIsTocOpen] = useState(false);
+  const [preferences, setPreferences] = useState<ReaderPreferences>(DEFAULT_READER_PREFERENCES);
+  // Copied out of the navigator's own `EpubPreferencesEditor` once it exists,
+  // rather than read off the instance while rendering: the editor is a live
+  // object hanging off a ref, and a ref is not something a render may consult.
+  const [fontSizeBounds, setFontSizeBounds] = useState(DEFAULT_FONT_SIZE_BOUNDS);
+
+  const goForward = useCallback(() => navigatorRef.current?.goForward(true, () => {}), []);
+  const goBackward = useCallback(() => navigatorRef.current?.goBackward(true, () => {}), []);
+
+  // Stable, because both page turns read the navigator out of a ref. That is
+  // what lets the same handler be bound to each publication frame for its whole
+  // life without the navigator having to be rebuilt.
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent) => {
+      if (event.key === 'ArrowRight') goForward();
+      if (event.key === 'ArrowLeft') goBackward();
+    },
+    [goForward, goBackward]
+  );
+
+  useEffect(() => {
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [handleKeyDown]);
+
+  const isReady =
+    sessionStatus === 'ready' &&
+    publicationStatus === 'ready' &&
+    !!publication &&
+    positions !== undefined;
+
+  useEffect(() => {
+    if (!isReady) return;
+    const viewport = viewportRef.current;
+    if (!viewport) return;
+
+    // An AbortController rather than a plain flag: this boot is a chain of
+    // awaits, and every step has to be able to ask whether it still matters.
+    const teardown = new AbortController();
+    // Read through a call rather than the property: a narrowed flag is not what
+    // this is, and the compiler would happily prove a later check redundant.
+    const isStale = () => teardown.signal.aborted;
+    let epubNavigator: EpubNavigator | null = null;
+    let container: HTMLDivElement | null = null;
+
+    const boot = bootRef.current.then(async () => {
+      if (isStale()) return;
+      await whenSized(viewport);
+      if (isStale()) return;
+
+      container = document.createElement('div');
+      container.style.position = 'relative';
+      container.style.height = '100%';
+      container.style.margin = '0 auto';
+      viewport.appendChild(container);
+
+      epubNavigator = new EpubNavigator(
+        container,
+        publication,
+        {
+          /**
+           * One frame of the publication is in the DOM and scriptable.
+           *
+           * The seam M3.2 hangs its highlights on: decorations are applied per
+           * frame, so this is where a newly loaded resource gets the ones that
+           * belong to it. Today it only reveals the page and gives the frame
+           * the arrow keys, which a same-origin iframe does not bubble up on
+           * its own.
+           */
+          frameLoaded: (frameWindow: Window) => {
+            frameWindow.addEventListener('keydown', handleKeyDown);
+            setIsPageVisible(true);
+          },
+          positionChanged: (current: Locator) => setLocator(current),
+          /**
+           * The reader selected text in the book.
+           *
+           * `selection.locator` is populated by the navigator — the
+           * browser-selection to Locator half of ADR-0004 §2's write path.
+           * M4.1 converts it to an `XPointRange` and offers to highlight it;
+           * until then, selecting text does what selecting text does.
+           */
+          textSelected: () => {},
+          timelineItemChanged: () => {},
+          tap: () => true,
+          click: () => true,
+          zoom: () => {},
+          miscPointer: () => {},
+          scroll: () => {},
+          customEvent: () => {},
+          handleLocator: () => false,
+          contentProtection: () => {},
+          contextMenu: () => {},
+          peripheral: () => {},
+        },
+        positions,
+        undefined,
+        { preferences: toEpubPreferences(theme, preferences), defaults: {} }
+      );
+
+      // Reserved now so the group exists before anything draws into it, and so
+      // that a decoration activated in M3.2 already has somewhere to arrive.
+      epubNavigator.registerDecorationObserver(HIGHLIGHT_DECORATION_GROUP, {});
+
+      navigatorRef.current = epubNavigator;
+      await epubNavigator.load();
+      // The frame pool is laid out from the container's measurements, which
+      // are only final after the browser has painted the frames it just added.
+      await new Promise((resolve) => requestAnimationFrame(resolve));
+      await epubNavigator.resizeHandler();
+      if (isStale()) return;
+      const fontSize = epubNavigator.preferencesEditor.fontSize;
+      setFontSizeBounds({ range: fontSize.supportedRange, step: fontSize.step });
+      setLocator(epubNavigator.currentLocator);
+    });
+
+    bootRef.current = boot.catch(() => undefined);
+
+    return () => {
+      teardown.abort();
+      setIsPageVisible(false);
+      navigatorRef.current = null;
+      // Chained rather than immediate: destroying a navigator that is still
+      // loading leaves its frames behind in the container.
+      bootRef.current = boot
+        .then(() => epubNavigator?.destroy())
+        .then(() => container?.remove())
+        .catch(() => undefined);
+    };
+    // `preferences` is deliberately absent: it seeds the navigator here and is
+    // submitted to the live one below. Listing it would rebuild the reader,
+    // and the book would jump back to page one on every font-size nudge.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isReady, publication, positions, theme, handleKeyDown]);
+
+  useEffect(() => {
+    if (!isPageVisible) return;
+    void navigatorRef.current?.submitPreferences(toEpubPreferences(theme, preferences));
+  }, [isPageVisible, preferences, theme]);
+
+  const goToTocEntry = useCallback((link: Link) => {
+    setIsTocOpen(false);
+    navigatorRef.current?.goLink(link, true, () => {});
+  }, []);
+
+  const pageColors = readerPageColors(theme, preferences.theme);
+  const page = locator?.locations.position;
+  const progression = locator?.locations.totalProgression;
+  const pageCount = positions?.length ?? 0;
+  const positionLabel =
+    pageCount > 0 && page !== undefined
+      ? `Page ${page} of ${pageCount}` +
+        (progression === undefined ? '' : ` · ${Math.round(progression * 100)}%`)
+      : null;
+
+  if (publicationStatus === 'missing' || publicationStatus === 'error') {
+    return (
+      <ReaderMessage onClose={onClose}>
+        {publicationStatus === 'missing'
+          ? 'This book has no EPUB file, so there is nothing to read here yet. Upload one to read it in the browser.'
+          : 'The book could not be opened. Please try again later.'}
+      </ReaderMessage>
+    );
+  }
+
+  if (sessionStatus === 'error') {
+    return (
+      <ReaderMessage onClose={onClose}>
+        The reader could not start a session for this book. Please try again later.
+      </ReaderMessage>
+    );
+  }
+
+  return (
+    <Box
+      sx={{
+        position: 'fixed',
+        inset: 0,
+        zIndex: (t) => t.zIndex.appBar + 1,
+        display: 'flex',
+        flexDirection: 'column',
+        backgroundColor: pageColors.background,
+        color: pageColors.text,
+        transition: (t) => t.transitions.create(['background-color', 'color']),
+      }}
+    >
+      <ReaderChrome
+        title={title}
+        positionLabel={positionLabel}
+        onOpenToc={() => setIsTocOpen(true)}
+        onClose={onClose}
+        preferences={preferences}
+        onPreferencesChange={setPreferences}
+        fontSizeRange={fontSizeBounds.range}
+        fontSizeStep={fontSizeBounds.step}
+      />
+
+      <Box sx={{ flex: 1, minHeight: 0, position: 'relative' }}>
+        <PageTurnButton edge="left" onClick={goBackward} />
+        <PageTurnButton edge="right" onClick={goForward} />
+
+        {/* The element the navigator measures. Its own container is created
+            inside it once it has a box, and the frames Readium appends are
+            given the dimensions the library does not set for itself. */}
+        <Box
+          ref={viewportRef}
+          data-testid="reader-viewport"
+          sx={{
+            height: '100%',
+            px: `${PAGE_TURN_GUTTER}px`,
+            visibility: isPageVisible ? 'visible' : 'hidden',
+            '& .readium-navigator-iframe': {
+              position: 'absolute',
+              inset: 0,
+              width: '100%',
+              height: '100%',
+              border: 'none',
+            },
+          }}
+        />
+
+        {!isPageVisible && (
+          <Stack
+            aria-label="Loading the book"
+            aria-busy="true"
+            sx={{ position: 'absolute', inset: 0, p: 4, gap: 1.5, alignItems: 'center' }}
+          >
+            <Box sx={{ width: '100%', maxWidth: 640 }}>
+              {Array.from({ length: 12 }, (_, index) => index).map((index) => (
+                <Skeleton key={index} height={28} width={index % 5 === 4 ? '55%' : '100%'} />
+              ))}
+            </Box>
+          </Stack>
+        )}
+      </Box>
+
+      <TocDrawer
+        open={isTocOpen}
+        onClose={() => setIsTocOpen(false)}
+        toc={publication?.toc?.items ?? []}
+        onSelect={goToTocEntry}
+      />
+    </Box>
+  );
+};
+
+interface PageTurnButtonProps {
+  edge: 'left' | 'right';
+  onClick: () => void;
+}
+
+const PageTurnButton = ({ edge, onClick }: PageTurnButtonProps) => (
+  <IconButton
+    onClick={onClick}
+    color="inherit"
+    aria-label={edge === 'left' ? 'Previous page' : 'Next page'}
+    sx={{
+      position: 'absolute',
+      top: '50%',
+      transform: 'translateY(-50%)',
+      [edge]: 4,
+      zIndex: 1,
+    }}
+  >
+    {edge === 'left' ? (
+      <PreviousPageIcon sx={{ fontSize: ICON_SIZE.prominent }} />
+    ) : (
+      <NextPageIcon sx={{ fontSize: ICON_SIZE.prominent }} />
+    )}
+  </IconButton>
+);
+
+interface ReaderMessageProps {
+  children: string;
+  onClose: () => void;
+}
+
+/** The whole-viewport stand-in for a book that cannot be read. */
+const ReaderMessage = ({ children, onClose }: ReaderMessageProps) => (
+  <Box
+    sx={{
+      position: 'fixed',
+      inset: 0,
+      zIndex: (t) => t.zIndex.appBar + 1,
+      backgroundColor: 'background.default',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      p: 3,
+    }}
+  >
+    <Stack spacing={3} sx={{ maxWidth: 480, alignItems: 'center', textAlign: 'center' }}>
+      <Typography variant="body1" sx={{ color: 'text.secondary' }}>
+        {children}
+      </Typography>
+      <Button variant="outlined" onClick={onClose}>
+        Back to book
+      </Button>
+    </Stack>
+  </Box>
+);

--- a/frontend/src/components/reader/TocDrawer.tsx
+++ b/frontend/src/components/reader/TocDrawer.tsx
@@ -1,3 +1,4 @@
+import { chromeMarkerProps } from '@/components/reader/chromeMarker.ts';
 import { CloseIcon } from '@/theme/Icons.tsx';
 import { ICON_SIZE } from '@/theme/iconSizes.ts';
 import {
@@ -69,7 +70,12 @@ const TocEntries = ({ entries, depth, onSelect }: TocEntriesProps) => (
  */
 export const TocDrawer = ({ open, onClose, toc, onSelect }: TocDrawerProps) => (
   <Drawer anchor="left" open={open} onClose={onClose}>
-    <Box sx={{ width: { xs: 280, sm: 340 } }} role="navigation" aria-label="Table of contents">
+    <Box
+      {...chromeMarkerProps}
+      sx={{ width: { xs: 280, sm: 340 } }}
+      role="navigation"
+      aria-label="Table of contents"
+    >
       <Stack
         direction="row"
         sx={{ alignItems: 'center', justifyContent: 'space-between', p: 2, pb: 1 }}

--- a/frontend/src/components/reader/TocDrawer.tsx
+++ b/frontend/src/components/reader/TocDrawer.tsx
@@ -1,0 +1,95 @@
+import { CloseIcon } from '@/theme/Icons.tsx';
+import { ICON_SIZE } from '@/theme/iconSizes.ts';
+import {
+  Box,
+  Drawer,
+  IconButton,
+  List,
+  ListItemButton,
+  ListItemText,
+  Stack,
+  Typography,
+} from '@mui/material';
+import type { Link } from '@readium/shared';
+
+/**
+ * The href the API gives a heading that links nowhere — a part title with
+ * chapters under it, say. Such an entry is a label in the list, not a
+ * destination.
+ */
+const UNLINKED_HREF = '#';
+
+/** How far one level of nesting indents a chapter under its parent. */
+const INDENT_PER_LEVEL = 2;
+
+interface TocDrawerProps {
+  open: boolean;
+  onClose: () => void;
+  toc: Link[];
+  onSelect: (link: Link) => void;
+}
+
+interface TocEntriesProps {
+  entries: Link[];
+  depth: number;
+  onSelect: (link: Link) => void;
+}
+
+const TocEntries = ({ entries, depth, onSelect }: TocEntriesProps) => (
+  <>
+    {entries.map((entry, index) => {
+      const isNavigable = entry.href !== UNLINKED_HREF;
+      return (
+        <Box key={`${entry.href}-${index}`}>
+          <ListItemButton
+            disabled={!isNavigable}
+            onClick={() => onSelect(entry)}
+            sx={{ pl: 2 + depth * INDENT_PER_LEVEL, borderRadius: 1 }}
+          >
+            <ListItemText
+              primary={entry.title ?? 'Untitled'}
+              slotProps={{ primary: { variant: 'body2' } }}
+            />
+          </ListItemButton>
+          {entry.children && (
+            <TocEntries entries={entry.children.items} depth={depth + 1} onSelect={onSelect} />
+          )}
+        </Box>
+      );
+    })}
+  </>
+);
+
+/**
+ * The book's table of contents, as the manifest publishes it.
+ *
+ * Nesting is preserved rather than flattened: an EPUB's own contents page is
+ * how its author thought the book was shaped, and a part with six chapters
+ * under it reads very differently as a flat list of seven.
+ */
+export const TocDrawer = ({ open, onClose, toc, onSelect }: TocDrawerProps) => (
+  <Drawer anchor="left" open={open} onClose={onClose}>
+    <Box sx={{ width: { xs: 280, sm: 340 } }} role="navigation" aria-label="Table of contents">
+      <Stack
+        direction="row"
+        sx={{ alignItems: 'center', justifyContent: 'space-between', p: 2, pb: 1 }}
+      >
+        <Typography variant="sectionTitle" component="h2">
+          Contents
+        </Typography>
+        <IconButton onClick={onClose} aria-label="Close contents" size="small">
+          <CloseIcon sx={{ fontSize: ICON_SIZE.ui }} />
+        </IconButton>
+      </Stack>
+      {toc.length === 0 ? (
+        <Typography variant="body2" sx={{ color: 'text.secondary', px: 2, pb: 2 }}>
+          This book has no table of contents.
+        </Typography>
+      ) : (
+        <List sx={{ pb: 2 }}>
+          <TocEntries entries={toc} depth={0} onSelect={onSelect} />
+        </List>
+      )}
+    </Box>
+  </Drawer>
+);

--- a/frontend/src/components/reader/chromeMarker.ts
+++ b/frontend/src/components/reader/chromeMarker.ts
@@ -1,0 +1,15 @@
+/**
+ * The attribute every piece of the reader's own UI carries.
+ *
+ * The reader listens for arrow keys on the window, because the book has to
+ * turn pages wherever the focus happens to be. That makes the chrome's own
+ * controls ambiguous: an arrow on the font-size slider is a font size, not a
+ * page. Marking the chrome lets one `closest()` call answer "is this key meant
+ * for us or for the book", and it works for the contents drawer and the
+ * appearance popover too, which MUI portals out of the reader's React tree
+ * where no ancestor check in JSX terms would find them.
+ */
+export const CHROME_MARKER = 'data-reader-chrome';
+
+/** Spreadable form, so a component can mark itself without repeating the name. */
+export const chromeMarkerProps = { [CHROME_MARKER]: true } as const;

--- a/frontend/src/components/reader/decorations.ts
+++ b/frontend/src/components/reader/decorations.ts
@@ -1,0 +1,15 @@
+/**
+ * The decoration group Crossbill's own highlights are drawn under.
+ *
+ * `@readium/navigator` keys decorations by group: `applyDecorations(list,
+ * group)` replaces everything in that group and leaves every other group
+ * alone, and an observer registered for a group hears only about its own
+ * decorations. Reserving one name here means the highlight layer (M3.2) can
+ * replace the whole set on every change without touching whatever else may
+ * later be drawn on the page — a search-result flash, a selection preview.
+ *
+ * Nothing applies decorations yet. `ReaderShell` registers an observer for the
+ * group so the seam is wired and provably reaches the navigator; the handlers
+ * are no-ops until there is something to activate.
+ */
+export const HIGHLIGHT_DECORATION_GROUP = 'crossbill-highlights';

--- a/frontend/src/components/reader/publicationHardening.ts
+++ b/frontend/src/components/reader/publicationHardening.ts
@@ -74,6 +74,17 @@ const isJavascriptUrl = (value: string) => /^\s*javascript:/i.test(value);
 const disarm = (doc: Document): void => {
   doc.querySelectorAll('script').forEach((script) => script.remove());
 
+  // A declarative refresh is the way out of everything above. The URL is
+  // resolved against the `<base>` Readium injects, so a relative one points
+  // back at the publication API — and the document the frame lands on is a
+  // plain same-origin response: no blob, no CSP, and never passed through this
+  // function. Chromium happens not to honour a refresh inside a sandboxed
+  // frame, but an unset sandbox flag in one browser is not a control.
+  doc.querySelectorAll('meta').forEach((meta) => {
+    const pragma = meta.getAttribute('http-equiv')?.trim().toLowerCase();
+    if (pragma === 'refresh') meta.remove();
+  });
+
   doc.querySelectorAll('*').forEach((element) => {
     for (const attribute of Array.from(element.attributes)) {
       const isUrlAttribute = attribute.name === 'href' || attribute.name === 'src';

--- a/frontend/src/components/reader/publicationHardening.ts
+++ b/frontend/src/components/reader/publicationHardening.ts
@@ -1,0 +1,129 @@
+/**
+ * Strips a publication's own JavaScript before Readium ever frames it.
+ *
+ * ## Why this has to exist
+ *
+ * `@readium/navigator` frames each resource in an iframe it creates with
+ * `sandbox="allow-same-origin allow-scripts"`
+ * (`FrameManager.ts:28`), and the document it frames is a `blob:` URL built by
+ * our own page — so the frame is **same-origin with the app**. A `<script>` in
+ * a book therefore runs with the reader's privileges: it can read and write
+ * `parent.document`, call the API as the signed-in user, and spend the
+ * publication cookie. The library's own injected CSP does not stop it — it
+ * ships `script-src ${domains} blob: 'unsafe-inline'`
+ * (`FrameBlobBuilder.ts:5-21`), which deliberately permits both the book's
+ * inline scripts and its external ones.
+ *
+ * Crossbill is self-hosted and its books come from wherever their owner found
+ * them, so "the EPUB is trusted" is not a premise worth holding.
+ *
+ * ## Why a CSP rather than dropping `allow-scripts`
+ *
+ * Readium needs scripts *of its own* inside the frame: `css-selector-generator`
+ * is injected unconditionally (`epubInjectables.ts`), and it is what turns a
+ * browser selection into a Locator — the write path ADR-0004 §2 describes, and
+ * the thing M3/M4 are built on. Those injectables are injected as
+ * `<script src="blob:...">` (`Injector.ts`, `getOrCreateBlobUrl`), while a
+ * book's own scripts are inline or come from the publication's origin. A
+ * `script-src blob:` policy separates the two exactly: CSP policies combine by
+ * intersection, so ours meets the library's at `blob:` and nothing else.
+ *
+ * Removing `allow-scripts` would kill Readium's injectables too, and removing
+ * `allow-same-origin` would make the frame unscriptable from the parent, which
+ * is how the navigator drives it at all. Neither is available.
+ *
+ * ## What is left
+ *
+ * This is a mitigation, not a sandbox. The frame is still same-origin, so
+ * anything that does get script running in it has the page. The architectural
+ * fix is to serve publication resources from a separate origin; the blob-URL
+ * design makes that awkward, and it is not this ticket's to do.
+ */
+
+/**
+ * Allows the navigator's own injected scripts, and nothing else.
+ *
+ * `child-src`/`object-src` are closed because a nested browsing context loaded
+ * from our API origin would be a fresh same-origin document carrying no CSP at
+ * all — an `<iframe>` or an `<object>` would hand a book the execution this
+ * policy just took away. Styles, images and fonts are deliberately untouched:
+ * a book's typography is the point of rendering it.
+ */
+const CONTENT_POLICY = ['script-src blob:', "object-src 'none'", "child-src 'none'"].join('; ');
+
+/** The media types whose documents are parsed, cleaned, and re-serialised. */
+const parserTypeFor = (contentType: string): DOMParserSupportedType | null => {
+  const type = contentType.split(';')[0].trim().toLowerCase();
+  if (type === 'application/xhtml+xml') return 'application/xhtml+xml';
+  if (type === 'text/html') return 'text/html';
+  return null;
+};
+
+const isEventHandler = (name: string) => name.toLowerCase().startsWith('on');
+
+const isJavascriptUrl = (value: string) => /^\s*javascript:/i.test(value);
+
+/**
+ * Removes every way a document can name executable code.
+ *
+ * Belt and braces with the CSP above: the policy is the control the browser
+ * enforces, and this is what makes the document harmless even where a policy
+ * delivered by `<meta>` is not honoured. It also spares Readium the work of
+ * neutralising scripts that are no longer there.
+ */
+const disarm = (doc: Document): void => {
+  doc.querySelectorAll('script').forEach((script) => script.remove());
+
+  doc.querySelectorAll('*').forEach((element) => {
+    for (const attribute of Array.from(element.attributes)) {
+      const isUrlAttribute = attribute.name === 'href' || attribute.name === 'src';
+      if (isEventHandler(attribute.name) || (isUrlAttribute && isJavascriptUrl(attribute.value))) {
+        element.removeAttribute(attribute.name);
+      }
+    }
+  });
+};
+
+const harden = (text: string, parserType: DOMParserSupportedType): string => {
+  const doc = new DOMParser().parseFromString(text, parserType);
+  // A document that does not parse is Readium's to complain about, in its own
+  // words. Handing back the original text keeps that error the one the reader
+  // sees, rather than a mangled serialisation of a broken file.
+  if (doc.querySelector('parsererror')) return text;
+
+  disarm(doc);
+
+  const head = doc.head as HTMLHeadElement | null;
+  if (head) {
+    const meta = doc.createElement('meta');
+    meta.setAttribute('http-equiv', 'Content-Security-Policy');
+    meta.setAttribute('content', CONTENT_POLICY);
+    head.prepend(meta);
+  }
+
+  return new XMLSerializer().serializeToString(doc);
+};
+
+/**
+ * Wraps a fetch so every publication document it returns arrives disarmed.
+ *
+ * This is the seam because it is the only one that sees the bytes: Readium
+ * builds each frame from `publication.get(item).readAsString()`
+ * (`FrameBlobBuilder.buildHtmlFrame`), so a fetcher that hands back a cleaned
+ * document is a navigator that frames a cleaned document. Anything that is not
+ * a markup document — stylesheets, images, fonts — passes through untouched.
+ */
+export const hardeningFetch =
+  (inner: typeof fetch): typeof fetch =>
+  async (input, init) => {
+    const response = await inner(input, init);
+    const parserType = parserTypeFor(response.headers.get('content-type') ?? '');
+    if (!response.ok || parserType === null) return response;
+
+    const hardened = harden(await response.text(), parserType);
+    return new Response(hardened, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: response.headers,
+    });
+  };

--- a/frontend/src/components/reader/readerPreferences.ts
+++ b/frontend/src/components/reader/readerPreferences.ts
@@ -1,0 +1,47 @@
+import type { Theme } from '@mui/material/styles';
+import { EpubPreferences } from '@readium/navigator';
+
+/** The reading themes the settings popover offers, in the order it shows them. */
+export const READER_THEMES = ['light', 'sepia', 'dark'] as const;
+
+export type ReaderThemeName = (typeof READER_THEMES)[number];
+
+/** Sentence-case, because these are user-facing labels on the theme control. */
+export const READER_THEME_LABELS: Record<ReaderThemeName, string> = {
+  light: 'Light',
+  sepia: 'Sepia',
+  dark: 'Dark',
+};
+
+export interface ReaderPreferences {
+  theme: ReaderThemeName;
+  /**
+   * A multiplier on the publication's own font size, which is how Readium
+   * states it — 1 is the book as its publisher set it.
+   */
+  fontSize: number;
+}
+
+export const DEFAULT_READER_PREFERENCES: ReaderPreferences = { theme: 'light', fontSize: 1 };
+
+/** The page colours of a reading theme, for the reader's chrome and its content alike. */
+export const readerPageColors = (theme: Theme, name: ReaderThemeName) =>
+  theme.customColors.readerPage[name];
+
+/**
+ * Translates our two settings into the preferences the navigator understands.
+ *
+ * Deliberately a small surface: `EpubPreferences` has forty-odd fields, and
+ * every one we set is one the reader can no longer inherit from the book.
+ */
+export const toEpubPreferences = (
+  theme: Theme,
+  preferences: ReaderPreferences
+): EpubPreferences => {
+  const colors = readerPageColors(theme, preferences.theme);
+  return new EpubPreferences({
+    backgroundColor: colors.background,
+    textColor: colors.text,
+    fontSize: preferences.fontSize,
+  });
+};

--- a/frontend/src/components/reader/useReaderPublication.ts
+++ b/frontend/src/components/reader/useReaderPublication.ts
@@ -1,0 +1,124 @@
+import { API_BASE_URL } from '@/api/base-url.ts';
+import { useGetReadiumManifest } from '@/api/generated/readium/readium.ts';
+import { HttpFetcher, Locator, Manifest, Publication } from '@readium/shared';
+import Axios from 'axios';
+import { useEffect, useMemo, useState } from 'react';
+
+const isNotFound = (error: unknown) => Axios.isAxiosError(error) && error.response?.status === 404;
+
+/**
+ * The manifest is a book's structure, not its state: it only changes when the
+ * EPUB behind it is replaced. Caching it for the session means the "Read" tab's
+ * visibility probe and the reader itself share one request.
+ */
+const MANIFEST_QUERY = {
+  staleTime: Infinity,
+  // A missing EPUB answers 404, which is an answer, not a failure to retry.
+  retry: false,
+} as const;
+
+const manifestUrl = (bookId: number) =>
+  new URL(`${API_BASE_URL}/api/v1/readium/books/${bookId}/manifest.json`, window.location.origin)
+    .href;
+
+/**
+ * Fetches everything the navigator loads, with the publication cookie attached.
+ *
+ * The resources of a book are not requests the app makes on its own behalf —
+ * they are made by Readium, for iframes, and the credential that reaches an
+ * iframe is a cookie. `credentials: 'include'` is what puts the cookie
+ * `useReaderSession` minted on every one of them.
+ */
+const credentialedFetch: typeof fetch = (input, init) =>
+  fetch(input, { ...init, credentials: 'include' });
+
+/**
+ * Whether this book has an EPUB the web reader can open.
+ *
+ * `undefined` while the answer is unknown, so a caller can tell "no EPUB" from
+ * "not asked yet" and avoid flashing a tab that is about to disappear.
+ *
+ * The manifest is the only thing the API offers to ask with: `BookDetails`
+ * carries no `has_ebook` flag, so presence is inferred from the manifest
+ * answering rather than 404ing. That makes this a whole manifest parsed
+ * server-side to decide whether to draw a tab, where a boolean on the
+ * book-details view would do it for nothing. Cheap enough for now — the
+ * manifest is cached per book and the reader reuses this very response — but
+ * it is the thing to fix if the book page ever feels slow.
+ */
+export const useHasPublication = (bookId: number): boolean | undefined => {
+  const { isError, isPending } = useGetReadiumManifest(bookId, { query: MANIFEST_QUERY });
+  if (isPending) return undefined;
+  return !isError;
+};
+
+type ReaderPublicationStatus = 'pending' | 'ready' | 'missing' | 'error';
+
+export interface ReaderPublication {
+  status: ReaderPublicationStatus;
+  publication: Publication | undefined;
+  /**
+   * One locator per synthetic page — empty when the book publishes no position
+   * list, and `undefined` until the list has been fetched at all.
+   *
+   * The distinction matters to the navigator: it takes its positions once, at
+   * construction, so building it against a list that has not arrived yet means
+   * rebuilding it (and losing the reader's place) the moment it does.
+   */
+  positions: Locator[] | undefined;
+}
+
+/**
+ * Builds the Readium `Publication` the navigator reads from.
+ *
+ * The manifest arrives through the generated client (Bearer, axios, the app's
+ * own interceptors) and everything the manifest names is fetched by Readium
+ * through `credentialedFetch`. The self link is set to the URL actually
+ * fetched rather than trusted from the body: every resource href in the
+ * manifest is relative to it, and resolving them against this origin is what
+ * keeps the iframes same-origin and scriptable.
+ */
+export const useReaderPublication = (bookId: number): ReaderPublication => {
+  const { data, error, isPending } = useGetReadiumManifest(bookId, { query: MANIFEST_QUERY });
+  const [positions, setPositions] = useState<Locator[] | undefined>(undefined);
+
+  const publication = useMemo(() => {
+    if (data === undefined) return undefined;
+    const manifest = Manifest.deserialize(data);
+    if (!manifest) return undefined;
+    const selfHref = manifestUrl(bookId);
+    manifest.setSelfLink(selfHref);
+    return new Publication({
+      manifest,
+      fetcher: new HttpFetcher(credentialedFetch, selfHref),
+    });
+  }, [bookId, data]);
+
+  useEffect(() => {
+    if (!publication) return;
+    let cancelled = false;
+    // A book whose position list cannot be read is still readable; it just
+    // cannot say which page you are on.
+    publication
+      .positionsFromManifest()
+      .then((locators) => {
+        if (!cancelled) setPositions(locators);
+      })
+      .catch(() => {
+        if (!cancelled) setPositions([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [publication]);
+
+  const status = ((): ReaderPublicationStatus => {
+    if (isPending) return 'pending';
+    // 404 is the API saying this book has no EPUB (or no such book), which is
+    // an empty state rather than a failure. Anything else really did go wrong.
+    if (error) return isNotFound(error) ? 'missing' : 'error';
+    return publication ? 'ready' : 'error';
+  })();
+
+  return { status, publication, positions };
+};

--- a/frontend/src/components/reader/useReaderPublication.ts
+++ b/frontend/src/components/reader/useReaderPublication.ts
@@ -1,5 +1,6 @@
 import { API_BASE_URL } from '@/api/base-url.ts';
 import { useGetReadiumManifest } from '@/api/generated/readium/readium.ts';
+import { hardeningFetch } from '@/components/reader/publicationHardening.ts';
 import { HttpFetcher, Locator, Manifest, Publication } from '@readium/shared';
 import Axios from 'axios';
 import { useEffect, useMemo, useState } from 'react';
@@ -7,15 +8,21 @@ import { useEffect, useMemo, useState } from 'react';
 const isNotFound = (error: unknown) => Axios.isAxiosError(error) && error.response?.status === 404;
 
 /**
- * The manifest is a book's structure, not its state: it only changes when the
- * EPUB behind it is replaced. Caching it for the session means the "Read" tab's
- * visibility probe and the reader itself share one request.
+ * The manifest is a book's structure, so it changes only when the EPUB behind
+ * it is replaced — which no screen in this app can do. The only writer is the
+ * KOReader plugin's upload, out of band, so there is no mutation here to hang
+ * an invalidation off and no event that could tell this tab the book changed.
+ *
+ * That rules out caching it for the session: a book replaced on the e-reader
+ * would keep serving its old chapters until a hard reload. It inherits the
+ * app-wide five minutes instead, which bounds the stale window without costing
+ * much — the backend caches the parsed publication under the book's file and
+ * evicts it on upload, so a refetch is a cache read, not a re-parse.
+ *
+ * `retry` is the one thing worth overriding: a missing EPUB answers 404, which
+ * is an answer rather than a failure to try again.
  */
-const MANIFEST_QUERY = {
-  staleTime: Infinity,
-  // A missing EPUB answers 404, which is an answer, not a failure to retry.
-  retry: false,
-} as const;
+const MANIFEST_QUERY = { retry: false } as const;
 
 const manifestUrl = (bookId: number) =>
   new URL(`${API_BASE_URL}/api/v1/readium/books/${bookId}/manifest.json`, window.location.origin)
@@ -31,6 +38,13 @@ const manifestUrl = (bookId: number) =>
  */
 const credentialedFetch: typeof fetch = (input, init) =>
   fetch(input, { ...init, credentials: 'include' });
+
+/**
+ * What the navigator is actually given: the credentialed fetch above, with
+ * every markup document it returns stripped of the book's own JavaScript. See
+ * `publicationHardening.ts` for why a book's scripts are the app's problem.
+ */
+const publicationFetch = hardeningFetch(credentialedFetch);
 
 /**
  * Whether this book has an EPUB the web reader can open.
@@ -90,7 +104,7 @@ export const useReaderPublication = (bookId: number): ReaderPublication => {
     manifest.setSelfLink(selfHref);
     return new Publication({
       manifest,
-      fetcher: new HttpFetcher(credentialedFetch, selfHref),
+      fetcher: new HttpFetcher(publicationFetch, selfHref),
     });
   }, [bookId, data]);
 

--- a/frontend/src/components/reader/useReaderSession.ts
+++ b/frontend/src/components/reader/useReaderSession.ts
@@ -26,7 +26,20 @@ const WAKE_MARGIN_MS = 30_000;
 /** Backoff for a renewal that failed while the book is still open. */
 const RETRY_DELAYS_MS = [1_000, 2_000, 5_000, 15_000, 30_000];
 
-export type ReaderSessionStatus = 'pending' | 'ready' | 'error';
+type ReaderSessionStatus = 'pending' | 'ready' | 'error';
+
+export interface ReaderSession {
+  status: ReaderSessionStatus;
+  /**
+   * True while the cookie is known to have lapsed and its replacement is still
+   * in flight.
+   *
+   * Only a cookie that has actually run out sets this. A renewal that happens
+   * early — the ordinary case — is invisible, because the credential the
+   * reader is using is still good and there is nothing to wait for.
+   */
+  isRenewing: boolean;
+}
 
 const refreshDelayMs = (expiresIn: number) =>
   Math.max(expiresIn * 1000 * REFRESH_AT, MIN_REFRESH_MS);
@@ -50,8 +63,9 @@ const refreshDelayMs = (expiresIn: number) =>
  * its own state rather than this one being asked to change books underneath
  * itself.
  */
-export const useReaderSession = (bookId: number): ReaderSessionStatus => {
+export const useReaderSession = (bookId: number): ReaderSession => {
   const [status, setStatus] = useState<ReaderSessionStatus>('pending');
+  const [isRenewing, setIsRenewing] = useState(false);
   // When the cookie the server last handed out runs out, in wall-clock terms.
   // Null until one has ever been issued, which is what separates "this reader
   // never started" from "a renewal went wrong mid-book".
@@ -80,6 +94,7 @@ export const useReaderSession = (bookId: number): ReaderSessionStatus => {
         if (isStale()) return;
         failuresRef.current = 0;
         expiresAtRef.current = Date.now() + session.expires_in * 1000;
+        setIsRenewing(false);
         setStatus('ready');
         schedule(refreshDelayMs(session.expires_in));
       } catch {
@@ -111,7 +126,12 @@ export const useReaderSession = (bookId: number): ReaderSessionStatus => {
     const renewIfDue = () => {
       if (isStale() || document.visibilityState !== 'visible') return;
       const expiresAt = expiresAtRef.current;
-      if (expiresAt !== null && Date.now() > expiresAt - WAKE_MARGIN_MS) void mintCookie();
+      if (expiresAt === null || Date.now() <= expiresAt - WAKE_MARGIN_MS) return;
+      // A cookie that has actually run out leaves the navigator loading
+      // resources against a dead credential, so the reader is held until the
+      // replacement lands. One renewed early needs no such ceremony.
+      if (Date.now() >= expiresAt) setIsRenewing(true);
+      void mintCookie();
     };
 
     void mintCookie();
@@ -126,5 +146,5 @@ export const useReaderSession = (bookId: number): ReaderSessionStatus => {
     };
   }, [bookId]);
 
-  return status;
+  return { status, isRenewing };
 };

--- a/frontend/src/components/reader/useReaderSession.ts
+++ b/frontend/src/components/reader/useReaderSession.ts
@@ -1,0 +1,69 @@
+import { startPublicationSession } from '@/api/generated/readium/readium.ts';
+import { useEffect, useState } from 'react';
+
+/**
+ * How much of the cookie's life to spend before minting a new one.
+ *
+ * The cookie is httpOnly, so the page cannot see it expire — it only knows the
+ * `expires_in` it was told. Renewing at four fifths leaves a real margin for a
+ * slow round trip without re-posting so often that the ceiling (the access
+ * token's own remaining life, ADR-0004 Amendment 1) is hit every time.
+ */
+const REFRESH_AT = 0.8;
+
+/** Never spin: a server that answered with a tiny expiry must not be hammered. */
+const MIN_REFRESH_MS = 5_000;
+
+export type ReaderSessionStatus = 'pending' | 'ready' | 'error';
+
+const refreshDelayMs = (expiresIn: number) =>
+  Math.max(expiresIn * 1000 * REFRESH_AT, MIN_REFRESH_MS);
+
+/**
+ * Keeps a publication cookie alive for one book while the reader is open.
+ *
+ * The navigator loads a book's resources into iframes, and an iframe load
+ * carries cookies and nothing else — never the in-memory access token. This
+ * hook is what buys that second credential: it POSTs the session endpoint with
+ * the Bearer token the axios instance already attaches, and re-posts on a
+ * timer derived from the `expires_in` it answers with.
+ *
+ * A 401 on the POST is not handled here. The axios interceptor refreshes the
+ * access token and replays the request, and only a genuinely dead session
+ * falls through it — into the same redirect to the login page every other call
+ * in the app takes.
+ *
+ * The status is not reset when `bookId` changes: the reader is mounted with
+ * the book's id as its key, so a different book is a different component with
+ * its own state rather than this one being asked to change books underneath
+ * itself.
+ */
+export const useReaderSession = (bookId: number): ReaderSessionStatus => {
+  const [status, setStatus] = useState<ReaderSessionStatus>('pending');
+
+  useEffect(() => {
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    const mintCookie = async () => {
+      try {
+        const session = await startPublicationSession(bookId);
+        if (cancelled) return;
+        setStatus('ready');
+        timer = setTimeout(() => void mintCookie(), refreshDelayMs(session.expires_in));
+      } catch {
+        if (cancelled) return;
+        setStatus('error');
+      }
+    };
+
+    void mintCookie();
+
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [bookId]);
+
+  return status;
+};

--- a/frontend/src/components/reader/useReaderSession.ts
+++ b/frontend/src/components/reader/useReaderSession.ts
@@ -1,5 +1,5 @@
 import { startPublicationSession } from '@/api/generated/readium/readium.ts';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 /**
  * How much of the cookie's life to spend before minting a new one.
@@ -13,6 +13,18 @@ const REFRESH_AT = 0.8;
 
 /** Never spin: a server that answered with a tiny expiry must not be hammered. */
 const MIN_REFRESH_MS = 5_000;
+
+/**
+ * How close to expiry counts as "renew now" when the tab comes back.
+ *
+ * Wide enough to cover a slow round trip, so a reader who returns to the tab
+ * turns a page against a cookie that is still good rather than one that dies
+ * mid-request.
+ */
+const WAKE_MARGIN_MS = 30_000;
+
+/** Backoff for a renewal that failed while the book is still open. */
+const RETRY_DELAYS_MS = [1_000, 2_000, 5_000, 15_000, 30_000];
 
 export type ReaderSessionStatus = 'pending' | 'ready' | 'error';
 
@@ -40,28 +52,77 @@ const refreshDelayMs = (expiresIn: number) =>
  */
 export const useReaderSession = (bookId: number): ReaderSessionStatus => {
   const [status, setStatus] = useState<ReaderSessionStatus>('pending');
+  // When the cookie the server last handed out runs out, in wall-clock terms.
+  // Null until one has ever been issued, which is what separates "this reader
+  // never started" from "a renewal went wrong mid-book".
+  const expiresAtRef = useRef<number | null>(null);
+  const failuresRef = useRef(0);
 
   useEffect(() => {
-    let cancelled = false;
+    // Read through a call, never the flag itself: assignments from the cleanup
+    // below are invisible to the compiler, which would then prove the checks
+    // after each await redundant.
+    const teardown = new AbortController();
+    const isStale = () => teardown.signal.aborted;
+    let inFlight = false;
     let timer: ReturnType<typeof setTimeout> | undefined;
 
+    const schedule = (delay: number) => {
+      clearTimeout(timer);
+      timer = setTimeout(() => void mintCookie(), delay);
+    };
+
     const mintCookie = async () => {
+      if (isStale() || inFlight) return;
+      inFlight = true;
       try {
         const session = await startPublicationSession(bookId);
-        if (cancelled) return;
+        if (isStale()) return;
+        failuresRef.current = 0;
+        expiresAtRef.current = Date.now() + session.expires_in * 1000;
         setStatus('ready');
-        timer = setTimeout(() => void mintCookie(), refreshDelayMs(session.expires_in));
+        schedule(refreshDelayMs(session.expires_in));
       } catch {
-        if (cancelled) return;
-        setStatus('error');
+        if (isStale()) return;
+        // Never having held a cookie is fatal: nothing can load without one.
+        if (expiresAtRef.current === null) {
+          setStatus('error');
+          return;
+        }
+        // Losing a *renewal* is not. The cookie in the browser may still be
+        // good, the reader is mid-page, and the usual cause is a blip that
+        // will have passed by the next attempt. Ending the session here would
+        // tear down the navigator and lose their place over a dropped packet.
+        const delay = RETRY_DELAYS_MS[Math.min(failuresRef.current, RETRY_DELAYS_MS.length - 1)];
+        failuresRef.current += 1;
+        schedule(delay);
+      } finally {
+        inFlight = false;
       }
     };
 
+    /**
+     * Timers are not a promise the browser keeps. A backgrounded tab has them
+     * throttled to minutes, and a sleeping machine does not run them at all,
+     * so the renewal scheduled comfortably inside the cookie's life can land
+     * long after it expired. Whenever the reader comes back to the tab, the
+     * question is asked against the clock instead.
+     */
+    const renewIfDue = () => {
+      if (isStale() || document.visibilityState !== 'visible') return;
+      const expiresAt = expiresAtRef.current;
+      if (expiresAt !== null && Date.now() > expiresAt - WAKE_MARGIN_MS) void mintCookie();
+    };
+
     void mintCookie();
+    document.addEventListener('visibilitychange', renewIfDue);
+    window.addEventListener('focus', renewIfDue);
 
     return () => {
-      cancelled = true;
+      teardown.abort();
       clearTimeout(timer);
+      document.removeEventListener('visibilitychange', renewIfDue);
+      window.removeEventListener('focus', renewIfDue);
     };
   }, [bookId]);
 

--- a/frontend/src/pages/BookPage/navigation/DesktopNavLinks.tsx
+++ b/frontend/src/pages/BookPage/navigation/DesktopNavLinks.tsx
@@ -1,6 +1,6 @@
 import { Box, List, ListItemButton, ListItemIcon, ListItemText } from '@mui/material';
 import { createLink, useMatchRoute } from '@tanstack/react-router';
-import { BOOK_PAGE_LABELS, BOOK_PAGE_ROUTES } from './bookPageRoutes.ts';
+import { BOOK_PAGE_LABELS, useBookPageRoutes } from './bookPageRoutes.ts';
 
 const NavListItemButton = createLink(ListItemButton);
 
@@ -10,11 +10,12 @@ interface DesktopNavLinksProps {
 
 export const DesktopNavLinks = ({ bookId }: DesktopNavLinksProps) => {
   const matchRoute = useMatchRoute();
+  const routes = useBookPageRoutes(Number(bookId));
 
   return (
     <Box sx={{ mb: 3 }}>
       <List disablePadding>
-        {BOOK_PAGE_ROUTES.map((item) => {
+        {routes.map((item) => {
           const isActive = !!matchRoute({ to: item.to, params: { bookId } });
           const Icon = item.icon;
 

--- a/frontend/src/pages/BookPage/navigation/MobileBottomNav.tsx
+++ b/frontend/src/pages/BookPage/navigation/MobileBottomNav.tsx
@@ -11,12 +11,9 @@ import {
 } from '@mui/material';
 import { useNavigate, useParams, useRouterState } from '@tanstack/react-router';
 import { useLayoutEffect, useState } from 'react';
-import { BOOK_PAGE_LABELS, BOOK_PAGE_ROUTES } from './bookPageRoutes.ts';
+import { BOOK_PAGE_LABELS, BOOK_PAGE_ROUTES, useBookPageRoutes } from './bookPageRoutes.ts';
 
 const MORE_VALUE = 'more';
-
-const PRIMARY_ROUTES = BOOK_PAGE_ROUTES.filter((route) => !route.overflow);
-const OVERFLOW_ROUTES = BOOK_PAGE_ROUTES.filter((route) => route.overflow);
 
 const getActivePage = (pathname: string): string => {
   const match = BOOK_PAGE_ROUTES.find((route) => pathname.includes(`/${route.segment}`));
@@ -27,6 +24,9 @@ export const MobileBottomNav = () => {
   const { bookId } = useParams({ strict: false });
   const { location } = useRouterState();
   const navigate = useNavigate();
+  const routes = useBookPageRoutes(Number(bookId));
+  const primaryRoutes = routes.filter((route) => !route.overflow);
+  const overflowRoutes = routes.filter((route) => route.overflow);
 
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
   const menuOpen = Boolean(anchorEl);
@@ -40,7 +40,7 @@ export const MobileBottomNav = () => {
   }, []);
 
   const activePage = getActivePage(location.pathname);
-  const isOverflowActive = OVERFLOW_ROUTES.some((route) => route.segment === activePage);
+  const isOverflowActive = overflowRoutes.some((route) => route.segment === activePage);
   // Highlight the "More" tab whenever the active destination lives in the menu.
   const bottomNavValue = isOverflowActive ? MORE_VALUE : activePage;
 
@@ -77,7 +77,7 @@ export const MobileBottomNav = () => {
       }}
     >
       <BottomNavigation value={bottomNavValue} onChange={handleChange} showLabels>
-        {PRIMARY_ROUTES.map((route) => {
+        {primaryRoutes.map((route) => {
           const Icon = route.icon;
           return (
             <BottomNavigationAction
@@ -102,7 +102,7 @@ export const MobileBottomNav = () => {
         anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
         transformOrigin={{ vertical: 'bottom', horizontal: 'right' }}
       >
-        {OVERFLOW_ROUTES.map((route) => {
+        {overflowRoutes.map((route) => {
           const Icon = route.icon;
           return (
             <MenuItem

--- a/frontend/src/pages/BookPage/navigation/bookPageRoutes.ts
+++ b/frontend/src/pages/BookPage/navigation/bookPageRoutes.ts
@@ -1,14 +1,17 @@
+import { useHasPublication } from '@/components/reader/useReaderPublication.ts';
 import {
   ChapterListIcon,
   FlashcardsIcon,
   HighlightsIcon,
   NotesIcon,
+  ReaderIcon,
   ReflectionIcon,
   StatisticsIcon,
 } from '@/theme/Icons.tsx';
 import type { SvgIconComponent } from '@mui/icons-material';
 
 type BookPageRoute =
+  | '/book/$bookId/read'
   | '/book/$bookId/structure'
   | '/book/$bookId/highlights'
   | '/book/$bookId/flashcards'
@@ -22,6 +25,7 @@ type BookPageRoute =
  * nav and another on the page it opens.
  */
 export const BOOK_PAGE_LABELS = {
+  read: 'Read',
   structure: 'Structure',
   highlights: 'Highlights',
   flashcards: 'Flashcards',
@@ -42,9 +46,21 @@ export interface BookPageRouteConfig {
    * routes regardless.
    */
   overflow?: boolean;
+  /**
+   * When true, the route is only offered for a book that has an EPUB behind
+   * it. There is nothing to read in the browser without one, and a tab that
+   * can only lead to an empty state is worse than no tab.
+   */
+  needsPublication?: boolean;
 }
 
 export const BOOK_PAGE_ROUTES: BookPageRouteConfig[] = [
+  {
+    to: '/book/$bookId/read',
+    segment: 'read',
+    icon: ReaderIcon,
+    needsPublication: true,
+  },
   {
     to: '/book/$bookId/structure',
     segment: 'structure',
@@ -79,3 +95,16 @@ export const BOOK_PAGE_ROUTES: BookPageRouteConfig[] = [
     overflow: true,
   },
 ];
+
+/**
+ * The tabs this particular book actually has.
+ *
+ * Everything but the reader is offered for every book. The reader needs an
+ * EPUB, and while it is unknown whether there is one the tab stays hidden —
+ * appearing late is a smaller surprise than appearing and then vanishing under
+ * the pointer.
+ */
+export const useBookPageRoutes = (bookId: number): BookPageRouteConfig[] => {
+  const hasPublication = useHasPublication(bookId);
+  return BOOK_PAGE_ROUTES.filter((route) => !route.needsPublication || hasPublication === true);
+};

--- a/frontend/src/pages/ReaderPage/ReaderPage.test.tsx
+++ b/frontend/src/pages/ReaderPage/ReaderPage.test.tsx
@@ -5,6 +5,7 @@ import { noPublication, readiumApi, sessionUnauthorizedOnce } from '@tests/msw/r
 import { worker } from '@tests/msw/worker';
 import { http, HttpResponse } from 'msw';
 import { expect, test } from 'vitest';
+import { userEvent } from 'vitest/browser';
 
 /**
  * `bookApi` serves a book with no EPUB by default, so the reader's own
@@ -45,6 +46,28 @@ test('the book loads into the reader and it reports where it is', async () => {
   await expect.element(screen.getByText('Page 1 of 2', { exact: false })).toBeVisible();
 });
 
+/**
+ * Readium frames a publication in an iframe that is same-origin with the app
+ * and carries `allow-same-origin allow-scripts`, so a book's own JavaScript
+ * would run with the page's own privileges — able to read the DOM, spend the
+ * session cookie, and call the API as the reader. Books here come from
+ * wherever their owner found them, so "the EPUB is trusted" is not a premise
+ * worth holding.
+ */
+test('a book cannot run its own scripts against the page that opened it', async () => {
+  worker.use(...bookApi({ book: aBookDetails({ title: 'The Pragmatic Reader' }) }).handlers);
+  worker.use(...readiumApi({ hostile: true }));
+
+  const screen = await renderApp({ path: '/book/1/read' });
+  await expect.element(screen.getByText('Page 1 of 2', { exact: false })).toBeVisible();
+
+  // Settled rather than polled: a script that got through would mark the page
+  // a frame or two after the chapter renders, so an immediate assertion could
+  // pass while the attack was still in flight.
+  await new Promise((resolve) => setTimeout(resolve, 400));
+  expect(document.body.getAttribute('data-pwned')).toBeNull();
+});
+
 test('the contents drawer lists the chapters the manifest publishes', async () => {
   aBookWithAnEpub();
 
@@ -70,6 +93,80 @@ test('the appearance popover offers font size and page colour', async () => {
   await expect
     .element(screen.getByRole('button', { name: 'Sepia' }))
     .toHaveAttribute('aria-pressed', 'true');
+});
+
+/**
+ * The reader listens for arrow keys on the window so the book turns wherever
+ * the focus is. That used to mean the font-size slider did two things at once:
+ * grew the text and skipped a page.
+ */
+test('an arrow key on the font-size slider does not also turn the page', async () => {
+  aBookWithAnEpub();
+
+  const screen = await renderApp({ path: '/book/1/read' });
+  await expect.element(screen.getByText('Page 1 of 2', { exact: false })).toBeVisible();
+
+  await screen.getByRole('button', { name: 'Appearance' }).click();
+  const slider = screen.getByRole('slider', { name: 'Font size' });
+  await expect.element(slider).toBeVisible();
+
+  // Focused rather than clicked: this is the keyboard user's route to the
+  // control, and clicking a slider thumb mid-transition is a fight with the
+  // animation rather than a test of anything.
+  (slider.element() as HTMLElement).focus();
+  await userEvent.keyboard('{ArrowRight}');
+
+  // The slider took the key...
+  await expect.element(slider).not.toHaveAttribute('aria-valuenow', '1');
+
+  // ...and the book stayed where it was. Settled rather than asserted straight
+  // away: a page turn lands about a second later, so an immediate check would
+  // pass whether or not one was on its way.
+  await new Promise((resolve) => setTimeout(resolve, 1200));
+  expect(document.body.innerText).toContain('Page 1 of 2');
+});
+
+/**
+ * A load that fails used to leave the skeleton up forever, and — because
+ * teardown was chained off the boot's success — leak the half-built
+ * navigator's frames and blobs when the reader gave up and left.
+ */
+test('a book whose chapters will not load says so, and can be retried', async () => {
+  worker.use(...bookApi({ book: aBookDetails() }).handlers);
+  worker.use(...readiumApi());
+  worker.use(
+    http.get(
+      '/api/v1/readium/books/:bookId/resources/*',
+      () => new HttpResponse(null, { status: 500 })
+    )
+  );
+
+  const screen = await renderApp({ path: '/book/1/read' });
+
+  await expect
+    .element(screen.getByText('This book could not be opened in the reader.'))
+    .toBeVisible();
+  await expect.element(screen.getByRole('button', { name: 'Try again' })).toBeVisible();
+});
+
+/** A session that never succeeded is terminal — nothing can load without one. */
+test('a session that cannot be started at all reports it', async () => {
+  worker.use(...bookApi({ book: aBookDetails() }).handlers);
+  worker.use(...readiumApi());
+  worker.use(
+    http.post(
+      '/api/v1/readium/books/:bookId/session',
+      () => new HttpResponse(null, { status: 500 })
+    )
+  );
+
+  const screen = await renderApp({ path: '/book/1/read' });
+
+  await expect
+    .element(
+      screen.getByText('The reader could not start a session for this book.', { exact: false })
+    )
+    .toBeVisible();
 });
 
 test('closing the reader goes back to the book', async () => {

--- a/frontend/src/pages/ReaderPage/ReaderPage.test.tsx
+++ b/frontend/src/pages/ReaderPage/ReaderPage.test.tsx
@@ -1,0 +1,141 @@
+import { aBookDetails } from '@tests/fixtures/book';
+import { renderApp } from '@tests/harness/renderApp';
+import { bookApi } from '@tests/msw/bookApi';
+import { noPublication, readiumApi, sessionUnauthorizedOnce } from '@tests/msw/readiumApi';
+import { worker } from '@tests/msw/worker';
+import { http, HttpResponse } from 'msw';
+import { expect, test } from 'vitest';
+
+/**
+ * `bookApi` serves a book with no EPUB by default, so the reader's own
+ * handlers have to be registered afterwards to win: MSW resolves in
+ * registration order, newest first.
+ */
+const aBookWithAnEpub = (...extra: Parameters<typeof worker.use>) => {
+  worker.use(...bookApi({ book: aBookDetails({ title: 'The Pragmatic Reader' }) }).handlers);
+  worker.use(...readiumApi(), ...extra);
+};
+
+test('the reader opens with the book title and its controls', async () => {
+  aBookWithAnEpub();
+
+  const screen = await renderApp({ path: '/book/1/read' });
+
+  await expect.element(screen.getByRole('heading', { name: 'The Pragmatic Reader' })).toBeVisible();
+  await expect.element(screen.getByRole('button', { name: 'Contents' })).toBeVisible();
+  await expect.element(screen.getByRole('button', { name: 'Appearance' })).toBeVisible();
+  await expect.element(screen.getByRole('button', { name: 'Next page' })).toBeVisible();
+  await expect.element(screen.getByRole('button', { name: 'Previous page' })).toBeVisible();
+});
+
+/**
+ * The one test that drives the real navigator end to end: MSW serves the
+ * manifest, the position list and the chapters, and Readium does its own
+ * fetching, blob-building and framing on top. It earns its keep by proving the
+ * two things the spike could not — that the container is sized before the
+ * frames are built, and that `frameLoaded` reaches us — so it stays.
+ */
+test('the book loads into the reader and it reports where it is', async () => {
+  aBookWithAnEpub();
+
+  const screen = await renderApp({ path: '/book/1/read' });
+
+  // The skeleton stands until the first frame is in the DOM.
+  await expect.element(screen.getByLabelText('Loading the book')).not.toBeInTheDocument();
+  await expect.element(screen.getByText('Page 1 of 2', { exact: false })).toBeVisible();
+});
+
+test('the contents drawer lists the chapters the manifest publishes', async () => {
+  aBookWithAnEpub();
+
+  const screen = await renderApp({ path: '/book/1/read' });
+  await screen.getByRole('button', { name: 'Contents' }).click();
+
+  const contents = screen.getByRole('navigation', { name: 'Table of contents' });
+  await expect.element(contents.getByText('On Attention')).toBeVisible();
+  // A part heading and the chapter nested under it: the tree is kept, not flattened.
+  await expect.element(contents.getByText('Part two')).toBeVisible();
+  await expect.element(contents.getByText('On Memory')).toBeVisible();
+});
+
+test('the appearance popover offers font size and page colour', async () => {
+  aBookWithAnEpub();
+
+  const screen = await renderApp({ path: '/book/1/read' });
+  await screen.getByRole('button', { name: 'Appearance' }).click();
+
+  await expect.element(screen.getByRole('slider', { name: 'Font size' })).toBeVisible();
+  await expect.element(screen.getByRole('button', { name: 'Sepia' })).toBeVisible();
+  await screen.getByRole('button', { name: 'Sepia' }).click();
+  await expect
+    .element(screen.getByRole('button', { name: 'Sepia' }))
+    .toHaveAttribute('aria-pressed', 'true');
+});
+
+test('closing the reader goes back to the book', async () => {
+  aBookWithAnEpub();
+
+  const screen = await renderApp({ path: '/book/1/read' });
+  await screen.getByRole('button', { name: 'Close reader' }).click();
+
+  await expect.element(screen.getByRole('heading', { name: 'Structure' })).toBeVisible();
+  expect(window.location.pathname).toBe('/book/1/structure');
+});
+
+test('a book with an EPUB offers the Read tab', async () => {
+  aBookWithAnEpub();
+
+  const screen = await renderApp({ path: '/book/1/structure' });
+
+  await expect.element(screen.getByRole('link', { name: 'Read' })).toBeVisible();
+});
+
+test('a book with no EPUB does not offer the Read tab', async () => {
+  worker.use(...bookApi({ book: aBookDetails() }).handlers);
+
+  const screen = await renderApp({ path: '/book/1/structure' });
+  await expect.element(screen.getByRole('heading', { name: 'Structure' })).toBeVisible();
+
+  await expect(screen.getByRole('link', { name: 'Read' }).query()).toBeNull();
+});
+
+test('opening the reader for a book with no EPUB explains there is nothing to read', async () => {
+  worker.use(...bookApi({ book: aBookDetails() }).handlers);
+  worker.use(...noPublication);
+
+  const screen = await renderApp({ path: '/book/1/read' });
+
+  await expect
+    .element(screen.getByText('This book has no EPUB file', { exact: false }))
+    .toBeVisible();
+  await expect.element(screen.getByRole('button', { name: 'Back to book' })).toBeVisible();
+});
+
+/**
+ * A 401 on the session POST is not the reader's problem to solve: the shared
+ * axios interceptor refreshes the access token and replays the request, which
+ * is the same re-auth path every other call in the app takes. What matters
+ * here is that the reader lets it happen rather than dead-ending on the 401.
+ */
+test('a session refused with a 401 is retried through the app refresh', async () => {
+  let refreshes = 0;
+  aBookWithAnEpub(
+    http.post('/api/v1/auth/refresh', () => {
+      refreshes += 1;
+      return HttpResponse.json({
+        access_token: 'fresh-token',
+        refresh_token: 'fresh-refresh',
+        token_type: 'bearer',
+        expires_in: 900,
+      });
+    })
+  );
+  // Registered last so it answers the first session POST; the replay after the
+  // refresh falls through to the handler `readiumApi` registered above.
+  worker.use(sessionUnauthorizedOnce);
+
+  const screen = await renderApp({ path: '/book/1/read' });
+  await expect.element(screen.getByRole('heading', { name: 'The Pragmatic Reader' })).toBeVisible();
+
+  await expect.poll(() => refreshes).toBeGreaterThan(0);
+});

--- a/frontend/src/pages/ReaderPage/ReaderPage.test.tsx
+++ b/frontend/src/pages/ReaderPage/ReaderPage.test.tsx
@@ -1,10 +1,15 @@
 import { aBookDetails } from '@tests/fixtures/book';
 import { renderApp } from '@tests/harness/renderApp';
 import { bookApi } from '@tests/msw/bookApi';
-import { noPublication, readiumApi, sessionUnauthorizedOnce } from '@tests/msw/readiumApi';
+import {
+  ESCAPE_HATCH,
+  noPublication,
+  readiumApi,
+  sessionUnauthorizedOnce,
+} from '@tests/msw/readiumApi';
 import { worker } from '@tests/msw/worker';
-import { http, HttpResponse } from 'msw';
-import { expect, test } from 'vitest';
+import { delay, http, HttpResponse } from 'msw';
+import { expect, test, vi } from 'vitest';
 import { userEvent } from 'vitest/browser';
 
 /**
@@ -58,14 +63,30 @@ test('a book cannot run its own scripts against the page that opened it', async 
   worker.use(...bookApi({ book: aBookDetails({ title: 'The Pragmatic Reader' }) }).handlers);
   worker.use(...readiumApi({ hostile: true }));
 
+  // A file the publication never references, so asking for it can only mean
+  // the frame navigated out of the document we sanitised and into a raw,
+  // unsanitised one served straight from the API.
+  let escaped = false;
+  worker.use(
+    http.get(`/api/v1/readium/books/:bookId/resources/OEBPS/${ESCAPE_HATCH}`, () => {
+      escaped = true;
+      return new HttpResponse('', { headers: { 'Content-Type': 'application/xhtml+xml' } });
+    })
+  );
+
   const screen = await renderApp({ path: '/book/1/read' });
-  await expect.element(screen.getByText('Page 1 of 2', { exact: false })).toBeVisible();
 
   // Settled rather than polled: a script that got through would mark the page
   // a frame or two after the chapter renders, so an immediate assertion could
-  // pass while the attack was still in flight.
-  await new Promise((resolve) => setTimeout(resolve, 400));
+  // pass while the attack was still in flight. Long enough, too, for a meta
+  // refresh to navigate the frame.
+  await new Promise((resolve) => setTimeout(resolve, 1500));
   expect(document.body.getAttribute('data-pwned')).toBeNull();
+  expect(escaped).toBe(false);
+
+  // And the book really did render, so the assertions above were about a
+  // loaded chapter rather than an empty frame that could never attack anything.
+  await expect.element(screen.getByText('Page 1 of 2', { exact: false })).toBeVisible();
 });
 
 test('the contents drawer lists the chapters the manifest publishes', async () => {
@@ -147,6 +168,77 @@ test('a book whose chapters will not load says so, and can be retried', async ()
     .element(screen.getByText('This book could not be opened in the reader.'))
     .toBeVisible();
   await expect.element(screen.getByRole('button', { name: 'Try again' })).toBeVisible();
+});
+
+/**
+ * The slow one, and it earns it. A load that hangs cannot be waited out, and
+ * every later step was chained to it — including the teardown, and so the next
+ * attempt: "Try again" queued behind the load that hung and waited forever.
+ * Nothing short of a real hang reproduces that, and a real hang means waiting
+ * for the watchdog.
+ */
+test('a book whose load never finishes can still be retried', { timeout: 40_000 }, async () => {
+  worker.use(...bookApi({ book: aBookDetails() }).handlers);
+  worker.use(...readiumApi());
+
+  let chapterRequests = 0;
+  worker.use(
+    http.get('/api/v1/readium/books/:bookId/resources/OEBPS/chapter1.xhtml', async () => {
+      chapterRequests += 1;
+      // Never settles, which is what a hung load is.
+      await new Promise(() => {});
+      return new HttpResponse(null);
+    })
+  );
+
+  const screen = await renderApp({ path: '/book/1/read' });
+
+  await expect
+    .element(screen.getByRole('button', { name: 'Try again' }), { timeout: 25_000 })
+    .toBeVisible();
+  expect(chapterRequests).toBe(1);
+
+  await screen.getByRole('button', { name: 'Try again' }).click();
+
+  // A second attempt at the chapter means a genuinely new navigator was built,
+  // rather than one queued behind a promise that will never settle.
+  await vi.waitFor(() => expect(chapterRequests).toBe(2), { timeout: 10_000 });
+});
+
+/**
+ * Coming back to a tab that slept past the cookie's expiry starts a renewal,
+ * but the navigator was still interactive while it ran: a page turn would ask
+ * for a chapter with a dead credential and get a blank frame.
+ */
+test('a lapsed session holds the book until it has been renewed', async () => {
+  worker.use(...bookApi({ book: aBookDetails() }).handlers);
+  // One second of life, so the cookie has genuinely lapsed by the time the tab
+  // is brought back. The scheduled renewal cannot interfere: its floor is five.
+  worker.use(...readiumApi({ expiresIn: 1 }));
+
+  const screen = await renderApp({ path: '/book/1/read' });
+  await expect.element(screen.getByText('Page 1 of 2', { exact: false })).toBeVisible();
+
+  // The renewal that the return to the tab triggers, held open long enough to
+  // observe what the reader does while it is in flight.
+  worker.use(
+    http.post('/api/v1/readium/books/:bookId/session', async () => {
+      await delay(2_000);
+      return HttpResponse.json({ expires_in: 900 });
+    })
+  );
+
+  await new Promise((resolve) => setTimeout(resolve, 1_200));
+  window.dispatchEvent(new Event('focus'));
+
+  await expect.element(screen.getByText('Reconnecting...')).toBeVisible();
+  await expect.element(screen.getByRole('button', { name: 'Next page' })).toBeDisabled();
+
+  // ...and the book comes back on its own once the cookie has.
+  await expect
+    .element(screen.getByText('Reconnecting...'), { timeout: 5_000 })
+    .not.toBeInTheDocument();
+  await expect.element(screen.getByRole('button', { name: 'Next page' })).toBeEnabled();
 });
 
 /** A session that never succeeded is terminal — nothing can load without one. */

--- a/frontend/src/pages/ReaderPage/ReaderPage.tsx
+++ b/frontend/src/pages/ReaderPage/ReaderPage.tsx
@@ -1,0 +1,29 @@
+import { useGetBookDetails } from '@/api/generated/books/books.ts';
+import { ReaderShell } from '@/components/reader/ReaderShell.tsx';
+import { useNavigate, useParams } from '@tanstack/react-router';
+
+/**
+ * Reading a book in the browser, at `/book/{id}/read`.
+ *
+ * The page itself is thin on purpose: it turns the URL into a book, borrows
+ * the title from the book-details query the book page has usually already
+ * filled, and hands both to the reader. Everything else — the two credentials,
+ * the navigator, the chrome — belongs to `ReaderShell`.
+ */
+export const ReaderPage = () => {
+  const { bookId } = useParams({ strict: false });
+  const navigate = useNavigate();
+  const { data: book } = useGetBookDetails(Number(bookId));
+
+  return (
+    // Keyed by the book, so opening a different one gets a fresh navigator,
+    // a fresh publication cookie and a fresh place in the text rather than
+    // one book's reader being asked to become another's.
+    <ReaderShell
+      key={bookId}
+      bookId={Number(bookId)}
+      title={book?.title ?? ''}
+      onClose={() => void navigate({ to: '/book/$bookId', params: { bookId: bookId! } })}
+    />
+  );
+};

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -22,6 +22,7 @@ import { Route as BookBookIdNotesRouteImport } from './routes/book.$bookId/notes
 import { Route as BookBookIdReflectionRouteImport } from './routes/book.$bookId/reflection'
 import { Route as BookBookIdStatisticsRouteImport } from './routes/book.$bookId/statistics'
 import { Route as BookBookIdStructureRouteImport } from './routes/book.$bookId/structure'
+import { Route as BookBookIdReadRouteImport } from './routes/book_.$bookId/read'
 
 const IndexRoute = IndexRouteImport.update({
   id: '/',
@@ -88,6 +89,11 @@ const BookBookIdStructureRoute = BookBookIdStructureRouteImport.update({
   path: '/structure',
   getParentRoute: () => BookBookIdRoute,
 } as any)
+const BookBookIdReadRoute = BookBookIdReadRouteImport.update({
+  id: '/book_/$bookId/read',
+  path: '/book/$bookId/read',
+  getParentRoute: () => rootRouteImport,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
@@ -102,6 +108,7 @@ export interface FileRoutesByFullPath {
   '/book/$bookId/reflection': typeof BookBookIdReflectionRoute
   '/book/$bookId/statistics': typeof BookBookIdStatisticsRoute
   '/book/$bookId/structure': typeof BookBookIdStructureRoute
+  '/book/$bookId/read': typeof BookBookIdReadRoute
   '/book/$bookId/': typeof BookBookIdIndexRoute
 }
 export interface FileRoutesByTo {
@@ -116,6 +123,7 @@ export interface FileRoutesByTo {
   '/book/$bookId/reflection': typeof BookBookIdReflectionRoute
   '/book/$bookId/statistics': typeof BookBookIdStatisticsRoute
   '/book/$bookId/structure': typeof BookBookIdStructureRoute
+  '/book/$bookId/read': typeof BookBookIdReadRoute
   '/book/$bookId': typeof BookBookIdIndexRoute
 }
 export interface FileRoutesById {
@@ -132,6 +140,7 @@ export interface FileRoutesById {
   '/book/$bookId/reflection': typeof BookBookIdReflectionRoute
   '/book/$bookId/statistics': typeof BookBookIdStatisticsRoute
   '/book/$bookId/structure': typeof BookBookIdStructureRoute
+  '/book_/$bookId/read': typeof BookBookIdReadRoute
   '/book/$bookId/': typeof BookBookIdIndexRoute
 }
 export interface FileRouteTypes {
@@ -149,6 +158,7 @@ export interface FileRouteTypes {
     | '/book/$bookId/reflection'
     | '/book/$bookId/statistics'
     | '/book/$bookId/structure'
+    | '/book/$bookId/read'
     | '/book/$bookId/'
   fileRoutesByTo: FileRoutesByTo
   to:
@@ -163,6 +173,7 @@ export interface FileRouteTypes {
     | '/book/$bookId/reflection'
     | '/book/$bookId/statistics'
     | '/book/$bookId/structure'
+    | '/book/$bookId/read'
     | '/book/$bookId'
   id:
     | '__root__'
@@ -178,6 +189,7 @@ export interface FileRouteTypes {
     | '/book/$bookId/reflection'
     | '/book/$bookId/statistics'
     | '/book/$bookId/structure'
+    | '/book_/$bookId/read'
     | '/book/$bookId/'
   fileRoutesById: FileRoutesById
 }
@@ -188,6 +200,7 @@ export interface RootRouteChildren {
   RegisterRoute: typeof RegisterRoute
   SettingsRoute: typeof SettingsRoute
   BookBookIdRoute: typeof BookBookIdRouteWithChildren
+  BookBookIdReadRoute: typeof BookBookIdReadRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -283,6 +296,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof BookBookIdStructureRouteImport
       parentRoute: typeof BookBookIdRoute
     }
+    '/book_/$bookId/read': {
+      id: '/book_/$bookId/read'
+      path: '/book/$bookId/read'
+      fullPath: '/book/$bookId/read'
+      preLoaderRoute: typeof BookBookIdReadRouteImport
+      parentRoute: typeof rootRouteImport
+    }
   }
 }
 
@@ -317,6 +337,7 @@ const rootRouteChildren: RootRouteChildren = {
   RegisterRoute: RegisterRoute,
   SettingsRoute: SettingsRoute,
   BookBookIdRoute: BookBookIdRouteWithChildren,
+  BookBookIdReadRoute: BookBookIdReadRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/frontend/src/routes/book_.$bookId/read.tsx
+++ b/frontend/src/routes/book_.$bookId/read.tsx
@@ -1,0 +1,12 @@
+import { ReaderPage } from '@/pages/ReaderPage/ReaderPage.tsx';
+import { createFileRoute } from '@tanstack/react-router';
+
+/**
+ * The `book_` prefix is what keeps the reader out of the book page's own
+ * layout: the URL still reads as one of the book's pages, but the route is a
+ * sibling of `/book/$bookId` rather than a child, so the reader gets the whole
+ * viewport instead of a column between the tab rail and the right rail.
+ */
+export const Route = createFileRoute('/book_/$bookId/read')({
+  component: ReaderPage,
+});

--- a/frontend/src/theme/Icons.tsx
+++ b/frontend/src/theme/Icons.tsx
@@ -16,6 +16,10 @@ export {
   MoreVert as ManageIcon,
   Menu as MenuIcon,
   MoreHoriz as MoreIcon,
+  ChevronRight as NextPageIcon,
+  // The reader's page turns. Chevrons rather than the arrows above: those mean
+  // "somewhere else in the app", these mean "one page along in this book".
+  ChevronLeft as PreviousPageIcon,
   KeyboardArrowUp as ScrollToTopIcon,
   Search as SearchIcon,
 } from '@mui/icons-material';
@@ -32,6 +36,9 @@ export {
   FormatQuote as HighlightsIcon,
   Notes as NotesIcon,
   PaletteOutlined as PaletteIcon,
+  // Reading the book in the browser, as against `ReadingSessionIcon`, which
+  // means a session already read on a device.
+  ChromeReaderMode as ReaderIcon,
   AutoStories as ReadingSessionIcon,
   Psychology as ReflectionIcon,
   Equalizer as StatisticsIcon,

--- a/frontend/src/theme/theme.ts
+++ b/frontend/src/theme/theme.ts
@@ -79,6 +79,17 @@ const customColors = {
     empty: colors.stone[100], // A day with no reading
     full: colors.amber[700], // The book's heaviest reading days, as primary.main
   },
+
+  // The web reader's page colours, stated as pairs because a reading theme is
+  // chosen as a pair. These are the only colours in the app that leave it:
+  // they are handed to the publication's own stylesheet through Readium
+  // preferences, so the book's text is painted with them inside its iframe,
+  // and the reader's chrome is tinted to match.
+  readerPage: {
+    light: { background: '#ffffff', text: colors.stone[900] },
+    sepia: { background: '#f4ecd8', text: colors.amber[800] },
+    dark: { background: colors.stone[900], text: colors.stone[100] },
+  },
 };
 
 const COARSE_POINTER_QUERY = '@media (pointer: coarse)';

--- a/frontend/tests/fixtures/publication.ts
+++ b/frontend/tests/fixtures/publication.ts
@@ -1,0 +1,65 @@
+import type { PositionList, WebPublicationManifest } from '@/api/generated/model';
+
+/** Where a book's manifest is served from, as the API's own `self` link states it. */
+const manifestHref = (bookId = 1) =>
+  `${window.location.origin}/api/v1/readium/books/${bookId}/manifest.json`;
+
+/**
+ * A small but genuine Readium Web Publication Manifest.
+ *
+ * Written the way the backend serves one — camelCase keys, hrefs relative to
+ * the manifest's own URL, an unlinked `#` heading in the table of contents —
+ * so that what the navigator and our own code parse in a test is the shape
+ * they will meet in production.
+ */
+export const aManifest = (
+  overrides: Partial<WebPublicationManifest> = {}
+): WebPublicationManifest => ({
+  metadata: {
+    title: 'The Pragmatic Reader',
+    author: 'Ada Lovelace',
+    language: 'en',
+    identifier: 'urn:uuid:pragmatic-reader',
+  },
+  links: [
+    { href: manifestHref(), rel: 'self', type: 'application/webpub+json' },
+    {
+      href: 'positions.json',
+      rel: 'http://readium.org/position-list',
+      type: 'application/vnd.readium.position-list+json',
+    },
+  ],
+  readingOrder: [
+    { href: 'resources/OEBPS/chapter1.xhtml', type: 'application/xhtml+xml' },
+    { href: 'resources/OEBPS/chapter2.xhtml', type: 'application/xhtml+xml' },
+  ],
+  resources: [{ href: 'resources/OEBPS/style.css', type: 'text/css' }],
+  toc: [
+    { href: 'resources/OEBPS/chapter1.xhtml', title: 'On Attention' },
+    {
+      // A part heading links nowhere; its chapters do.
+      href: '#',
+      title: 'Part two',
+      children: [{ href: 'resources/OEBPS/chapter2.xhtml', title: 'On Memory' }],
+    },
+  ],
+  ...overrides,
+});
+
+/** The position list the manifest's `position-list` link resolves to. */
+export const aPositionList = (overrides: Partial<PositionList> = {}): PositionList => ({
+  total: 2,
+  positions: [
+    {
+      href: 'resources/OEBPS/chapter1.xhtml',
+      type: 'application/xhtml+xml',
+      locations: { position: 1, progression: 0, totalProgression: 0 },
+    },
+    {
+      href: 'resources/OEBPS/chapter2.xhtml',
+      type: 'application/xhtml+xml',
+      locations: { position: 2, progression: 0, totalProgression: 0.5 },
+    },
+  ],
+  ...overrides,
+});

--- a/frontend/tests/msw/bookApi.ts
+++ b/frontend/tests/msw/bookApi.ts
@@ -14,6 +14,7 @@ import { http, HttpResponse } from 'msw';
 import { aBookDetails } from '../fixtures/book';
 import { aNote } from '../fixtures/notes';
 import { aBookActivity, aBookStatistics, noBookStatistics } from '../fixtures/sessions';
+import { noPublication } from './readiumApi';
 
 interface BookApiState {
   book: BookDetails;
@@ -52,6 +53,10 @@ export function bookApi(initial: Partial<BookApiState> = {}) {
 
   const handlers = [
     http.get('/api/v1/books/:bookId', () => HttpResponse.json(state.book)),
+    // The book page asks whether there is an EPUB, to decide whether to offer
+    // the "Read" tab. Books in tests have none unless the test says otherwise,
+    // in which case it registers `readiumApi()` after these handlers.
+    ...noPublication,
     http.get('/api/v1/books/:bookId/notes', () => HttpResponse.json({ items: state.notes })),
     http.get('/api/v1/books/:bookId/digest', () => HttpResponse.json({ items: state.digests })),
 

--- a/frontend/tests/msw/readiumApi.ts
+++ b/frontend/tests/msw/readiumApi.ts
@@ -1,0 +1,68 @@
+import type { PositionList, WebPublicationManifest } from '@/api/generated/model';
+import { http, HttpResponse } from 'msw';
+import { aManifest, aPositionList } from '../fixtures/publication';
+
+const MANIFEST_PATH = '/api/v1/readium/books/:bookId/manifest.json';
+const POSITIONS_PATH = '/api/v1/readium/books/:bookId/positions.json';
+const SESSION_PATH = '/api/v1/readium/books/:bookId/session';
+const RESOURCE_PATH = '/api/v1/readium/books/:bookId/resources/*';
+
+/** A chapter as an EPUB actually ships one: XHTML, with its own namespace. */
+const chapterDocument = (title: string) =>
+  `<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head><title>${title}</title></head>
+  <body><h1>${title}</h1><p>Attention is the rarest and purest form of generosity.</p></body>
+</html>`;
+
+/** The files `aManifest` names, keyed by the path the resource route receives. */
+const RESOURCES: Record<string, { body: string; type: string } | undefined> = {
+  'OEBPS/chapter1.xhtml': { body: chapterDocument('On Attention'), type: 'application/xhtml+xml' },
+  'OEBPS/chapter2.xhtml': { body: chapterDocument('On Memory'), type: 'application/xhtml+xml' },
+  'OEBPS/style.css': { body: 'body { margin: 0; }', type: 'text/css' },
+};
+
+interface ReadiumApiOptions {
+  manifest?: WebPublicationManifest;
+  positions?: PositionList;
+  /** Seconds of life the session endpoint claims for the publication cookie. */
+  expiresIn?: number;
+}
+
+/**
+ * The web reader's endpoints for a book that has an EPUB — resources included.
+ *
+ * The navigator fetches the reading order itself, so serving the chapters here
+ * is what lets a test drive the real thing rather than a mock of it.
+ */
+export const readiumApi = ({ manifest, positions, expiresIn = 900 }: ReadiumApiOptions = {}) => [
+  http.post(SESSION_PATH, () => HttpResponse.json({ expires_in: expiresIn })),
+  http.get(MANIFEST_PATH, () => HttpResponse.json(manifest ?? aManifest())),
+  http.get(POSITIONS_PATH, () => HttpResponse.json(positions ?? aPositionList())),
+  http.get(RESOURCE_PATH, ({ params }) => {
+    const path = String(params[0]);
+    const resource = RESOURCES[path];
+    if (!resource) return new HttpResponse(null, { status: 404 });
+    return new HttpResponse(resource.body, {
+      headers: { 'Content-Type': resource.type, ETag: `"${path}"` },
+    });
+  }),
+];
+
+/** A book with no EPUB: the manifest 404s, which is how the app learns there is none. */
+export const noPublication = [
+  http.post(SESSION_PATH, () => HttpResponse.json({ expires_in: 900 })),
+  http.get(MANIFEST_PATH, () => new HttpResponse(null, { status: 404 })),
+];
+
+/**
+ * The session endpoint refusing exactly once, as it does when the access token
+ * has just expired: the next attempt, carrying a refreshed token, is answered
+ * by whichever session handler was registered before this one.
+ */
+export const sessionUnauthorizedOnce = http.post(
+  SESSION_PATH,
+  () => new HttpResponse(null, { status: 401 }),
+  { once: true }
+);

--- a/frontend/tests/msw/readiumApi.ts
+++ b/frontend/tests/msw/readiumApi.ts
@@ -7,6 +7,14 @@ const POSITIONS_PATH = '/api/v1/readium/books/:bookId/positions.json';
 const SESSION_PATH = '/api/v1/readium/books/:bookId/session';
 const RESOURCE_PATH = '/api/v1/readium/books/:bookId/resources/*';
 
+/**
+ * The file a hostile chapter tries to navigate its own frame to.
+ *
+ * Named by nothing else in the publication, so a request for it is proof the
+ * frame left the document we sanitised.
+ */
+export const ESCAPE_HATCH = 'escape-hatch.xhtml';
+
 /** A chapter as an EPUB actually ships one: XHTML, with its own namespace. */
 const chapterDocument = (title: string) =>
   `<?xml version="1.0" encoding="utf-8"?>
@@ -25,6 +33,17 @@ const chapterDocument = (title: string) =>
  * session. Every vector marks `document.body` so a test can see which one got
  * through: an inline script, an external script from the publication's own
  * origin, an inline event handler, and a `javascript:` URL.
+ *
+ * The meta refresh is the one that walks around the sanitiser rather than
+ * through it: it navigates the frame to a raw publication URL, which Readium's
+ * injected base element resolves straight to the API. That load is a plain
+ * same-origin document — no blob, no CSP, and it never passes through the
+ * fetcher that would have disarmed it.
+ *
+ * Its target is a file nothing else in the publication references, so a request
+ * for `ESCAPE_HATCH` can only mean the frame navigated. That, rather than
+ * whether the document it lands on then manages to run, is what a test can
+ * observe without depending on how the frame pool happens to be timed.
  */
 const hostileChapter = () =>
   `<?xml version="1.0" encoding="utf-8"?>
@@ -34,6 +53,7 @@ const hostileChapter = () =>
     <title>On Attention</title>
     <script>parent.document.body.setAttribute('data-pwned', 'inline-script')</script>
     <script src="evil.js"></script>
+    <meta http-equiv="REFRESH" content="0; url=${ESCAPE_HATCH}" />
   </head>
   <body onload="parent.document.body.setAttribute('data-pwned', 'onload')">
     <h1>On Attention</h1>

--- a/frontend/tests/msw/readiumApi.ts
+++ b/frontend/tests/msw/readiumApi.ts
@@ -16,11 +16,41 @@ const chapterDocument = (title: string) =>
   <body><h1>${title}</h1><p>Attention is the rarest and purest form of generosity.</p></body>
 </html>`;
 
+/**
+ * A chapter that tries to break out of its frame.
+ *
+ * The frame is same-origin with the app and Readium runs it with
+ * `allow-same-origin allow-scripts`, so any of these, if it executed, would be
+ * reading and writing the app's own DOM — and could just as easily spend the
+ * session. Every vector marks `document.body` so a test can see which one got
+ * through: an inline script, an external script from the publication's own
+ * origin, an inline event handler, and a `javascript:` URL.
+ */
+const hostileChapter = () =>
+  `<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <title>On Attention</title>
+    <script>parent.document.body.setAttribute('data-pwned', 'inline-script')</script>
+    <script src="evil.js"></script>
+  </head>
+  <body onload="parent.document.body.setAttribute('data-pwned', 'onload')">
+    <h1>On Attention</h1>
+    <p><a href="javascript:parent.document.body.setAttribute('data-pwned','href')">A link.</a></p>
+    <img src="x.png" onerror="parent.document.body.setAttribute('data-pwned', 'onerror')" />
+  </body>
+</html>`;
+
 /** The files `aManifest` names, keyed by the path the resource route receives. */
 const RESOURCES: Record<string, { body: string; type: string } | undefined> = {
   'OEBPS/chapter1.xhtml': { body: chapterDocument('On Attention'), type: 'application/xhtml+xml' },
   'OEBPS/chapter2.xhtml': { body: chapterDocument('On Memory'), type: 'application/xhtml+xml' },
   'OEBPS/style.css': { body: 'body { margin: 0; }', type: 'text/css' },
+  'OEBPS/evil.js': {
+    body: "parent.document.body.setAttribute('data-pwned', 'external-script')",
+    type: 'text/javascript',
+  },
 };
 
 interface ReadiumApiOptions {
@@ -28,6 +58,8 @@ interface ReadiumApiOptions {
   positions?: PositionList;
   /** Seconds of life the session endpoint claims for the publication cookie. */
   expiresIn?: number;
+  /** Serve the first chapter as a book that attacks the page that opened it. */
+  hostile?: boolean;
 }
 
 /**
@@ -36,13 +68,21 @@ interface ReadiumApiOptions {
  * The navigator fetches the reading order itself, so serving the chapters here
  * is what lets a test drive the real thing rather than a mock of it.
  */
-export const readiumApi = ({ manifest, positions, expiresIn = 900 }: ReadiumApiOptions = {}) => [
+export const readiumApi = ({
+  manifest,
+  positions,
+  expiresIn = 900,
+  hostile = false,
+}: ReadiumApiOptions = {}) => [
   http.post(SESSION_PATH, () => HttpResponse.json({ expires_in: expiresIn })),
   http.get(MANIFEST_PATH, () => HttpResponse.json(manifest ?? aManifest())),
   http.get(POSITIONS_PATH, () => HttpResponse.json(positions ?? aPositionList())),
   http.get(RESOURCE_PATH, ({ params }) => {
     const path = String(params[0]);
-    const resource = RESOURCES[path];
+    const resource =
+      hostile && path === 'OEBPS/chapter1.xhtml'
+        ? { body: hostileChapter(), type: 'application/xhtml+xml' }
+        : RESOURCES[path];
     if (!resource) return new HttpResponse(null, { status: 404 });
     return new HttpResponse(resource.body, {
       headers: { 'Content-Type': resource.type, ETag: `"${path}"` },

--- a/frontend/tests/setup.ts
+++ b/frontend/tests/setup.ts
@@ -12,6 +12,31 @@ AXIOS_INSTANCE.defaults.baseURL = '';
 
 const unhandledRequests: string[] = [];
 
+/**
+ * Chromium raises this whenever a `ResizeObserver` callback changes layout, so
+ * that the observations it could not deliver this frame are delivered on the
+ * next one. That is the specified behaviour, not a fault — and it is exactly
+ * what `@readium/navigator` does, because its own observer resizes the reader's
+ * container in response to being resized.
+ *
+ * It reaches the page as a window `error` event all the same, and Vitest fails
+ * whichever test happens to be running when one lands. Swallowing this one
+ * message keeps a third-party library's normal behaviour from failing tests at
+ * random; every other error still fails the run.
+ */
+const RESIZE_OBSERVER_NOTICE = 'ResizeObserver loop';
+
+window.addEventListener(
+  'error',
+  (event) => {
+    if (event.message.includes(RESIZE_OBSERVER_NOTICE)) {
+      event.stopImmediatePropagation();
+      event.preventDefault();
+    }
+  },
+  true
+);
+
 beforeAll(async () => {
   // The axios default above can be reassigned; this one cannot — components
   // build URLs from a constant compiled out of `import.meta.env`, so a leaked

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,8 @@
         "@mui/icons-material": "^9.3.1",
         "@mui/material": "^9.4.0",
         "@mui/x-date-pickers": "^9.12.0",
+        "@readium/navigator": "^2.8.2",
+        "@readium/shared": "^2.4.0",
         "@tanstack/react-query": "^5.101.4",
         "@tanstack/react-router": "^1.170.32",
         "axios": "^1.20.0",
@@ -2624,6 +2626,68 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
+      }
+    },
+    "node_modules/@readium/decorator": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@readium/decorator/-/decorator-1.0.2.tgz",
+      "integrity": "sha512-bod7LemtcZR+rANs8hmpxG5bTxFn9Dqa3gJ4XS5oV0tB23NatVDyFa3DZhELwvW6JUhmduZd8EGxhGkU1NZ0mw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@readium/navigator-html-injectables": "2.6.3",
+        "@readium/shared": "2.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@readium/helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@readium/helpers/-/helpers-1.0.0.tgz",
+      "integrity": "sha512-7q1ZZhY6/drlSyJvcNweWZlbqv4yfr5fLgM+UF4sf1qa7EJJ+yPmVcuhui1ntPbiS3Wae0mh0kL4AFsyOXyrbQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "user-agent-data-types": "^0.4.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@readium/navigator": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/@readium/navigator/-/navigator-2.8.2.tgz",
+      "integrity": "sha512-lZ12/HnkuP8B3xiGBCvLWZZQiKEIBbEVKqqfHznuyOKebSKyNqkrDNXZ2oYcVe0lSLXmisB5FIezPTZwGoTDIw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@readium/decorator": "1.0.2",
+        "@readium/helpers": "1.0.0",
+        "@readium/navigator-html-injectables": "2.6.3",
+        "@readium/shared": "2.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@readium/navigator-html-injectables": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/@readium/navigator-html-injectables/-/navigator-html-injectables-2.6.3.tgz",
+      "integrity": "sha512-9txUqqQ2pJ6UJvnVFFrCsxCf9qujAi99sP6DeyCGBF3WIKVP2UGC63El35A8im68aDMbFOmeGLY+HXCOaxvviw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@readium/helpers": "1.0.0",
+        "@readium/shared": "2.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@readium/shared": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@readium/shared/-/shared-2.4.0.tgz",
+      "integrity": "sha512-j3N2dqCuFja5ToksYr+G4uKg5vnzNVSLlZy9C071jSkQeRUSIIdREPYo5Gx/XOptkvPwip9O28oaG/JXCW4Z1g==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rolldown/binding-android-arm-eabi": {
@@ -9596,6 +9660,12 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
+    },
+    "node_modules/user-agent-data-types": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/user-agent-data-types/-/user-agent-data-types-0.4.3.tgz",
+      "integrity": "sha512-Dn3fjwVgeM363mx1sEgOpOp9NNqHBj6Gn68dFbV1WoTr3s05CijKdxfH6A3Q5uzXnYNB6vdAfs/1HWFpObc7EQ==",
+      "license": "MIT"
     },
     "node_modules/vfile": {
       "version": "6.0.3",


### PR DESCRIPTION
Fixes #741 (M2.2, epic #729/#739). Built to the ratified spec on the issue; supersedes the ticket body's `usePublication` wording per the M2.1 spike verdict.

- Full-viewport `/book/{id}/read` route + Read tab (hidden without an EPUB); `ReaderShell` owns an `EpubNavigator` in a ref — StrictMode-safe serialized boots, sized ResizeObserver-driven container (the spike's unsolved 300×150 problem, solved), 15s boot watchdog with a genuinely-recovering "Try again" (abandons hung loads instead of queueing behind them).
- Load chain: publication-cookie session with wall-clock expiry tracking, visibility/focus renewal, backoff on lost renewals, and a "Reconnecting..." interaction gate when a lapsed cookie is being renewed; manifest → `Manifest.deserialize` → `Publication`.
- MUI + theme.ts chrome: top bar, TOC drawer, prev/next + per-frame arrow keys (guarded against chrome-focused targets), font-size/light/sepia/dark via `EpubPreferencesEditor`, position readout from positions.json.
- `frameLoaded`/`textSelected` seams and the `crossbill-highlights` decoration group wired for M3/M4.
- **Security hardening** (three adversarial review rounds): EPUB-embedded JS is blocked — the navigator's frames are same-origin with `allow-scripts` by design, and a fixture book's `onload` reached the app DOM before mitigation. `publicationHardening.ts` wraps the fetcher: strips `script`/`on*`/`javascript:`/`meta[refresh]`, injects a CSP meta that intersects Readium's own to exactly `blob:` (verified: CSP alone blocks all four script vectors; stripping is defence-in-depth). Residual documented in ADR-0004 Amendment 2; recommended backend follow-up: a CSP response header on the resource endpoint (separate change).
- Deep test renders the real navigator end-to-end in Chromium through MSW; hostile-EPUB, retry-deadlock, and lapsed-cookie tests all red-first. A latent `ResizeObserver` flake Readium provokes by design is pinned in tests/setup.ts (that one message only).

Gates: 220 frontend tests (3 consecutive clean runs), type-check/lint/knip/format clean, jscpd 0.9% (threshold 1.05), 0 backend files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)