### PR TITLE
feat: sandbox CSP on served publication resources

### DIFF
--- a/backend/src/infrastructure/web_reader/routers/readium.py
+++ b/backend/src/infrastructure/web_reader/routers/readium.py
@@ -72,6 +72,24 @@ UNLINKED_TOC_HREF = "#"
 # max-age: a book's file can be replaced under it at any time.
 RESOURCE_CACHE_CONTROL = "private"
 
+# The bytes served below are a file the user uploaded, and ADR-0004 Amendment 2
+# disarms them in the frontend -- but only along the path Readium takes, which
+# reads a resource with `fetch()` and frames a blob it built from the text
+# (`FrameBlobBuilder.buildHtmlFrame`). Any path that loads one of these URLs
+# *as a document* instead -- a frame navigating itself, a link followed out of
+# the reader, a URL pasted into the address bar -- gets the original markup with
+# no policy at all, and it is same-origin with the API.
+#
+# `sandbox` with no tokens is the answer to the whole family rather than to any
+# one member: the document is given an opaque origin and no scripts, no forms,
+# no plugins and no top-level navigation, so there is nothing left for a book's
+# markup to reach. It costs the reader nothing, because a header does not travel
+# into a blob: the navigator has only the response *text* by the time it builds
+# the frame, and the frame's own policy is the one Readium injects there.
+# Stylesheets, images and fonts are unaffected too -- CSP applies `sandbox` when
+# a response becomes a document or a worker, never to a subresource.
+RESOURCE_CONTENT_SECURITY_POLICY = "sandbox"
+
 # A media type as RFC 9110 §8.3.1 writes one, with no parameters, which is all
 # an EPUB's package document ever declares.
 _MEDIA_TYPE = re.compile(r"[A-Za-z0-9][A-Za-z0-9!#$&^_.+-]*/[A-Za-z0-9][A-Za-z0-9!#$&^_.+-]*")
@@ -273,9 +291,13 @@ async def get_readium_resource(
         path=path,
         known_versions=_known_versions(request.headers.get("if-none-match")),
     )
+    # The policy goes on the 304 as well as the 200: a 304 updates the headers
+    # of the copy a cache already holds (RFC 9111 §4.3.4), so omitting it would
+    # let a revalidation strip the policy off a stored response.
     headers = {
         "ETag": f'"{resource.version}"',
         "Cache-Control": RESOURCE_CACHE_CONTROL,
+        "Content-Security-Policy": RESOURCE_CONTENT_SECURITY_POLICY,
     }
     # No content means the caller's copy is current -- and, because it was asked
     # up front, means the file was never decompressed to find that out.

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -307,6 +307,17 @@ class SecurityHeadersMiddleware:
                 if settings.ENVIRONMENT != "development":
                     headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
                     headers["Strict-Transport-Security"] = "max-age=31536000; includeSubDomains"
+                # A route that set its own policy keeps it. `MutableHeaders`
+                # replaces rather than appends, so assigning here unconditionally
+                # would overwrite a narrower policy with this broader one --
+                # which is exactly what the publication resource endpoint sets
+                # (`Content-Security-Policy: sandbox`, ADR-0004 Amendment 2) and
+                # exactly the environments where it matters. The app policy is
+                # the default for responses that express none.
+                if (
+                    settings.ENVIRONMENT != "development"
+                    and "content-security-policy" not in headers
+                ):
                     headers["Content-Security-Policy"] = (
                         "default-src 'self'; "
                         "script-src 'self'; "

--- a/backend/tests/test_readium_resources.py
+++ b/backend/tests/test_readium_resources.py
@@ -19,11 +19,12 @@ from io import BytesIO
 from pathlib import Path
 
 import pytest
-from httpx import AsyncClient
+from httpx import AsyncClient, Response
 from sqlalchemy.ext.asyncio import AsyncSession
 from starlette import status
 
 from src.infrastructure.web_reader.queries import publication_resource_query
+from src.main import settings as main_settings
 from src.models import Book
 from tests.test_readium_manifest import (
     LITERAL_PERCENT_EPUB,
@@ -42,6 +43,23 @@ COVER_ART = "EPUB/images/cover%20art.png"
 def resource_url(book: Book, href: str) -> str:
     """The URL a navigator resolves for a manifest href, ``resources/`` and all."""
     return f"/api/v1/readium/books/{book.id}/resources/{href}"
+
+
+async def serve_every_manifest_href(
+    client: AsyncClient, book: Book
+) -> list[tuple[dict[str, str], Response]]:
+    """Fetch every file the manifest names, paired with the link that named it.
+
+    A manifest that advertises an href this endpoint will not serve is the
+    failure the two of them can only have together, so the manifest is what
+    drives the requests rather than a list copied out of it.
+    """
+    manifest = (await client.get(f"/api/v1/readium/books/{book.id}/manifest.json")).json()
+    links: list[dict[str, str]] = manifest["readingOrder"] + manifest["resources"]
+    return [
+        (link, await client.get(resource_url(book, link["href"].removeprefix("resources/"))))
+        for link in links
+    ]
 
 
 def member_bytes(epub_content: bytes, name: str) -> bytes:
@@ -212,25 +230,118 @@ class TestServingPublicationFiles:
     async def test_the_manifests_hrefs_all_resolve(
         self, client: AsyncClient, nested_toc_book: Book
     ) -> None:
-        """Should serve every file the manifest names, with the type it named.
+        """Should serve every file the manifest names, with the type it named."""
+        served = await serve_every_manifest_href(client, nested_toc_book)
+        assert len(served) == 5
 
-        A manifest that advertises an href this endpoint will not serve is the
-        failure the two of them can only have together, so the manifest is what
-        drives the requests rather than a list copied out of it.
-        """
-        manifest = (
-            await client.get(f"/api/v1/readium/books/{nested_toc_book.id}/manifest.json")
-        ).json()
-        links = manifest["readingOrder"] + manifest["resources"]
-        assert len(links) == 5
-
-        for link in links:
-            href = link["href"].removeprefix("resources/")
-            response = await client.get(resource_url(nested_toc_book, href))
-
+        for link, response in served:
             assert response.status_code == status.HTTP_200_OK, link["href"]
             assert response.headers["content-type"] == link["type"], link["href"]
             assert response.content, link["href"]
+
+
+class TestServedResourcesCarryASandboxPolicy:
+    """The policy that makes a resource harmless when a browser loads it directly.
+
+    ADR-0004 Amendment 2 disarms a publication's markup in the frontend, but only
+    along the path Readium takes: it reads a resource with ``fetch()`` and frames
+    a blob built from the text. A path that loads one of these URLs *as a
+    document* -- a frame navigating itself, a link followed out of the reader --
+    never passes through that, and lands on a same-origin document made of bytes
+    the user uploaded. ``Content-Security-Policy: sandbox`` is what closes that
+    at the source: an opaque origin with no scripts, no forms and no top-level
+    navigation left to reach with.
+    """
+
+    async def test_a_chapter_is_served_under_a_sandbox_policy(
+        self, client: AsyncClient, nested_toc_book: Book
+    ) -> None:
+        """Should send the policy with the markup the reader's frames are built from."""
+        response = await client.get(resource_url(nested_toc_book, CHAPTER_1))
+
+        assert response.status_code == status.HTTP_200_OK, response.text
+        assert response.headers["content-security-policy"] == "sandbox"
+        assert response.headers["x-content-type-options"] == "nosniff"
+
+    async def test_a_direct_document_load_carries_the_policy(
+        self, client: AsyncClient, nested_toc_book: Book
+    ) -> None:
+        """Should send the policy to a browser navigating straight at the resource.
+
+        This is the request the frontend hardening cannot see: no ``fetch()``, no
+        blob, just a document load of the archive's own bytes. The endpoint does
+        not vary on how it was asked, and that is the point -- the policy is not
+        conditional on the caller looking like Readium.
+        """
+        response = await client.get(
+            resource_url(nested_toc_book, CHAPTER_1),
+            headers={
+                "Accept": "text/html,application/xhtml+xml",
+                "Sec-Fetch-Dest": "document",
+                "Sec-Fetch-Mode": "navigate",
+            },
+        )
+
+        assert response.status_code == status.HTTP_200_OK, response.text
+        assert b"<html" in response.content
+        assert response.headers["content-security-policy"] == "sandbox"
+
+    async def test_a_conditional_request_still_carries_the_policy(
+        self, client: AsyncClient, nested_toc_book: Book
+    ) -> None:
+        """Should send the policy on a 304 as well as on the file itself.
+
+        A 304 updates the headers of the copy a cache already holds (RFC 9111
+        §4.3.4), so a policy left off one would be a policy revalidation strips
+        from a stored response.
+        """
+        etag = (await client.get(resource_url(nested_toc_book, CHAPTER_1))).headers["etag"]
+
+        response = await client.get(
+            resource_url(nested_toc_book, CHAPTER_1), headers={"If-None-Match": etag}
+        )
+
+        assert response.status_code == status.HTTP_304_NOT_MODIFIED
+        assert response.headers["content-security-policy"] == "sandbox"
+
+    async def test_every_file_the_manifest_names_is_sandboxed(
+        self, client: AsyncClient, nested_toc_book: Book
+    ) -> None:
+        """Should policy every resource, not only the ones that look like documents.
+
+        A media type is copied from a package document the user uploaded, so it
+        is no basis for deciding what a browser will treat as a document -- an
+        SVG is scriptable, and a mislabelled file is exactly the case the header
+        has to cover.
+        """
+        served = await serve_every_manifest_href(client, nested_toc_book)
+        assert len(served) == 5
+
+        for link, response in served:
+            assert response.status_code == status.HTTP_200_OK, link["href"]
+            assert response.headers["content-security-policy"] == "sandbox", link["href"]
+
+    async def test_the_app_wide_policy_does_not_overwrite_it(
+        self,
+        client: AsyncClient,
+        nested_toc_book: Book,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Should keep the resource's own policy where the app sets one of its own.
+
+        ``SecurityHeadersMiddleware`` sends the app's policy outside development,
+        and ``MutableHeaders`` assignment replaces rather than appends -- so a
+        middleware that did not defer would quietly widen this endpoint back to
+        ``script-src 'self'`` in every environment that matters, and only there.
+        """
+        monkeypatch.setattr(main_settings, "ENVIRONMENT", "production")
+
+        resource = await client.get(resource_url(nested_toc_book, CHAPTER_1))
+        manifest = await client.get(f"/api/v1/readium/books/{nested_toc_book.id}/manifest.json")
+
+        assert resource.headers["content-security-policy"] == "sandbox"
+        # The app policy still reaches a response that expresses none of its own.
+        assert "default-src 'self'" in manifest.headers["content-security-policy"]
 
 
 class TestConditionalRequests:

--- a/docs/adr/0004-web-reader-anchors.md
+++ b/docs/adr/0004-web-reader-anchors.md
@@ -396,3 +396,17 @@ is still same-origin, so anything that does get script running there has the
 page. Scripted EPUB content does not work, which is the intended trade. The
 architectural fix is to serve publication resources from a separate origin;
 Readium's blob-URL design makes that awkward and it is not M2.2's to do.
+
+**Residual closed at the source (#741 follow-up).** The part of that residual
+that was about *documents loaded directly* rather than framed — a frame
+navigating itself, or any path reaching a resource URL without going through the
+hardening fetch — is now handled by the server: `GET
+/api/v1/readium/books/{book_id}/resources/{path}` answers with
+`Content-Security-Policy: sandbox` on both 200 and 304, which gives such a
+document an opaque origin and no scripts whatever the frontend does, and costs
+the reader nothing because the navigator reads the response as *text* and frames
+a blob it builds itself (`FrameBlobBuilder.buildHtmlFrame`), so the header never
+travels into the frame. `SecurityHeadersMiddleware` was changed in the same
+place to leave a response's own policy alone rather than overwrite it, since the
+app-wide policy is only sent outside development — exactly where this one
+matters.


### PR DESCRIPTION
Follow-up to #779 (M2.2), closing ADR-0004 Amendment 2's documented residual at the source.

`Content-Security-Policy: sandbox` on `GET .../resources/{path}` responses (200 and 304 — a 304 updates a cached response's headers per RFC 9111 §4.3.4). Any direct document load of a raw resource — frame self-navigation, a followed link, a pasted URL — now gets an opaque origin with no scripts. The reader's normal path is untouched: the navigator consumes only the response *text* and frames its own blob, so the header never reaches it (verified in `FrameBlobBuilder.buildHtmlFrame`); subresource loads (CSS/images/fonts) are unaffected because `sandbox` binds only documents.

Also fixes a real bug this surfaced: `SecurityHeadersMiddleware` assigned the app-wide CSP unconditionally, which would have silently **overwritten** the sandbox policy — only outside development, exactly where it matters, invisible to CI. It now defers to a policy the response already set, pinned by a production-mode test.

Manifest/positions JSON deliberately unchanged (Pydantic-serialized, not raw uploaded bytes; `nosniff` already global).

Gates: 1224 backend tests, pyright 0, lint-imports 5/0, jscpd 2.0% (a test-loop clone was extracted rather than tolerated), no schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)