### PR TITLE
feat(reader): mobile tap zones, breathing room, and the WebKit frame fix

### DIFF
--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -319,10 +319,20 @@ class SecurityHeadersMiddleware:
                     settings.ENVIRONMENT != "development"
                     and "content-security-policy" not in headers
                 ):
+                    # `blob:` in three directives is the web reader, and only
+                    # the web reader. Readium frames each publication resource
+                    # as a `blob:` document (`frame-src`) whose Readium CSS
+                    # arrives as a `blob:` stylesheet (`style-src`), and injects
+                    # its own scripts -- the selector generator ADR-0004 §2's
+                    # write path needs -- as `<script src="blob:...">`
+                    # (`script-src`). A book's own scripts are not covered by
+                    # any of it: they are inline or served from this origin, and
+                    # `publicationHardening.ts` strips them and pins the frame
+                    # to `script-src blob:` besides.
                     headers["Content-Security-Policy"] = (
                         "default-src 'self'; "
-                        "script-src 'self' blob: 'sha256-ZswfTY7H35rbv8WC7NXBoiC7WNu86vSzCDChNWwZZDM=' 'sha256-vkotUvpkIPYVpizTziU6038SoZQpXC7BFstfTehf3jU=' 'sha256-XwZ85A6voLmUP8995sA5TSyPQ64ebkQ2WDs4WBrJxCU=';"
-                        "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com blob:;"
+                        "script-src 'self' blob:; "
+                        "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com blob:; "
                         "img-src 'self' data: blob:; "
                         "font-src 'self' https://fonts.gstatic.com; "
                         "connect-src 'self'; "

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -321,11 +321,12 @@ class SecurityHeadersMiddleware:
                 ):
                     headers["Content-Security-Policy"] = (
                         "default-src 'self'; "
-                        "script-src 'self'; "
-                        "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; "
+                        "script-src 'self' blob: 'sha256-ZswfTY7H35rbv8WC7NXBoiC7WNu86vSzCDChNWwZZDM=' 'sha256-vkotUvpkIPYVpizTziU6038SoZQpXC7BFstfTehf3jU=' 'sha256-XwZ85A6voLmUP8995sA5TSyPQ64ebkQ2WDs4WBrJxCU=';"
+                        "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com blob:;"
                         "img-src 'self' data: blob:; "
                         "font-src 'self' https://fonts.gstatic.com; "
                         "connect-src 'self'; "
+                        "frame-src 'self' blob:; "
                         "frame-ancestors 'none'; "
                         "base-uri 'self'; "
                         "form-action 'self'"

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -337,7 +337,24 @@ class SecurityHeadersMiddleware:
                         "font-src 'self' https://fonts.gstatic.com; "
                         "connect-src 'self'; "
                         "frame-src 'self' blob:; "
-                        "frame-ancestors 'none'; "
+                        # 'self' rather than 'none', and the web reader is why.
+                        # A blob: document inherits the CSP of the context that
+                        # created it, and WebKit then enforces the inherited
+                        # `frame-ancestors` against that document's own
+                        # ancestor -- so `'none'` made Safari refuse every
+                        # publication frame the reader built ("Refused to load
+                        # blob:... because it does not appear in the
+                        # frame-ancestors directive"), and a book never opened
+                        # on an iPhone. Chromium does not apply inherited
+                        # `frame-ancestors` to blob: children, which is why
+                        # desktop never saw it.
+                        #
+                        # Nothing is given up. `X-Frame-Options: DENY` above
+                        # still refuses every attempt to frame the app, and
+                        # `'self'` still refuses every cross-origin one at the
+                        # CSP level; what it now permits is this page framing
+                        # its own blob: documents, which is exactly the reader.
+                        "frame-ancestors 'self'; "
                         "base-uri 'self'; "
                         "form-action 'self'"
                     )

--- a/backend/tests/test_readium_resources.py
+++ b/backend/tests/test_readium_resources.py
@@ -343,6 +343,35 @@ class TestServedResourcesCarryASandboxPolicy:
         # The app policy still reaches a response that expresses none of its own.
         assert "default-src 'self'" in manifest.headers["content-security-policy"]
 
+    async def test_the_app_policy_lets_the_reader_frame_its_own_documents(
+        self,
+        client: AsyncClient,
+        nested_toc_book: Book,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Should not forbid this page from framing the reader's blob: documents.
+
+        A blob: document inherits the policy of the context that created it, and
+        WebKit enforces the inherited ``frame-ancestors`` against that
+        document's own ancestor. With ``'none'`` it refused every publication
+        frame the reader built, so a book never opened on iPhone Safari while
+        desktop Chromium -- which does not apply inherited ``frame-ancestors``
+        to blob: children -- was perfectly happy.
+
+        ``X-Frame-Options: DENY`` is what keeps the app itself unframeable, and
+        ``'self'`` still refuses every cross-origin attempt at the CSP level.
+        """
+        monkeypatch.setattr(main_settings, "ENVIRONMENT", "production")
+
+        manifest = await client.get(f"/api/v1/readium/books/{nested_toc_book.id}/manifest.json")
+
+        policy = manifest.headers["content-security-policy"]
+        assert "frame-ancestors 'self'" in policy
+        assert "frame-ancestors 'none'" not in policy
+        assert manifest.headers["x-frame-options"] == "DENY"
+        # And the frames themselves are still allowed to be blob: at all.
+        assert "frame-src 'self' blob:" in policy
+
 
 class TestConditionalRequests:
     """The entity tag, and what a reader that already holds a file is told."""

--- a/frontend/src/components/reader/ReaderShell.tsx
+++ b/frontend/src/components/reader/ReaderShell.tsx
@@ -10,6 +10,7 @@ import {
 import { TocDrawer } from '@/components/reader/TocDrawer.tsx';
 import { useReaderPublication } from '@/components/reader/useReaderPublication.ts';
 import { useReaderSession } from '@/components/reader/useReaderSession.ts';
+import { useReaderTapZones } from '@/components/reader/useReaderTapZones.ts';
 import { useReadingPositionWriter } from '@/components/reader/useReadingPositionWriter.ts';
 import { useResumeLocator } from '@/components/reader/useResumeLocator.ts';
 import { useSnackbar } from '@/context/SnackbarContext.tsx';
@@ -154,6 +155,15 @@ export const ReaderShell = ({ bookId, title, onClose }: ReaderShellProps) => {
   const goForward = useCallback(() => navigatorRef.current?.goForward(true, () => {}), []);
   const goBackward = useCallback(() => navigatorRef.current?.goBackward(true, () => {}), []);
 
+  // What replaces the arrow buttons where there is no room for them. Stable for
+  // the same reason `handleKeyDown` is, and bound to each frame in the same place.
+  const bindTapZones = useReaderTapZones({
+    enabled: isCompact,
+    suspended: isRenewing,
+    onPrevious: goBackward,
+    onNext: goForward,
+  });
+
   // Mirrored into a ref so the key handler can consult it without becoming a
   // new function, which would mean rebinding every publication frame.
   const isRenewingRef = useRef(false);
@@ -269,12 +279,14 @@ export const ReaderShell = ({ bookId, title, onClose }: ReaderShellProps) => {
            *
            * The seam M3.2 hangs its highlights on: decorations are applied per
            * frame, so this is where a newly loaded resource gets the ones that
-           * belong to it. Today it only reveals the page and gives the frame
-           * the arrow keys, which a same-origin iframe does not bubble up on
-           * its own.
+           * belong to it. Today it reveals the page and hands the frame the two
+           * ways of turning it — the arrow keys and, where the buttons cannot
+           * fit, the tap zones — neither of which a same-origin iframe bubbles
+           * up on its own.
            */
           frameLoaded: (frameWindow: Window) => {
             frameWindow.addEventListener('keydown', handleKeyDown);
+            bindTapZones(frameWindow);
             setIsPageVisible(true);
           },
           /**
@@ -299,6 +311,10 @@ export const ReaderShell = ({ bookId, title, onClose }: ReaderShellProps) => {
            */
           textSelected: () => {},
           timelineItemChanged: () => {},
+          // Readium pages the book itself on a pointer in the outer quarters of
+          // a frame unless the listener claims the event. It has to stay
+          // claimed: `useReaderTapZones` is what turns pages here, and a tap
+          // answered twice would skip one.
           tap: () => true,
           click: () => true,
           zoom: () => {},
@@ -409,6 +425,7 @@ export const ReaderShell = ({ bookId, title, onClose }: ReaderShellProps) => {
     openAt,
     theme,
     handleKeyDown,
+    bindTapZones,
     recordPosition,
     setArriving,
     bootAttempt,

--- a/frontend/src/components/reader/ReaderShell.tsx
+++ b/frontend/src/components/reader/ReaderShell.tsx
@@ -155,13 +155,19 @@ export const ReaderShell = ({ bookId, title, onClose }: ReaderShellProps) => {
   const goForward = useCallback(() => navigatorRef.current?.goForward(true, () => {}), []);
   const goBackward = useCallback(() => navigatorRef.current?.goBackward(true, () => {}), []);
 
+  // Spatial rather than logical, because a tap zone is a physical edge: in a
+  // right-to-left book the next page is the one to the *left*. The navigator
+  // resolves the two against the publication's reading progression.
+  const goLeft = useCallback(() => navigatorRef.current?.goLeft(true, () => {}), []);
+  const goRight = useCallback(() => navigatorRef.current?.goRight(true, () => {}), []);
+
   // What replaces the arrow buttons where there is no room for them. Stable for
   // the same reason `handleKeyDown` is, and bound to each frame in the same place.
   const bindTapZones = useReaderTapZones({
     enabled: isCompact,
     suspended: isRenewing,
-    onPrevious: goBackward,
-    onNext: goForward,
+    onLeft: goLeft,
+    onRight: goRight,
   });
 
   // Mirrored into a ref so the key handler can consult it without becoming a

--- a/frontend/src/components/reader/ReaderShell.tsx
+++ b/frontend/src/components/reader/ReaderShell.tsx
@@ -70,7 +70,7 @@ const DEFAULT_FONT_SIZE_BOUNDS: { range: [number, number]; step: number } = {
  * short enough that a reader who is never getting a book is told rather than
  * left watching a skeleton.
  */
-const BOOT_TIMEOUT_MS = 15_000;
+const BOOT_TIMEOUT_MS = 60_000;
 
 /** How long an abandoned navigator gets to tear itself down before it is dropped. */
 const DESTROY_TIMEOUT_MS = 2_000;

--- a/frontend/src/components/reader/ReaderShell.tsx
+++ b/frontend/src/components/reader/ReaderShell.tsx
@@ -69,8 +69,14 @@ const DEFAULT_FONT_SIZE_BOUNDS: { range: [number, number]; step: number } = {
  * fetching a chapter or two and assembling their blobs. Generous for that, and
  * short enough that a reader who is never getting a book is told rather than
  * left watching a skeleton.
+ *
+ * Briefly 60s, while books would not open on iPhone Safari. That was a CSP
+ * refusal rather than a slow load — `frame-ancestors 'none'`, inherited into
+ * the reader's blob: frames and enforced there by WebKit alone — so the frame
+ * failed instantly and no clock could have saved it. Waiting longer only meant
+ * a minute of skeleton before the same apology.
  */
-const BOOT_TIMEOUT_MS = 60_000;
+const BOOT_TIMEOUT_MS = 15_000;
 
 /** How long an abandoned navigator gets to tear itself down before it is dropped. */
 const DESTROY_TIMEOUT_MS = 2_000;

--- a/frontend/src/components/reader/ReaderShell.tsx
+++ b/frontend/src/components/reader/ReaderShell.tsx
@@ -15,13 +15,39 @@ import { useResumeLocator } from '@/components/reader/useResumeLocator.ts';
 import { useSnackbar } from '@/context/SnackbarContext.tsx';
 import { NextPageIcon, PreviousPageIcon } from '@/theme/Icons.tsx';
 import { ICON_SIZE } from '@/theme/iconSizes.ts';
-import { Box, Button, IconButton, Skeleton, Stack, Typography, useTheme } from '@mui/material';
+import {
+  Box,
+  Button,
+  IconButton,
+  Skeleton,
+  Stack,
+  Typography,
+  useMediaQuery,
+  useTheme,
+} from '@mui/material';
 import { EpubNavigator } from '@readium/navigator';
 import type { Link, Locator } from '@readium/shared';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
-/** Room in the margins for the page-turn buttons, so they never sit on the text. */
+/**
+ * Room in the margins for the page-turn buttons, so they never sit on the text.
+ *
+ * Only where those buttons are: on a phone the two gutters together were most of
+ * the screen, and the book was reduced to a strip down the middle. Below the
+ * breakpoint the buttons give way to tap zones and the reader keeps the width —
+ * with no gutter of ours at all, because Readium's own page gutter already holds
+ * the text 20px off each edge of the frame.
+ */
 const PAGE_TURN_GUTTER = 48;
+
+/**
+ * Air above and below the book, in theme spacing units.
+ *
+ * Readium's page gutter is horizontal only (`padding: 0 var(--RS__pageGutter)`),
+ * so without this the first line sits against the chrome's border and the last
+ * against the bottom of the screen. Nothing to double up with, at any width.
+ */
+const READING_SURFACE_INSET = 2;
 
 /**
  * What the font-size control offers before there is a navigator to ask.
@@ -95,6 +121,9 @@ const whenSized = (element: HTMLElement) =>
  */
 export const ReaderShell = ({ bookId, title, onClose }: ReaderShellProps) => {
   const theme = useTheme();
+  // A phone, near enough. The arrow buttons need gutters this viewport cannot
+  // spare, so below here the edges of the page turn it instead.
+  const isCompact = useMediaQuery(theme.breakpoints.down('sm'));
   const { showSnackbar } = useSnackbar();
   const { status: sessionStatus, isRenewing } = useReaderSession(bookId);
   const { status: publicationStatus, publication, positions } = useReaderPublication(bookId);
@@ -473,8 +502,12 @@ export const ReaderShell = ({ bookId, title, onClose }: ReaderShellProps) => {
       />
 
       <Box sx={{ flex: 1, minHeight: 0, position: 'relative' }}>
-        <PageTurnButton edge="left" onClick={goBackward} disabled={isRenewing} />
-        <PageTurnButton edge="right" onClick={goForward} disabled={isRenewing} />
+        {!isCompact && (
+          <>
+            <PageTurnButton edge="left" onClick={goBackward} disabled={isRenewing} />
+            <PageTurnButton edge="right" onClick={goForward} disabled={isRenewing} />
+          </>
+        )}
 
         {/* The element the navigator measures. Its own container is created
             inside it once it has a box, and the frames Readium appends are
@@ -484,7 +517,8 @@ export const ReaderShell = ({ bookId, title, onClose }: ReaderShellProps) => {
           data-testid="reader-viewport"
           sx={{
             height: '100%',
-            px: `${PAGE_TURN_GUTTER}px`,
+            px: { xs: 0, sm: `${PAGE_TURN_GUTTER}px` },
+            py: READING_SURFACE_INSET,
             visibility: isPageVisible ? 'visible' : 'hidden',
             '& .readium-navigator-iframe': {
               position: 'absolute',

--- a/frontend/src/components/reader/useReaderTapZones.ts
+++ b/frontend/src/components/reader/useReaderTapZones.ts
@@ -1,0 +1,145 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+/** How much of each edge of the reading surface turns a page. */
+const TAP_ZONE_FRACTION = 0.2;
+
+/**
+ * How far a pointer may travel and still be a tap.
+ *
+ * A swipe, a drag across text and a flick to scroll all begin as a pointerdown
+ * on the page; the distance travelled is what separates them from a finger put
+ * down and lifted in one place. Generous enough to forgive the wobble a thumb
+ * puts into a deliberate tap.
+ */
+const TAP_SLOP_PX = 10;
+
+/**
+ * How long a pointer may be held and still be a tap.
+ *
+ * A long press is the gesture that opens a selection, and it must not also cost
+ * the reader their page.
+ */
+const TAP_MAX_MS = 500;
+
+/** Things that answer a pointer themselves, and whose answer is not a page turn. */
+const INTERACTIVE_SELECTOR =
+  'a[href], button, input, select, textarea, summary, [role="button"], [role="link"]';
+
+interface TapOrigin {
+  x: number;
+  y: number;
+  at: number;
+  /** Whether text was already selected when the pointer went down. */
+  overSelection: boolean;
+}
+
+/**
+ * The interactive element a pointer landed on, if any.
+ *
+ * `instanceof Element` is no use here: the target belongs to the publication's
+ * own document, a separate realm whose `Element` is not this one — the same
+ * property the reader's key handler relies on to ignore in-frame events.
+ */
+const nearestInteractive = (target: EventTarget | null): Element | null => {
+  const element = target as Element | null;
+  return typeof element?.closest === 'function' ? element.closest(INTERACTIVE_SELECTOR) : null;
+};
+
+interface ReaderTapZoneOptions {
+  /** False wherever the arrow buttons are shown, which is where taps are not wanted. */
+  enabled: boolean;
+  /** Page turns are held while true, as they are for the arrow buttons. */
+  suspended: boolean;
+  onPrevious: () => void;
+  onNext: () => void;
+}
+
+/**
+ * Turning pages by tapping the edges of the book.
+ *
+ * Returns a function to give each publication frame as it loads. The listeners
+ * go *inside* the frame rather than over it: an overlay across the reading
+ * surface would be the simpler thing to write, but it would sit between the
+ * reader and the book and eat the selection, the links and the scrolling that
+ * belong to the publication's own document. A same-origin frame does not bubble
+ * its events out, so reaching into it through `frameLoaded` is the same seam the
+ * arrow keys already use.
+ *
+ * Readium has a tap pager of its own — fixed quarters, no notion of how long the
+ * pointer was down — which the reader suppresses by returning `true` from the
+ * navigator's `tap` and `click` listeners. That must stay true, or a tap here
+ * would turn two pages.
+ */
+export const useReaderTapZones = ({
+  enabled,
+  suspended,
+  onPrevious,
+  onNext,
+}: ReaderTapZoneOptions) => {
+  // Mirrored into a ref rather than closed over, so that crossing the breakpoint
+  // or renewing a session does not change the identity of the binder below —
+  // which is a dependency of the boot effect, and so would rebuild the navigator.
+  const gateRef = useRef({ enabled, suspended });
+  useEffect(() => {
+    gateRef.current = { enabled, suspended };
+  }, [enabled, suspended]);
+
+  // `frameLoaded` fires again for a frame the pool has kept, and these listeners
+  // are fresh closures every time, so `addEventListener` would not dedupe them.
+  const boundFrames = useRef(new WeakSet<Window>());
+
+  return useCallback(
+    (frameWindow: Window) => {
+      if (boundFrames.current.has(frameWindow)) return;
+      boundFrames.current.add(frameWindow);
+
+      const isSelecting = () => frameWindow.getSelection()?.isCollapsed === false;
+
+      let origin: TapOrigin | null = null;
+
+      frameWindow.addEventListener('pointerdown', (event) => {
+        origin = event.isPrimary
+          ? {
+              x: event.clientX,
+              y: event.clientY,
+              at: Date.now(),
+              overSelection: isSelecting(),
+            }
+          : null;
+      });
+
+      // A gesture the browser took over — a scroll, or a system gesture from the
+      // edge of the screen — never becomes a tap.
+      frameWindow.addEventListener('pointercancel', () => {
+        origin = null;
+      });
+
+      frameWindow.addEventListener('pointerup', (event) => {
+        const start = origin;
+        origin = null;
+        const { enabled: tapsTurnPages, suspended: held } = gateRef.current;
+        if (!start || !tapsTurnPages || held) return;
+
+        if (
+          Math.abs(event.clientX - start.x) > TAP_SLOP_PX ||
+          Math.abs(event.clientY - start.y) > TAP_SLOP_PX
+        )
+          return;
+        if (Date.now() - start.at > TAP_MAX_MS) return;
+
+        // A tap on a selection, or the one that dismisses it. The second is why
+        // the pointer's *origin* is consulted as well: by the time the pointer
+        // comes up the browser has already collapsed what was selected, so the
+        // tap that ended a selection would otherwise read as an ordinary one.
+        if (start.overSelection || isSelecting()) return;
+
+        if (nearestInteractive(event.target)) return;
+
+        const zone = frameWindow.innerWidth * TAP_ZONE_FRACTION;
+        if (event.clientX < zone) onPrevious();
+        else if (event.clientX > frameWindow.innerWidth - zone) onNext();
+      });
+    },
+    [onPrevious, onNext]
+  );
+};

--- a/frontend/src/components/reader/useReaderTapZones.ts
+++ b/frontend/src/components/reader/useReaderTapZones.ts
@@ -31,6 +31,15 @@ interface TapOrigin {
   at: number;
   /** Whether text was already selected when the pointer went down. */
   overSelection: boolean;
+  /**
+   * Whether taps turned pages when the pointer went down.
+   *
+   * Sampled here as well as at the lift because a rotation can cross the
+   * breakpoint mid-gesture: a finger put down while the arrow buttons were on
+   * screen must not turn a page when it comes up in tap-zone territory, and a
+   * real tap must not be dropped by the reverse.
+   */
+  enabled: boolean;
 }
 
 /**
@@ -50,8 +59,16 @@ interface ReaderTapZoneOptions {
   enabled: boolean;
   /** Page turns are held while true, as they are for the arrow buttons. */
   suspended: boolean;
-  onPrevious: () => void;
-  onNext: () => void;
+  /**
+   * Where the page to the *left* lies, spatially — not the previous one.
+   *
+   * A tap zone is a physical edge, so in an Arabic or Hebrew book the left edge
+   * is where the *next* page is. The navigator's own `goLeft`/`goRight` make
+   * that mapping off the publication's reading progression, and are what these
+   * should be given.
+   */
+  onLeft: () => void;
+  onRight: () => void;
 }
 
 /**
@@ -73,8 +90,8 @@ interface ReaderTapZoneOptions {
 export const useReaderTapZones = ({
   enabled,
   suspended,
-  onPrevious,
-  onNext,
+  onLeft,
+  onRight,
 }: ReaderTapZoneOptions) => {
   // Mirrored into a ref rather than closed over, so that crossing the breakpoint
   // or renewing a session does not change the identity of the binder below —
@@ -104,6 +121,7 @@ export const useReaderTapZones = ({
               y: event.clientY,
               at: Date.now(),
               overSelection: isSelecting(),
+              enabled: gateRef.current.enabled,
             }
           : null;
       });
@@ -118,7 +136,11 @@ export const useReaderTapZones = ({
         const start = origin;
         origin = null;
         const { enabled: tapsTurnPages, suspended: held } = gateRef.current;
-        if (!start || !tapsTurnPages || held) return;
+        // Both ends of the gesture have to agree, so that a rotation across the
+        // breakpoint mid-tap neither invents a page turn nor swallows one.
+        // `suspended` is read at the lift alone: a renewal that began and
+        // finished under the reader's finger leaves a page turn perfectly safe.
+        if (!start || !start.enabled || !tapsTurnPages || held) return;
 
         if (
           Math.abs(event.clientX - start.x) > TAP_SLOP_PX ||
@@ -136,10 +158,10 @@ export const useReaderTapZones = ({
         if (nearestInteractive(event.target)) return;
 
         const zone = frameWindow.innerWidth * TAP_ZONE_FRACTION;
-        if (event.clientX < zone) onPrevious();
-        else if (event.clientX > frameWindow.innerWidth - zone) onNext();
+        if (event.clientX < zone) onLeft();
+        else if (event.clientX > frameWindow.innerWidth - zone) onRight();
       });
     },
-    [onPrevious, onNext]
+    [onLeft, onRight]
   );
 };

--- a/frontend/src/pages/ReaderPage/ReaderPage.test.tsx
+++ b/frontend/src/pages/ReaderPage/ReaderPage.test.tsx
@@ -62,11 +62,6 @@ test('the reader opens with the book title and its controls', async () => {
   await expect.element(screen.getByRole('button', { name: 'Previous page' })).toBeVisible();
 });
 
-/**
- * On a phone the two arrow gutters were most of the screen, and the book was a
- * strip down the middle. The buttons go, and the chrome above the page — which
- * fits either way — stays exactly as it was.
- */
 /** The book open on a phone-sized viewport, showing its first page. */
 const aBookOpenOnAPhone = async (...extra: Parameters<typeof worker.use>) => {
   aBookWithAnEpub(...extra);
@@ -77,6 +72,11 @@ const aBookOpenOnAPhone = async (...extra: Parameters<typeof worker.use>) => {
   return screen;
 };
 
+/**
+ * On a phone the two arrow gutters were most of the screen, and the book was a
+ * strip down the middle. The buttons go, and the chrome above the page — which
+ * fits either way — stays exactly as it was.
+ */
 test('the arrow buttons give the page its width back on a phone', async () => {
   const screen = await aBookOpenOnAPhone();
 
@@ -94,7 +94,17 @@ test('the arrow buttons give the page its width back on a phone', async () => {
  * `userEvent` cannot: it drives the page the test is rendered in, and the frame
  * is a document of its own.
  */
-const gestureInPublication = ({ across, dragBy = 0 }: { across: number; dragBy?: number }) => {
+const gestureInPublication = async ({
+  across,
+  dragBy = 0,
+  holdFor = 0,
+  onSelection = false,
+}: {
+  across: number;
+  dragBy?: number;
+  holdFor?: number;
+  onSelection?: boolean;
+}) => {
   // Readium keeps a pool of frames and hides the ones that are not on screen.
   // Only the visible one is the page the reader is looking at, and only it is
   // the frame the navigator reported through `frameLoaded`.
@@ -116,8 +126,11 @@ const gestureInPublication = ({ across, dragBy = 0 }: { across: number; dragBy?:
     pointerType: 'touch',
   });
 
+  if (onSelection) view.getSelection()?.selectAllChildren(frame.contentDocument.body);
+
   target.dispatchEvent(new view.PointerEvent('pointerdown', at(from)));
   if (dragBy !== 0) target.dispatchEvent(new view.PointerEvent('pointermove', at(from - dragBy)));
+  if (holdFor !== 0) await new Promise((resolve) => setTimeout(resolve, holdFor));
   target.dispatchEvent(new view.PointerEvent('pointerup', at(from - dragBy)));
 };
 
@@ -133,7 +146,7 @@ const expectNoPageTurn = async () => {
 test('a tap on the right of the page turns to the next one', async () => {
   const screen = await aBookOpenOnAPhone();
 
-  gestureInPublication({ across: 0.9 });
+  await gestureInPublication({ across: 0.9 });
 
   await expect.element(screen.getByText('Page 2 of 2', { exact: false })).toBeVisible();
 });
@@ -145,7 +158,7 @@ test('a tap on the left of the page turns back', async () => {
   const screen = await renderApp({ path: '/book/1/read' });
   await expect.element(screen.getByText('Page 2 of 2', { exact: false })).toBeVisible();
 
-  gestureInPublication({ across: 0.1 });
+  await gestureInPublication({ across: 0.1 });
 
   await expect.element(screen.getByText('Page 1 of 2', { exact: false })).toBeVisible();
 });
@@ -157,7 +170,7 @@ test('a tap on the left of the page turns back', async () => {
 test('a tap in the middle of the page turns nothing', async () => {
   await aBookOpenOnAPhone();
 
-  gestureInPublication({ across: 0.5 });
+  await gestureInPublication({ across: 0.5 });
 
   await expectNoPageTurn();
 });
@@ -170,7 +183,33 @@ test('a tap in the middle of the page turns nothing', async () => {
 test('a pointer that travelled across the zone is not a tap', async () => {
   await aBookOpenOnAPhone();
 
-  gestureInPublication({ across: 0.9, dragBy: 30 });
+  await gestureInPublication({ across: 0.9, dragBy: 30 });
+
+  await expectNoPageTurn();
+});
+
+/**
+ * A long press is how a reader opens a selection, and M4 will hang the
+ * highlighting on it. Holding a finger down in a tap zone must not cost them
+ * the page they were about to select from.
+ */
+test('a finger held down in the zone is not a tap', async () => {
+  await aBookOpenOnAPhone();
+
+  await gestureInPublication({ across: 0.9, holdFor: 700 });
+
+  await expectNoPageTurn();
+});
+
+/**
+ * Selecting text runs to the edge of the page like any other text, so the tap
+ * that lands on a selection — and the one that dismisses it — has to leave the
+ * page alone. Otherwise a reader loses the passage they had just selected.
+ */
+test('a tap on selected text is not a page turn', async () => {
+  await aBookOpenOnAPhone();
+
+  await gestureInPublication({ across: 0.9, onSelection: true });
 
   await expectNoPageTurn();
 });
@@ -182,7 +221,7 @@ test('a click on the edge of the page turns nothing on a desktop viewport', asyn
   const screen = await renderApp({ path: '/book/1/read' });
   await expect.element(screen.getByText('Page 1 of 2', { exact: false })).toBeVisible();
 
-  gestureInPublication({ across: 0.9 });
+  await gestureInPublication({ across: 0.9 });
 
   await expectNoPageTurn();
 });

--- a/frontend/src/pages/ReaderPage/ReaderPage.test.tsx
+++ b/frontend/src/pages/ReaderPage/ReaderPage.test.tsx
@@ -1,5 +1,5 @@
 import { aBookDetails } from '@tests/fixtures/book';
-import { aResumePosition } from '@tests/fixtures/publication';
+import { aManifest, aResumePosition } from '@tests/fixtures/publication';
 import { renderApp } from '@tests/harness/renderApp';
 import { bookApi } from '@tests/msw/bookApi';
 import {
@@ -99,11 +99,14 @@ const gestureInPublication = async ({
   dragBy = 0,
   holdFor = 0,
   onSelection = false,
+  resizeTo,
 }: {
   across: number;
   dragBy?: number;
   holdFor?: number;
   onSelection?: boolean;
+  /** Resize the viewport mid-gesture, as a rotation does. */
+  resizeTo?: { width: number; height: number };
 }) => {
   // Readium keeps a pool of frames and hides the ones that are not on screen.
   // Only the visible one is the page the reader is looking at, and only it is
@@ -131,6 +134,12 @@ const gestureInPublication = async ({
   target.dispatchEvent(new view.PointerEvent('pointerdown', at(from)));
   if (dragBy !== 0) target.dispatchEvent(new view.PointerEvent('pointermove', at(from - dragBy)));
   if (holdFor !== 0) await new Promise((resolve) => setTimeout(resolve, holdFor));
+  if (resizeTo) {
+    await page.viewport(resizeTo.width, resizeTo.height);
+    // The media query has to reach React, and React the reader, before the
+    // finger comes up — otherwise the race this simulates never happens.
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
   target.dispatchEvent(new view.PointerEvent('pointerup', at(from - dragBy)));
 };
 
@@ -210,6 +219,50 @@ test('a tap on selected text is not a page turn', async () => {
   await aBookOpenOnAPhone();
 
   await gestureInPublication({ across: 0.9, onSelection: true });
+
+  await expectNoPageTurn();
+});
+
+/**
+ * The zones are physical edges, so what they mean depends on which way the book
+ * runs. In an Arabic or Hebrew book the next page lies to the *left*, and a
+ * reader tapping the left edge is reaching for it — the navigator's own
+ * `goLeft`/`goRight` are what map an edge onto a direction.
+ *
+ * The progression is taken from the language here, which is how Readium derives
+ * it when a manifest does not say (`Metadata.effectiveReadingProgression`), and
+ * how our own manifests arrive: the backend publishes no `readingProgression`.
+ * This pins the mapping only — M2.2 left RTL *rendering* untested, and this does
+ * not certify it.
+ */
+test('a tap on the left of a right-to-left book turns forward', async () => {
+  aBookWithAPublication({
+    manifest: aManifest({
+      metadata: { title: 'The Pragmatic Reader', language: 'ar', identifier: 'urn:uuid:rtl' },
+    }),
+  });
+  await page.viewport(PHONE_VIEWPORT.width, PHONE_VIEWPORT.height);
+
+  const screen = await renderApp({ path: '/book/1/read' });
+  await expect.element(screen.getByText('Page 1 of 2', { exact: false })).toBeVisible();
+
+  await gestureInPublication({ across: 0.1 });
+
+  await expect.element(screen.getByText('Page 2 of 2', { exact: false })).toBeVisible();
+});
+
+/**
+ * A rotation can cross the breakpoint between a finger going down and coming
+ * up. Sampling only at the end would let a gesture begun in button territory
+ * turn a page, so both ends of the tap have to agree that taps turn pages.
+ */
+test('a gesture that crosses the breakpoint mid-tap turns nothing', async () => {
+  aBookWithAnEpub();
+
+  const screen = await renderApp({ path: '/book/1/read' });
+  await expect.element(screen.getByText('Page 1 of 2', { exact: false })).toBeVisible();
+
+  await gestureInPublication({ across: 0.9, resizeTo: PHONE_VIEWPORT });
 
   await expectNoPageTurn();
 });

--- a/frontend/src/pages/ReaderPage/ReaderPage.test.tsx
+++ b/frontend/src/pages/ReaderPage/ReaderPage.test.tsx
@@ -11,8 +11,18 @@ import {
 } from '@tests/msw/readiumApi';
 import { worker } from '@tests/msw/worker';
 import { delay, http, HttpResponse } from 'msw';
-import { expect, test, vi } from 'vitest';
-import { userEvent } from 'vitest/browser';
+import { afterEach, expect, test, vi } from 'vitest';
+import { page, userEvent } from 'vitest/browser';
+
+/** Narrower than the `sm` breakpoint the reader lays itself out against. */
+const PHONE_VIEWPORT = { width: 390, height: 780 };
+
+/** `vitest.config.ts`'s own viewport, restored after a test has narrowed it. */
+const DEFAULT_VIEWPORT = { width: 1440, height: 900 };
+
+afterEach(async () => {
+  await page.viewport(DEFAULT_VIEWPORT.width, DEFAULT_VIEWPORT.height);
+});
 
 /**
  * `bookApi` serves a book with no EPUB by default, so the reader's own
@@ -50,6 +60,23 @@ test('the reader opens with the book title and its controls', async () => {
   await expect.element(screen.getByRole('button', { name: 'Appearance' })).toBeVisible();
   await expect.element(screen.getByRole('button', { name: 'Next page' })).toBeVisible();
   await expect.element(screen.getByRole('button', { name: 'Previous page' })).toBeVisible();
+});
+
+/**
+ * On a phone the two arrow gutters were most of the screen, and the book was a
+ * strip down the middle. The buttons go, and the chrome above the page — which
+ * fits either way — stays exactly as it was.
+ */
+test('the arrow buttons give the page its width back on a phone', async () => {
+  aBookWithAnEpub();
+  await page.viewport(PHONE_VIEWPORT.width, PHONE_VIEWPORT.height);
+
+  const screen = await renderApp({ path: '/book/1/read' });
+  await expect.element(screen.getByText('Page 1 of 2', { exact: false })).toBeVisible();
+
+  expect(screen.getByRole('button', { name: 'Next page' }).query()).toBeNull();
+  expect(screen.getByRole('button', { name: 'Previous page' }).query()).toBeNull();
+  await expect.element(screen.getByRole('button', { name: 'Contents' })).toBeVisible();
 });
 
 /**

--- a/frontend/src/pages/ReaderPage/ReaderPage.test.tsx
+++ b/frontend/src/pages/ReaderPage/ReaderPage.test.tsx
@@ -67,16 +67,124 @@ test('the reader opens with the book title and its controls', async () => {
  * strip down the middle. The buttons go, and the chrome above the page — which
  * fits either way — stays exactly as it was.
  */
-test('the arrow buttons give the page its width back on a phone', async () => {
-  aBookWithAnEpub();
+/** The book open on a phone-sized viewport, showing its first page. */
+const aBookOpenOnAPhone = async (...extra: Parameters<typeof worker.use>) => {
+  aBookWithAnEpub(...extra);
   await page.viewport(PHONE_VIEWPORT.width, PHONE_VIEWPORT.height);
 
   const screen = await renderApp({ path: '/book/1/read' });
   await expect.element(screen.getByText('Page 1 of 2', { exact: false })).toBeVisible();
+  return screen;
+};
+
+test('the arrow buttons give the page its width back on a phone', async () => {
+  const screen = await aBookOpenOnAPhone();
 
   expect(screen.getByRole('button', { name: 'Next page' }).query()).toBeNull();
   expect(screen.getByRole('button', { name: 'Previous page' }).query()).toBeNull();
   await expect.element(screen.getByRole('button', { name: 'Contents' })).toBeVisible();
+});
+
+/**
+ * A pointer gesture inside the publication's own frame.
+ *
+ * The tap zones listen in the frame rather than over it — an overlay would sit
+ * between the reader and the book and eat the selection and the links that
+ * belong to it — so a test has to reach into the frame the way a finger does.
+ * `userEvent` cannot: it drives the page the test is rendered in, and the frame
+ * is a document of its own.
+ */
+const gestureInPublication = ({ across, dragBy = 0 }: { across: number; dragBy?: number }) => {
+  // Readium keeps a pool of frames and hides the ones that are not on screen.
+  // Only the visible one is the page the reader is looking at, and only it is
+  // the frame the navigator reported through `frameLoaded`.
+  const frame = [
+    ...document.querySelectorAll<HTMLIFrameElement>('iframe.readium-navigator-iframe'),
+  ].find((candidate) => candidate.style.visibility !== 'hidden');
+  const view = frame?.contentWindow as (Window & typeof globalThis) | null | undefined;
+  if (!view || !frame?.contentDocument) throw new Error('The publication has no frame to tap.');
+
+  const from = Math.round(view.innerWidth * across);
+  const y = Math.round(view.innerHeight / 2);
+  const target = frame.contentDocument.elementFromPoint(from, y) ?? frame.contentDocument.body;
+  const at = (clientX: number) => ({
+    clientX,
+    clientY: y,
+    bubbles: true,
+    isPrimary: true,
+    pointerId: 1,
+    pointerType: 'touch',
+  });
+
+  target.dispatchEvent(new view.PointerEvent('pointerdown', at(from)));
+  if (dragBy !== 0) target.dispatchEvent(new view.PointerEvent('pointermove', at(from - dragBy)));
+  target.dispatchEvent(new view.PointerEvent('pointerup', at(from - dragBy)));
+};
+
+/** Long enough for a page turn to have landed if one was coming. */
+const A_PAGE_TURN = 1_200;
+
+/** That the reader stayed where it was, waited out long enough to mean it. */
+const expectNoPageTurn = async () => {
+  await new Promise((resolve) => setTimeout(resolve, A_PAGE_TURN));
+  expect(document.body.innerText).toContain('Page 1 of 2');
+};
+
+test('a tap on the right of the page turns to the next one', async () => {
+  const screen = await aBookOpenOnAPhone();
+
+  gestureInPublication({ across: 0.9 });
+
+  await expect.element(screen.getByText('Page 2 of 2', { exact: false })).toBeVisible();
+});
+
+test('a tap on the left of the page turns back', async () => {
+  aBookWithAnEpub(...readingPositionApi(aResumePosition()).handlers);
+  await page.viewport(PHONE_VIEWPORT.width, PHONE_VIEWPORT.height);
+
+  const screen = await renderApp({ path: '/book/1/read' });
+  await expect.element(screen.getByText('Page 2 of 2', { exact: false })).toBeVisible();
+
+  gestureInPublication({ across: 0.1 });
+
+  await expect.element(screen.getByText('Page 1 of 2', { exact: false })).toBeVisible();
+});
+
+/**
+ * The zones are the edges, not the whole page: the middle has to stay a place a
+ * reader can put a finger down without losing their place.
+ */
+test('a tap in the middle of the page turns nothing', async () => {
+  await aBookOpenOnAPhone();
+
+  gestureInPublication({ across: 0.5 });
+
+  await expectNoPageTurn();
+});
+
+/**
+ * A swipe, a drag across text and a flick to scroll all begin as a pointer put
+ * down on the page, and every one of them would land in a tap zone. What
+ * separates a tap from all of them is that the pointer did not travel.
+ */
+test('a pointer that travelled across the zone is not a tap', async () => {
+  await aBookOpenOnAPhone();
+
+  gestureInPublication({ across: 0.9, dragBy: 30 });
+
+  await expectNoPageTurn();
+});
+
+/** The arrow buttons are still the way to turn a page where there is room for them. */
+test('a click on the edge of the page turns nothing on a desktop viewport', async () => {
+  aBookWithAnEpub();
+
+  const screen = await renderApp({ path: '/book/1/read' });
+  await expect.element(screen.getByText('Page 1 of 2', { exact: false })).toBeVisible();
+
+  gestureInPublication({ across: 0.9 });
+
+  await expectNoPageTurn();
 });
 
 /**

--- a/frontend/tests/msw/readiumApi.ts
+++ b/frontend/tests/msw/readiumApi.ts
@@ -66,6 +66,14 @@ const PARAGRAPHS_PAST_ONE_SCREEN = 120;
  * for `ESCAPE_HATCH` can only mean the frame navigated. That, rather than
  * whether the document it lands on then manages to run, is what a test can
  * observe without depending on how the frame pool happens to be timed.
+ *
+ * The `onerror` vector hangs off a `data:` URL that is not a PNG rather than a
+ * missing file. It has to fail to load for the handler to have its chance, and
+ * a `data:` URL fails in the decoder rather than over the network — WebKit
+ * issues the request for a missing file late enough that it lands after the
+ * test's own handlers are gone, which the unmocked-request guard rightly calls
+ * out. The vector is the same either way: an inline event handler that must not
+ * survive `disarm`.
  */
 const hostileChapter = () =>
   `<?xml version="1.0" encoding="utf-8"?>
@@ -80,7 +88,7 @@ const hostileChapter = () =>
   <body onload="parent.document.body.setAttribute('data-pwned', 'onload')">
     <h1>On Attention</h1>
     <p><a href="javascript:parent.document.body.setAttribute('data-pwned','href')">A link.</a></p>
-    <img src="x.png" onerror="parent.document.body.setAttribute('data-pwned', 'onerror')" />
+    <img src="data:image/png;base64,bm90LWFuLWltYWdl" onerror="parent.document.body.setAttribute('data-pwned', 'onerror')" />
   </body>
 </html>`;
 

--- a/frontend/tests/setup.ts
+++ b/frontend/tests/setup.ts
@@ -29,7 +29,12 @@ const RESIZE_OBSERVER_NOTICE = 'ResizeObserver loop';
 window.addEventListener(
   'error',
   (event) => {
-    if (event.message.includes(RESIZE_OBSERVER_NOTICE)) {
+    // Not every `error` event is an `ErrorEvent`: a subresource that fails to
+    // load fires a plain `Event` on the way up, whose `message` is undefined.
+    // Reading it threw *inside this handler*, which Vitest then reported as the
+    // unhandled error the handler exists to prevent — noise under Chromium, and
+    // enough to fail whole files under WebKit, which fires more of them.
+    if (typeof event.message === 'string' && event.message.includes(RESIZE_OBSERVER_NOTICE)) {
       event.stopImmediatePropagation();
       event.preventDefault();
     }

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -3,6 +3,21 @@ import path from 'path';
 import { defineConfig, mergeConfig } from 'vitest/config';
 import viteConfig from './vite.config';
 
+/**
+ * The engines to run in — Chromium alone unless `TEST_BROWSERS` says otherwise.
+ *
+ * The web reader is the reason this is a knob at all. It leans on the browser
+ * far harder than the rest of the app does (blob: documents, same-origin frames,
+ * a `<meta>` CSP inside them), and those are exactly the places engines differ:
+ * a book that would not open on iPhone Safari was a WebKit-only fault the
+ * Chromium suite could not see. `TEST_BROWSERS=chromium,webkit npm run test`
+ * runs both.
+ */
+const browsers = (process.env.TEST_BROWSERS ?? 'chromium')
+  .split(',')
+  .map((name) => name.trim())
+  .filter(Boolean);
+
 export default mergeConfig(
   viteConfig,
   defineConfig({
@@ -34,7 +49,7 @@ export default mergeConfig(
         enabled: true,
         headless: true,
         provider: playwright(),
-        instances: [{ browser: 'chromium' }],
+        instances: browsers.map((browser) => ({ browser })),
         viewport: { width: 1440, height: 900 },
       },
     },


### PR DESCRIPTION
Fixes #783, plus the production CSP work and the iPhone Safari bug.

**Mobile layout**: below `sm` the arrow buttons unrender and the left/right ~20% edges page on genuine taps (guards: movement >10px, hold >500ms, active selection at pointerdown or pointerup, interactive elements, breakpoint agreement at both gesture ends). Tap zones map through the navigator's `goLeft`/`goRight`, so RTL books page the way they run (pinned with an Arabic fixture; RTL rendering overall remains uncertified). Zero extra horizontal gutter on mobile (Readium's own 20px inner gutter kept), 16px vertical breathing room at all sizes. Readium's built-in guardless tap pager stays deliberately suppressed.

**Production CSP** (maintainer's commit, reviewed): `blob:` in `script-src`/`style-src`/`frame-src` is required — blob documents inherit the creator's CSP and Readium mounts its modules as blob scripts. Three sha256 hashes removed: two matched nothing anywhere in the repo or its history; one was Cloudflare Insights' inline snippet, inert without its domains in `script-src`/`connect-src` (and previously removed in 5fc0a7 for hash-rot; allowing CF analytics is a dashboard/policy decision, not a hash-list one).

**iPhone Safari never loading books — root cause, not timeout**: blob documents inherit `frame-ancestors 'none'`, and WebKit enforces it against the frame's own parent, refusing every publication frame instantly (Chromium doesn't, hence desktop working). Fixed with `frame-ancestors 'self'` — probe-verified in both engines that a foreign origin still cannot frame the app, with `X-Frame-Options: DENY` unaffected. `BOOT_TIMEOUT_MS` reverted to the measured 15s. The reader test suite now runs in **chromium + webkit** (`TEST_BROWSERS`), which is the only reason this class of bug is visible to CI; pre-existing `PullToRefresh.test.tsx` WebKit failure flagged, untouched.

Gates: backend 1290 tests / pyright 0; frontend 239 (chromium) + 68 reader tests across both engines; lint/knip/format/duplication clean (0.9%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)