### PR TITLE
feat(reader): persistent settings, alignment, TOC position, single column

### DIFF
--- a/frontend/src/components/reader/ReaderChrome.tsx
+++ b/frontend/src/components/reader/ReaderChrome.tsx
@@ -18,6 +18,11 @@ interface ReaderChromeProps {
   fontSizeStep: number;
   /** Passed through to the appearance popover; see `ReaderSettings`. */
   canChooseColumns: boolean;
+  /**
+   * Called as the popover opens, so the shell can measure the layout it is
+   * about to offer controls for while that layout is settled.
+   */
+  onOpenSettings: () => void;
 }
 
 /**
@@ -38,6 +43,7 @@ export const ReaderChrome = ({
   fontSizeRange,
   fontSizeStep,
   canChooseColumns,
+  onOpenSettings,
 }: ReaderChromeProps) => {
   const [settingsAnchor, setSettingsAnchor] = useState<HTMLElement | null>(null);
 
@@ -72,7 +78,12 @@ export const ReaderChrome = ({
 
         <Tooltip title="Appearance">
           <IconButton
-            onClick={(event) => setSettingsAnchor(event.currentTarget)}
+            onClick={(event) => {
+              // Before the anchor, so the measurement and the opening land in
+              // one render and the popover never shows a stale set of controls.
+              onOpenSettings();
+              setSettingsAnchor(event.currentTarget);
+            }}
             aria-label="Appearance"
             color="inherit"
           >

--- a/frontend/src/components/reader/ReaderChrome.tsx
+++ b/frontend/src/components/reader/ReaderChrome.tsx
@@ -16,6 +16,8 @@ interface ReaderChromeProps {
   onPreferencesChange: (preferences: ReaderPreferences) => void;
   fontSizeRange: [number, number];
   fontSizeStep: number;
+  /** Passed through to the appearance popover; see `ReaderSettings`. */
+  canChooseColumns: boolean;
 }
 
 /**
@@ -35,6 +37,7 @@ export const ReaderChrome = ({
   onPreferencesChange,
   fontSizeRange,
   fontSizeStep,
+  canChooseColumns,
 }: ReaderChromeProps) => {
   const [settingsAnchor, setSettingsAnchor] = useState<HTMLElement | null>(null);
 
@@ -91,6 +94,7 @@ export const ReaderChrome = ({
         onChange={onPreferencesChange}
         fontSizeRange={fontSizeRange}
         fontSizeStep={fontSizeStep}
+        canChooseColumns={canChooseColumns}
       />
     </Box>
   );

--- a/frontend/src/components/reader/ReaderSettings.tsx
+++ b/frontend/src/components/reader/ReaderSettings.tsx
@@ -1,15 +1,18 @@
 import { chromeMarkerProps } from '@/components/reader/chromeMarker.ts';
 import {
-  READER_THEMES,
+  READER_ALIGNMENT_LABELS,
+  READER_ALIGNMENTS,
   READER_THEME_LABELS,
+  READER_THEMES,
   type ReaderPreferences,
-  type ReaderThemeName,
 } from '@/components/reader/readerPreferences.ts';
 import {
   Box,
+  FormControlLabel,
   Popover,
   Slider,
   Stack,
+  Switch,
   ToggleButton,
   ToggleButtonGroup,
   Typography,
@@ -23,17 +26,67 @@ interface ReaderSettingsProps {
   /** The range and step the navigator's own `EpubPreferencesEditor` reports for font size. */
   fontSizeRange: [number, number];
   fontSizeStep: number;
+  /**
+   * Whether the viewport is wide enough for a second column to be possible.
+   * Where it is not, the column control would be a switch that changed
+   * nothing, so it is not offered at all.
+   */
+  canChooseColumns: boolean;
 }
 
 const asPercentage = (multiplier: number) => `${Math.round(multiplier * 100)}%`;
 
+interface ChoiceSectionProps<Option extends string> {
+  /** The heading above the control, and the group's accessible name. */
+  heading: string;
+  options: readonly Option[];
+  labels: Record<Option, string>;
+  value: Option;
+  onSelect: (option: Option) => void;
+}
+
+/** A headed row of mutually exclusive choices — the popover's shape for a setting. */
+const ChoiceSection = <Option extends string>({
+  heading,
+  options,
+  labels,
+  value,
+  onSelect,
+}: ChoiceSectionProps<Option>) => (
+  <Box>
+    <Typography variant="h6" component="h2" gutterBottom>
+      {heading}
+    </Typography>
+    <ToggleButtonGroup
+      exclusive
+      fullWidth
+      size="small"
+      value={value}
+      aria-label={heading}
+      onChange={(_event, chosen: Option | null) => {
+        // Null when the pressed button was already the active one. Every one of
+        // these settings always has a value, so that click means nothing.
+        if (chosen !== null) onSelect(chosen);
+      }}
+    >
+      {options.map((option) => (
+        <ToggleButton key={option} value={option}>
+          {labels[option]}
+        </ToggleButton>
+      ))}
+    </ToggleButtonGroup>
+  </Box>
+);
+
 /**
- * The reader's appearance controls: how big the text is, and what colour the
- * page is.
+ * The reader's appearance controls: how big the text is, what colour the page
+ * is, how the lines are set, and how many columns they are set in.
  *
- * Deliberately two settings. Readium exposes forty, and the ones worth having
- * in a first reader are the two every e-reader opens with; the rest can be
- * added once there is a reason to prefer one over the book's own typography.
+ * Deliberately four settings. Readium exposes forty, and these are the ones a
+ * reader reaches for daily; the rest can be added once there is a reason to
+ * prefer one over the book's own typography. Two of them — alignment and
+ * columns — open on "whatever the book and the screen already decided", so
+ * that opening this popover and closing it again changes nothing.
  */
 export const ReaderSettings = ({
   anchorEl,
@@ -42,6 +95,7 @@ export const ReaderSettings = ({
   onChange,
   fontSizeRange,
   fontSizeStep,
+  canChooseColumns,
 }: ReaderSettingsProps) => (
   <Popover
     open={anchorEl !== null}
@@ -49,7 +103,7 @@ export const ReaderSettings = ({
     onClose={onClose}
     anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
     transformOrigin={{ vertical: 'top', horizontal: 'right' }}
-    slotProps={{ paper: { sx: { p: 2.5, width: 280 } } }}
+    slotProps={{ paper: { sx: { p: 2.5, width: 320 } } }}
   >
     <Stack spacing={3} {...chromeMarkerProps}>
       <Box>
@@ -72,29 +126,33 @@ export const ReaderSettings = ({
         </Stack>
       </Box>
 
-      <Box>
-        <Typography variant="h6" component="h2" gutterBottom>
-          Page colour
-        </Typography>
-        <ToggleButtonGroup
-          exclusive
-          fullWidth
-          size="small"
-          value={preferences.theme}
-          aria-label="Page colour"
-          onChange={(_event, value: ReaderThemeName | null) => {
-            // Null when the pressed button was already the active one; a
-            // reading theme is never "none", so that click means nothing.
-            if (value !== null) onChange({ ...preferences, theme: value });
-          }}
-        >
-          {READER_THEMES.map((name) => (
-            <ToggleButton key={name} value={name}>
-              {READER_THEME_LABELS[name]}
-            </ToggleButton>
-          ))}
-        </ToggleButtonGroup>
-      </Box>
+      <ChoiceSection
+        heading="Page colour"
+        options={READER_THEMES}
+        labels={READER_THEME_LABELS}
+        value={preferences.theme}
+        onSelect={(theme) => onChange({ ...preferences, theme })}
+      />
+
+      <ChoiceSection
+        heading="Text alignment"
+        options={READER_ALIGNMENTS}
+        labels={READER_ALIGNMENT_LABELS}
+        value={preferences.alignment}
+        onSelect={(alignment) => onChange({ ...preferences, alignment })}
+      />
+
+      {canChooseColumns && (
+        <FormControlLabel
+          control={
+            <Switch
+              checked={preferences.singleColumn}
+              onChange={(event) => onChange({ ...preferences, singleColumn: event.target.checked })}
+            />
+          }
+          label="Single column"
+        />
+      )}
     </Stack>
   </Popover>
 );

--- a/frontend/src/components/reader/ReaderShell.tsx
+++ b/frontend/src/components/reader/ReaderShell.tsx
@@ -33,7 +33,7 @@ import {
   useTheme,
 } from '@mui/material';
 import { EpubNavigator } from '@readium/navigator';
-import type { Link, Locator } from '@readium/shared';
+import type { Link, Locator, TimelineItem } from '@readium/shared';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 /**
@@ -235,6 +235,30 @@ export const ReaderShell = ({
   const [isPageVisible, setIsPageVisible] = useState(false);
   const [locator, setLocator] = useState<Locator | null>(null);
   const [isTocOpen, setIsTocOpen] = useState(false);
+  /**
+   * The contents entry the reader is currently in, or `null` where the book's
+   * contents do not name it.
+   *
+   * Resolved by Readium's own `Timeline.tocEntryFor` rather than by matching
+   * hrefs here. It answers in three tiers — the entry for this resource, then
+   * the nearest preceding entry *within* the resource, then the nearest
+   * preceding resource's entry — and the last two are worth more than a
+   * hand-rolled match: the second marks the right section of a book published
+   * as one long file, and the third marks a cover or an interstitial with the
+   * chapter it follows rather than leaving the reader unplaced.
+   */
+  const [currentTocEntry, setCurrentTocEntry] = useState<Link | null>(null);
+  /**
+   * Whether the page is actually laid out in more than one column.
+   *
+   * Measured rather than inferred from the viewport, because the breakpoint is
+   * the wrong question: Readium fits as many columns as the *optimal line
+   * length* allows, so a 900px window, an iPad and any screen at all once the
+   * font size is up are all single-column while being nowhere near a phone.
+   * Read when the appearance popover opens, which is the moment the answer
+   * matters and a moment when the layout has settled.
+   */
+  const [columnsArePossible, setColumnsArePossible] = useState(false);
   const [bootFailed, setBootFailed] = useState(false);
   // Bumped to ask for the whole navigator again, which is the only meaningful
   // retry: a half-built one has frames and blobs that have to go first.
@@ -248,6 +272,20 @@ export const ReaderShell = ({
   // rather than read off the instance while rendering: the editor is a live
   // object hanging off a ref, and a ref is not something a render may consult.
   const [fontSizeBounds, setFontSizeBounds] = useState(DEFAULT_FONT_SIZE_BOUNDS);
+
+  // Stable, and reads the navigator out of the ref, so that wiring it into the
+  // navigator's listeners is not a reason to rebuild the reader.
+  const markTimelineItem = useCallback((item: TimelineItem | undefined) => {
+    const navigator = navigatorRef.current;
+    setCurrentTocEntry(
+      navigator && item ? (navigator.timeline.tocEntryFor(item)?.link ?? null) : null
+    );
+  }, []);
+
+  const measureColumns = useCallback(() => {
+    const columns = navigatorRef.current?.settings.columnCount ?? null;
+    setColumnsArePossible(columns !== null && columns > 1);
+  }, []);
 
   const goForward = useCallback(() => navigatorRef.current?.goForward(true, () => {}), []);
   const goBackward = useCallback(() => navigatorRef.current?.goBackward(true, () => {}), []);
@@ -460,7 +498,11 @@ export const ReaderShell = ({
            * until then, selecting text does what selecting text does.
            */
           textSelected: () => {},
-          timelineItemChanged: () => {},
+          /**
+           * The reader has moved into a different part of the book's own
+           * timeline, which is what marks their place in the contents.
+           */
+          timelineItemChanged: markTimelineItem,
           // Readium pages the book itself on a pointer in the outer quarters of
           // a frame unless the listener claims the event. It has to stay
           // claimed: `useReaderTapZones` is what turns pages here, and a tap
@@ -535,6 +577,9 @@ export const ReaderShell = ({
         if (isStale()) return;
       }
       setLocator(epubNavigator.currentLocator);
+      // The navigator reports a timeline item only when it *changes*, so the
+      // place the book opened at has to be asked for rather than waited for.
+      markTimelineItem(epubNavigator.timeline.locate(epubNavigator.currentLocator));
       // The book is on screen and settled, so from here on a report is the
       // reader's own doing. Set synchronously rather than through state: the
       // settle report follows the layout by microtasks, and a render is not
@@ -619,6 +664,7 @@ export const ReaderShell = ({
     // a highlight being drawn is never a reason to rebuild the reader.
     decorationObserver,
     applyDecorations,
+    markTimelineItem,
   ]);
 
   // Said once the book is on screen, so the reader reads it against the page it
@@ -721,11 +767,14 @@ export const ReaderShell = ({
         onPreferencesChange={setPreferences}
         fontSizeRange={fontSizeBounds.range}
         fontSizeStep={fontSizeBounds.step}
-        // Below the breakpoint the viewport only ever fits one column, so
-        // Readium's own automatic count is already one and the switch would be
-        // a control that did nothing. The setting itself is untouched — it is
-        // global, and still in force on the desktop it was set from.
-        canChooseColumns={!isCompact}
+        onOpenSettings={measureColumns}
+        // Offered only where it would do something: where the page really is
+        // in more than one column, or where the reader has already asked for
+        // one and must be able to ask for the other again. A single-column
+        // layout the reader never chose is Readium's answer to the width and
+        // the font size, and a switch to force what is already true would be a
+        // control that changed nothing.
+        canChooseColumns={preferences.singleColumn || columnsArePossible}
       />
 
       <Box sx={{ flex: 1, minHeight: 0, position: 'relative' }}>
@@ -798,7 +847,7 @@ export const ReaderShell = ({
         onClose={() => setIsTocOpen(false)}
         toc={publication?.toc?.items ?? []}
         onSelect={goToTocEntry}
-        currentHref={locator?.href ?? null}
+        current={currentTocEntry}
       />
     </Box>
   );

--- a/frontend/src/components/reader/ReaderShell.tsx
+++ b/frontend/src/components/reader/ReaderShell.tsx
@@ -798,6 +798,7 @@ export const ReaderShell = ({
         onClose={() => setIsTocOpen(false)}
         toc={publication?.toc?.items ?? []}
         onSelect={goToTocEntry}
+        currentHref={locator?.href ?? null}
       />
     </Box>
   );

--- a/frontend/src/components/reader/ReaderShell.tsx
+++ b/frontend/src/components/reader/ReaderShell.tsx
@@ -707,6 +707,11 @@ export const ReaderShell = ({
         onPreferencesChange={setPreferences}
         fontSizeRange={fontSizeBounds.range}
         fontSizeStep={fontSizeBounds.step}
+        // Below the breakpoint the viewport only ever fits one column, so
+        // Readium's own automatic count is already one and the switch would be
+        // a control that did nothing. The setting itself is untouched — it is
+        // global, and still in force on the desktop it was set from.
+        canChooseColumns={!isCompact}
       />
 
       <Box sx={{ flex: 1, minHeight: 0, position: 'relative' }}>

--- a/frontend/src/components/reader/ReaderShell.tsx
+++ b/frontend/src/components/reader/ReaderShell.tsx
@@ -4,11 +4,14 @@ import { CHROME_MARKER } from '@/components/reader/chromeMarker.ts';
 import { HIGHLIGHT_DECORATION_GROUP } from '@/components/reader/decorations.ts';
 import { ReaderChrome } from '@/components/reader/ReaderChrome.tsx';
 import {
-  DEFAULT_READER_PREFERENCES,
   readerPageColors,
   toEpubPreferences,
   type ReaderPreferences,
 } from '@/components/reader/readerPreferences.ts';
+import {
+  loadReaderPreferences,
+  saveReaderPreferences,
+} from '@/components/reader/readerPreferenceStorage.ts';
 import { TocDrawer } from '@/components/reader/TocDrawer.tsx';
 import { useHighlightDecorations } from '@/components/reader/useHighlightDecorations.ts';
 import { useReaderLanding, type ReaderLanding } from '@/components/reader/useReaderLanding.ts';
@@ -236,7 +239,11 @@ export const ReaderShell = ({
   // Bumped to ask for the whole navigator again, which is the only meaningful
   // retry: a half-built one has frames and blobs that have to go first.
   const [bootAttempt, setBootAttempt] = useState(0);
-  const [preferences, setPreferences] = useState<ReaderPreferences>(DEFAULT_READER_PREFERENCES);
+  // Seeded from the browser's own memory rather than from the defaults, and
+  // read during the first render rather than in an effect: the navigator takes
+  // its preferences at construction, and a font size that arrived a tick later
+  // would mean every book visibly re-flowing the moment it opened.
+  const [preferences, setPreferences] = useState<ReaderPreferences>(loadReaderPreferences);
   // Copied out of the navigator's own `EpubPreferencesEditor` once it exists,
   // rather than read off the instance while rendering: the editor is a live
   // object hanging off a ref, and a ref is not something a render may consult.
@@ -637,6 +644,13 @@ export const ReaderShell = ({
     if (!isPageVisible) return;
     void navigatorRef.current?.submitPreferences(toEpubPreferences(theme, preferences));
   }, [isPageVisible, preferences, theme]);
+
+  // Kept for the next book rather than for this one, so it is deliberately not
+  // conditional on the navigator having taken them: a reader who nudges the
+  // font size and closes the book has still expressed a preference.
+  useEffect(() => {
+    saveReaderPreferences(preferences);
+  }, [preferences]);
 
   const goToTocEntry = useCallback((link: Link) => {
     setIsTocOpen(false);

--- a/frontend/src/components/reader/TocDrawer.tsx
+++ b/frontend/src/components/reader/TocDrawer.tsx
@@ -12,7 +12,7 @@ import {
   Typography,
 } from '@mui/material';
 import type { Link } from '@readium/shared';
-import { useEffect, useMemo, useRef } from 'react';
+import { useCallback } from 'react';
 
 /**
  * The href the API gives a heading that links nowhere — a part title with
@@ -24,75 +24,26 @@ const UNLINKED_HREF = '#';
 /** How far one level of nesting indents a chapter under its parent. */
 const INDENT_PER_LEVEL = 2;
 
-/**
- * The resource an href names, without the fragment or the query that follows
- * it. A contents entry may point into the middle of a chapter file; where the
- * reader *is* is only ever known by the file.
- */
-const resourceOf = (href: string): string => href.split(/[#?]/)[0];
-
-interface FlatEntry {
-  entry: Link;
-  depth: number;
-}
-
-/** Every entry of a contents tree, parents before their children. */
-const flatten = (entries: Link[], depth: number): FlatEntry[] =>
-  entries.flatMap((entry) => [
-    { entry, depth },
-    ...flatten(entry.children?.items ?? [], depth + 1),
-  ]);
-
-/**
- * Which entry of the contents the reader is currently inside, or `null` when
- * the book's contents do not name where they are.
- *
- * Resource-granular, because that is all a reading position reliably says: a
- * locator carries the file, and the sections within a file are the contents
- * page's own idea. Two rules turn the several entries that can share a file
- * into one answer.
- *
- * **Entries naming the whole file beat entries naming a section of it.** The
- * reader is *somewhere* in the chapter, and only the entry for the chapter
- * itself is true of wherever that is; picking one of its sections would be
- * marking a place nobody has been told they are at. Where every match names a
- * section — a book published as one long file, with its contents made of
- * fragments — there is no such entry and the first is the best available guess.
- *
- * **Then the deepest wins.** A part heading and the first chapter under it
- * routinely share an href, and the chapter is the more specific of the two.
- */
-const currentEntry = (toc: Link[], currentHref: string | null): Link | null => {
-  if (currentHref === null) return null;
-  const resource = resourceOf(currentHref);
-  const matches = flatten(toc, 0).filter(
-    ({ entry }) => entry.href !== UNLINKED_HREF && resourceOf(entry.href) === resource
-  );
-  if (matches.length === 0) return null;
-
-  const wholeResource = matches.filter(({ entry }) => !entry.href.includes('#'));
-  const candidates = wholeResource.length > 0 ? wholeResource : matches;
-  return candidates.reduce((deepest, candidate) =>
-    candidate.depth > deepest.depth ? candidate : deepest
-  ).entry;
-};
-
 interface TocDrawerProps {
   open: boolean;
   onClose: () => void;
   toc: Link[];
   onSelect: (link: Link) => void;
-  /** The resource the reader is in, from the navigator's own current locator. */
-  currentHref: string | null;
+  /**
+   * The entry the reader is currently in, resolved by Readium's own
+   * `Timeline.tocEntryFor` — see `ReaderShell`. Compared by identity, because
+   * that is the same `Link` object this tree is rendered from.
+   */
+  current: Link | null;
 }
 
 interface TocEntriesProps {
   entries: Link[];
   depth: number;
   onSelect: (link: Link) => void;
-  /** The one entry to mark, compared by identity — both come from the manifest. */
   current: Link | null;
-  currentRef: React.Ref<HTMLDivElement>;
+  /** Attached to the marked entry, which scrolls it into view as it mounts. */
+  currentRef: (node: HTMLDivElement | null) => void;
 }
 
 const TocEntries = ({ entries, depth, onSelect, current, currentRef }: TocEntriesProps) => (
@@ -142,16 +93,26 @@ const TocEntries = ({ entries, depth, onSelect, current, currentRef }: TocEntrie
  * of ninety chapters that always opens at chapter one is a list you have to
  * search to find yourself in.
  */
-export const TocDrawer = ({ open, onClose, toc, onSelect, currentHref }: TocDrawerProps) => {
-  const current = useMemo(() => currentEntry(toc, currentHref), [toc, currentHref]);
-  const currentRef = useRef<HTMLDivElement | null>(null);
-
-  useEffect(() => {
-    // The drawer mounts its contents as it opens, so this runs with the marked
-    // entry already laid out inside the scrolling panel. `nearest` because a
-    // chapter that is on screen anyway should not be moved under the reader.
-    if (open) currentRef.current?.scrollIntoView({ block: 'nearest' });
-  }, [open, current]);
+export const TocDrawer = ({ open, onClose, toc, onSelect, current }: TocDrawerProps) => {
+  /**
+   * Scrolls the marked entry into view as it attaches.
+   *
+   * A callback ref rather than an effect, and that is the whole point. A
+   * temporary `Drawer` renders nothing at all while it is closed, and MUI's
+   * `Portal` returns `null` on its first render — it only has a container to
+   * render into once its own layout effect has run. So the commit in which
+   * `open` becomes true mounts no list at all, and an effect keyed on `open`
+   * fires in exactly that commit, with nothing to scroll to; the commit that
+   * does mount the list changes none of that effect's dependencies, so it
+   * never runs again. The ref, by contrast, fires when the entry itself
+   * arrives, which is the first moment the question can be answered.
+   *
+   * Stable, so it fires on the marked entry appearing and moving rather than
+   * on every render of the list.
+   */
+  const currentRef = useCallback((node: HTMLDivElement | null) => {
+    node?.scrollIntoView({ block: 'center' });
+  }, []);
 
   return (
     <Drawer anchor="left" open={open} onClose={onClose}>

--- a/frontend/src/components/reader/TocDrawer.tsx
+++ b/frontend/src/components/reader/TocDrawer.tsx
@@ -12,6 +12,7 @@ import {
   Typography,
 } from '@mui/material';
 import type { Link } from '@readium/shared';
+import { useEffect, useMemo, useRef } from 'react';
 
 /**
  * The href the API gives a heading that links nowhere — a part title with
@@ -23,27 +24,89 @@ const UNLINKED_HREF = '#';
 /** How far one level of nesting indents a chapter under its parent. */
 const INDENT_PER_LEVEL = 2;
 
+/**
+ * The resource an href names, without the fragment or the query that follows
+ * it. A contents entry may point into the middle of a chapter file; where the
+ * reader *is* is only ever known by the file.
+ */
+const resourceOf = (href: string): string => href.split(/[#?]/)[0];
+
+interface FlatEntry {
+  entry: Link;
+  depth: number;
+}
+
+/** Every entry of a contents tree, parents before their children. */
+const flatten = (entries: Link[], depth: number): FlatEntry[] =>
+  entries.flatMap((entry) => [
+    { entry, depth },
+    ...flatten(entry.children?.items ?? [], depth + 1),
+  ]);
+
+/**
+ * Which entry of the contents the reader is currently inside, or `null` when
+ * the book's contents do not name where they are.
+ *
+ * Resource-granular, because that is all a reading position reliably says: a
+ * locator carries the file, and the sections within a file are the contents
+ * page's own idea. Two rules turn the several entries that can share a file
+ * into one answer.
+ *
+ * **Entries naming the whole file beat entries naming a section of it.** The
+ * reader is *somewhere* in the chapter, and only the entry for the chapter
+ * itself is true of wherever that is; picking one of its sections would be
+ * marking a place nobody has been told they are at. Where every match names a
+ * section — a book published as one long file, with its contents made of
+ * fragments — there is no such entry and the first is the best available guess.
+ *
+ * **Then the deepest wins.** A part heading and the first chapter under it
+ * routinely share an href, and the chapter is the more specific of the two.
+ */
+const currentEntry = (toc: Link[], currentHref: string | null): Link | null => {
+  if (currentHref === null) return null;
+  const resource = resourceOf(currentHref);
+  const matches = flatten(toc, 0).filter(
+    ({ entry }) => entry.href !== UNLINKED_HREF && resourceOf(entry.href) === resource
+  );
+  if (matches.length === 0) return null;
+
+  const wholeResource = matches.filter(({ entry }) => !entry.href.includes('#'));
+  const candidates = wholeResource.length > 0 ? wholeResource : matches;
+  return candidates.reduce((deepest, candidate) =>
+    candidate.depth > deepest.depth ? candidate : deepest
+  ).entry;
+};
+
 interface TocDrawerProps {
   open: boolean;
   onClose: () => void;
   toc: Link[];
   onSelect: (link: Link) => void;
+  /** The resource the reader is in, from the navigator's own current locator. */
+  currentHref: string | null;
 }
 
 interface TocEntriesProps {
   entries: Link[];
   depth: number;
   onSelect: (link: Link) => void;
+  /** The one entry to mark, compared by identity — both come from the manifest. */
+  current: Link | null;
+  currentRef: React.Ref<HTMLDivElement>;
 }
 
-const TocEntries = ({ entries, depth, onSelect }: TocEntriesProps) => (
+const TocEntries = ({ entries, depth, onSelect, current, currentRef }: TocEntriesProps) => (
   <>
     {entries.map((entry, index) => {
       const isNavigable = entry.href !== UNLINKED_HREF;
+      const isCurrent = entry === current;
       return (
         <Box key={`${entry.href}-${index}`}>
           <ListItemButton
+            ref={isCurrent ? currentRef : undefined}
             disabled={!isNavigable}
+            selected={isCurrent}
+            aria-current={isCurrent ? 'location' : undefined}
             onClick={() => onSelect(entry)}
             sx={{ pl: 2 + depth * INDENT_PER_LEVEL, borderRadius: 1 }}
           >
@@ -53,7 +116,13 @@ const TocEntries = ({ entries, depth, onSelect }: TocEntriesProps) => (
             />
           </ListItemButton>
           {entry.children && (
-            <TocEntries entries={entry.children.items} depth={depth + 1} onSelect={onSelect} />
+            <TocEntries
+              entries={entry.children.items}
+              depth={depth + 1}
+              onSelect={onSelect}
+              current={current}
+              currentRef={currentRef}
+            />
           )}
         </Box>
       );
@@ -62,40 +131,63 @@ const TocEntries = ({ entries, depth, onSelect }: TocEntriesProps) => (
 );
 
 /**
- * The book's table of contents, as the manifest publishes it.
+ * The book's table of contents, as the manifest publishes it, with the chapter
+ * being read marked in it.
  *
  * Nesting is preserved rather than flattened: an EPUB's own contents page is
  * how its author thought the book was shaped, and a part with six chapters
  * under it reads very differently as a flat list of seven.
+ *
+ * A long book's contents open scrolled to where the reader is, because a list
+ * of ninety chapters that always opens at chapter one is a list you have to
+ * search to find yourself in.
  */
-export const TocDrawer = ({ open, onClose, toc, onSelect }: TocDrawerProps) => (
-  <Drawer anchor="left" open={open} onClose={onClose}>
-    <Box
-      {...chromeMarkerProps}
-      sx={{ width: { xs: 280, sm: 340 } }}
-      role="navigation"
-      aria-label="Table of contents"
-    >
-      <Stack
-        direction="row"
-        sx={{ alignItems: 'center', justifyContent: 'space-between', p: 2, pb: 1 }}
+export const TocDrawer = ({ open, onClose, toc, onSelect, currentHref }: TocDrawerProps) => {
+  const current = useMemo(() => currentEntry(toc, currentHref), [toc, currentHref]);
+  const currentRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    // The drawer mounts its contents as it opens, so this runs with the marked
+    // entry already laid out inside the scrolling panel. `nearest` because a
+    // chapter that is on screen anyway should not be moved under the reader.
+    if (open) currentRef.current?.scrollIntoView({ block: 'nearest' });
+  }, [open, current]);
+
+  return (
+    <Drawer anchor="left" open={open} onClose={onClose}>
+      <Box
+        {...chromeMarkerProps}
+        sx={{ width: { xs: 280, sm: 340 } }}
+        role="navigation"
+        aria-label="Table of contents"
       >
-        <Typography variant="sectionTitle" component="h2">
-          Contents
-        </Typography>
-        <IconButton onClick={onClose} aria-label="Close contents" size="small">
-          <CloseIcon sx={{ fontSize: ICON_SIZE.ui }} />
-        </IconButton>
-      </Stack>
-      {toc.length === 0 ? (
-        <Typography variant="body2" sx={{ color: 'text.secondary', px: 2, pb: 2 }}>
-          This book has no table of contents.
-        </Typography>
-      ) : (
-        <List sx={{ pb: 2 }}>
-          <TocEntries entries={toc} depth={0} onSelect={onSelect} />
-        </List>
-      )}
-    </Box>
-  </Drawer>
-);
+        <Stack
+          direction="row"
+          sx={{ alignItems: 'center', justifyContent: 'space-between', p: 2, pb: 1 }}
+        >
+          <Typography variant="sectionTitle" component="h2">
+            Contents
+          </Typography>
+          <IconButton onClick={onClose} aria-label="Close contents" size="small">
+            <CloseIcon sx={{ fontSize: ICON_SIZE.ui }} />
+          </IconButton>
+        </Stack>
+        {toc.length === 0 ? (
+          <Typography variant="body2" sx={{ color: 'text.secondary', px: 2, pb: 2 }}>
+            This book has no table of contents.
+          </Typography>
+        ) : (
+          <List sx={{ pb: 2 }}>
+            <TocEntries
+              entries={toc}
+              depth={0}
+              onSelect={onSelect}
+              current={current}
+              currentRef={currentRef}
+            />
+          </List>
+        )}
+      </Box>
+    </Drawer>
+  );
+};

--- a/frontend/src/components/reader/readerPreferenceStorage.ts
+++ b/frontend/src/components/reader/readerPreferenceStorage.ts
@@ -1,0 +1,98 @@
+import {
+  alignmentOf,
+  DEFAULT_READER_PREFERENCES,
+  READER_THEMES,
+  SINGLE_COLUMN,
+  toTypographyPreferences,
+  type ReaderPreferences,
+  type ReaderThemeName,
+} from '@/components/reader/readerPreferences.ts';
+import { EpubPreferences } from '@readium/navigator';
+
+/**
+ * Where the reader's appearance is remembered, and the only key this app puts
+ * in a browser's storage.
+ *
+ * One key for the whole library rather than one per book. Font size, page
+ * colour, alignment and column count are facts about the person reading and
+ * the screen they are reading on — somebody who needs larger text needs it in
+ * every book they open, and a per-book setting would mean setting it again for
+ * each of them. Nothing here is a fact about a book.
+ */
+export const READER_PREFERENCES_KEY = 'crossbill.reader.preferences';
+
+/**
+ * The version of the shape stored under that key.
+ *
+ * Bumped whenever what the popover controls stops being expressible in what is
+ * already written down. Anything answering to another version is left alone
+ * and the reader gets the defaults, which is the same silence a first-time
+ * reader gets rather than an error about a browser's storage.
+ */
+const STORAGE_VERSION = 1;
+
+interface StoredPreferences {
+  version: number;
+  /** The reading theme's name. Ours: Readium knows colours, not themes. */
+  theme: string;
+  /**
+   * The navigator's own serialisation of everything else, so the stored shape
+   * tracks the library rather than a hand-copy of it. It is also the
+   * validation: `EpubPreferences` re-checks every field it parses — a font
+   * size outside the supported range, an alignment that is not one of the
+   * four, a negative column count — and drops whatever it cannot use.
+   */
+  epub: string;
+}
+
+const storedTheme = (value: unknown): ReaderThemeName =>
+  READER_THEMES.find((name) => name === value) ?? DEFAULT_READER_PREFERENCES.theme;
+
+/**
+ * The reader's remembered appearance, or the defaults.
+ *
+ * Every way this can go wrong ends in the same place, silently: storage a
+ * browser refuses to hand over (a private window, third-party cookies
+ * blocked), nothing written yet, a shape from another version, or text that is
+ * not the JSON it claims to be. None of those is worth a word to somebody who
+ * came here to read a book, and all of them leave a perfectly usable reader.
+ */
+export const loadReaderPreferences = (): ReaderPreferences => {
+  try {
+    const raw = window.localStorage.getItem(READER_PREFERENCES_KEY);
+    if (raw === null) return DEFAULT_READER_PREFERENCES;
+
+    const stored = JSON.parse(raw) as Partial<StoredPreferences> | null;
+    if (stored?.version !== STORAGE_VERSION || typeof stored.epub !== 'string') {
+      return DEFAULT_READER_PREFERENCES;
+    }
+
+    const epub = EpubPreferences.deserialize(stored.epub);
+    if (!epub) return DEFAULT_READER_PREFERENCES;
+
+    return {
+      theme: storedTheme(stored.theme),
+      fontSize: epub.fontSize ?? DEFAULT_READER_PREFERENCES.fontSize,
+      alignment: alignmentOf(epub.textAlign),
+      singleColumn: epub.columnCount === SINGLE_COLUMN,
+    };
+  } catch {
+    // Storage that throws on being read at all, or a value that is not JSON.
+    return DEFAULT_READER_PREFERENCES;
+  }
+};
+
+/** Writes the reader's appearance down, where the browser lets us. */
+export const saveReaderPreferences = (preferences: ReaderPreferences): void => {
+  try {
+    const stored: StoredPreferences = {
+      version: STORAGE_VERSION,
+      theme: preferences.theme,
+      epub: EpubPreferences.serialize(new EpubPreferences(toTypographyPreferences(preferences))),
+    };
+    window.localStorage.setItem(READER_PREFERENCES_KEY, JSON.stringify(stored));
+  } catch {
+    // Storage turned off, or a quota that is full. The reader behaves exactly
+    // as it did; it just will not remember this the next time a book is opened.
+  }
+};

--- a/frontend/src/components/reader/readerPreferenceStorage.ts
+++ b/frontend/src/components/reader/readerPreferenceStorage.ts
@@ -40,10 +40,24 @@ interface StoredPreferences {
    * tracks the library rather than a hand-copy of it. It is also the
    * validation: `EpubPreferences` re-checks every field it parses — a font
    * size outside the supported range, an alignment that is not one of the
-   * four, a negative column count — and drops whatever it cannot use.
+   * four, a negative column count — and drops whatever it cannot use. A blob
+   * it cannot parse at all comes back as `null`, having said so on the console
+   * on its way; the reader gets the defaults either way.
    */
   epub: string;
 }
+
+/** The version of the record already written here, or `null` if there is none. */
+const storedVersion = (): number | null => {
+  try {
+    const raw = window.localStorage.getItem(READER_PREFERENCES_KEY);
+    if (raw === null) return null;
+    const stored = JSON.parse(raw) as Partial<StoredPreferences> | null;
+    return typeof stored?.version === 'number' ? stored.version : null;
+  } catch {
+    return null;
+  }
+};
 
 const storedTheme = (value: unknown): ReaderThemeName =>
   READER_THEMES.find((name) => name === value) ?? DEFAULT_READER_PREFERENCES.theme;
@@ -82,9 +96,23 @@ export const loadReaderPreferences = (): ReaderPreferences => {
   }
 };
 
-/** Writes the reader's appearance down, where the browser lets us. */
+/**
+ * Writes the reader's appearance down, where the browser lets us — and never
+ * over a record from a later version of this app.
+ *
+ * Without that guard the version field would enable the very loss it exists to
+ * prevent. A reader who has used a newer build in another browser tab, or who
+ * loads an older one from a stale cache, has a record this code cannot read;
+ * it falls back to the defaults, and the save on mount would then write those
+ * defaults over their real settings, permanently. Refusing to overwrite costs
+ * this session's changes, which the reader can make again; overwriting costs
+ * settings they cannot get back.
+ */
 export const saveReaderPreferences = (preferences: ReaderPreferences): void => {
   try {
+    const existing = storedVersion();
+    if (existing !== null && existing > STORAGE_VERSION) return;
+
     const stored: StoredPreferences = {
       version: STORAGE_VERSION,
       theme: preferences.theme,

--- a/frontend/src/components/reader/readerPreferences.ts
+++ b/frontend/src/components/reader/readerPreferences.ts
@@ -1,5 +1,5 @@
 import type { Theme } from '@mui/material/styles';
-import { EpubPreferences } from '@readium/navigator';
+import { EpubPreferences, TextAlignment, type IEpubPreferences } from '@readium/navigator';
 
 /** The reading themes the settings popover offers, in the order it shows them. */
 export const READER_THEMES = ['light', 'sepia', 'dark'] as const;
@@ -13,6 +13,50 @@ export const READER_THEME_LABELS: Record<ReaderThemeName, string> = {
   dark: 'Dark',
 };
 
+/**
+ * How lines are set, as the popover offers it.
+ *
+ * Three states rather than a switch, because the honest default is neither of
+ * the other two: ReadiumCSS leaves `text-align` to the book's own stylesheet
+ * until a reader overrides it, and a binary control would have to pick one of
+ * them for everybody and quietly re-set every book in the library.
+ */
+export const READER_ALIGNMENTS = ['default', 'left', 'justified'] as const;
+
+export type ReaderAlignment = (typeof READER_ALIGNMENTS)[number];
+
+export const READER_ALIGNMENT_LABELS: Record<ReaderAlignment, string> = {
+  default: 'Default',
+  left: 'Left',
+  justified: 'Justified',
+};
+
+/**
+ * What each alignment is in the navigator's terms, `null` being "say nothing
+ * and let the book decide".
+ *
+ * `start` rather than `left`: in a right-to-left book the ragged edge belongs
+ * on the right, and only `start` follows the publication's own progression.
+ */
+const READIUM_ALIGNMENTS: Record<ReaderAlignment, TextAlignment | null> = {
+  default: null,
+  left: TextAlignment.start,
+  justified: TextAlignment.justify,
+};
+
+/** Which alignment a navigator preference is, for reading one back out of storage. */
+export const alignmentOf = (value: TextAlignment | null | undefined): ReaderAlignment =>
+  READER_ALIGNMENTS.find((name) => READIUM_ALIGNMENTS[name] === value) ?? 'default';
+
+/** One column, whatever the viewport could have fitted. */
+export const SINGLE_COLUMN = 1;
+
+/**
+ * As many columns as the width allows, which is what Readium does when nobody
+ * has asked for a number.
+ */
+const AUTOMATIC_COLUMNS = null;
+
 export interface ReaderPreferences {
   theme: ReaderThemeName;
   /**
@@ -20,19 +64,47 @@ export interface ReaderPreferences {
    * states it — 1 is the book as its publisher set it.
    */
   fontSize: number;
+  alignment: ReaderAlignment;
+  /**
+   * One column even where the viewport has room for two. Below the `sm`
+   * breakpoint there is only ever room for one, so the setting is real but
+   * inert there and the control is not offered.
+   */
+  singleColumn: boolean;
 }
 
-export const DEFAULT_READER_PREFERENCES: ReaderPreferences = { theme: 'light', fontSize: 1 };
+export const DEFAULT_READER_PREFERENCES: ReaderPreferences = {
+  theme: 'light',
+  fontSize: 1,
+  alignment: 'default',
+  singleColumn: false,
+};
 
 /** The page colours of a reading theme, for the reader's chrome and its content alike. */
 export const readerPageColors = (theme: Theme, name: ReaderThemeName) =>
   theme.customColors.readerPage[name];
 
 /**
- * Translates our two settings into the preferences the navigator understands.
+ * The half of the reader's preferences the navigator owns outright — every
+ * setting except the page colours, which the reading theme decides.
+ *
+ * Split out because this is also the half worth *storing*: colours are derived
+ * from a theme name and would only go stale in a browser's storage.
+ */
+export const toTypographyPreferences = (preferences: ReaderPreferences): IEpubPreferences => ({
+  fontSize: preferences.fontSize,
+  textAlign: READIUM_ALIGNMENTS[preferences.alignment],
+  columnCount: preferences.singleColumn ? SINGLE_COLUMN : AUTOMATIC_COLUMNS,
+});
+
+/**
+ * Translates our settings into the preferences the navigator understands.
  *
  * Deliberately a small surface: `EpubPreferences` has forty-odd fields, and
- * every one we set is one the reader can no longer inherit from the book.
+ * every one we set is one the reader can no longer inherit from the book. The
+ * two that can be *unset* are sent as `null` rather than omitted — the
+ * navigator merges preferences into the ones it already holds and skips
+ * whatever is `undefined`, so an omitted field is not a reset.
  */
 export const toEpubPreferences = (
   theme: Theme,
@@ -40,8 +112,8 @@ export const toEpubPreferences = (
 ): EpubPreferences => {
   const colors = readerPageColors(theme, preferences.theme);
   return new EpubPreferences({
+    ...toTypographyPreferences(preferences),
     backgroundColor: colors.background,
     textColor: colors.text,
-    fontSize: preferences.fontSize,
   });
 };

--- a/frontend/src/pages/ReaderPage/ReaderPage.test.tsx
+++ b/frontend/src/pages/ReaderPage/ReaderPage.test.tsx
@@ -1868,3 +1868,73 @@ test('a landing the navigator refused opens at the start without emphasising any
   await tintsOnThePage().toEqual([YELLOW_TINT]);
   expect(await emphasisAppearsWithin(EMPHASIS_RAMP_MS)).toBe(false);
 }, 30_000);
+/**
+ * A ReadiumCSS custom property as it stands in the frame the reader is looking
+ * at.
+ *
+ * This is the far end of the preferences path, and the only end worth
+ * asserting on: a setting the popover holds but never submits, or submits in
+ * terms ReadiumCSS does not recognise, would look identical in the control and
+ * change nothing about the words on the page. The navigator posts these into
+ * the frame and its own injectables write them onto the document element, so
+ * they arrive a moment after the click and every read of one is polled.
+ */
+const readiumProperty = (name: string): string =>
+  visibleFrame()?.contentDocument?.documentElement.style.getPropertyValue(name).trim() ?? '';
+
+/** How many columns ReadiumCSS has laid the current page out in. */
+const columnCount = () => readiumProperty('--USER__colCount');
+
+/** The appearance popover, open over the book. */
+const openAppearance = async (screen: Screen) => {
+  await screen.getByRole('button', { name: 'Appearance' }).click();
+  await expect.element(screen.getByRole('heading', { name: 'Text alignment' })).toBeVisible();
+};
+/**
+ * Justification is the setting worth proving end to end: unlike a colour or a
+ * font size it is one ReadiumCSS applies only when it is *told* to, leaving the
+ * book's own stylesheet in charge until then.
+ */
+test('an alignment the reader chooses reaches the words on the page', async () => {
+  aBookWithAnEpub();
+  const screen = await openTheBook();
+
+  // Nothing said, so the book's own stylesheet is still the one setting lines.
+  expect(readiumProperty('--USER__textAlign')).toBe('');
+
+  await openAppearance(screen);
+  await screen.getByRole('button', { name: 'Justified' }).click();
+
+  await expect.poll(() => readiumProperty('--USER__textAlign')).toBe('justify');
+});
+/**
+ * A wide screen fills itself with columns, which is more text per line than
+ * some people want to read. The switch is what caps it at one.
+ */
+test('the single-column switch holds a wide page to one column', async () => {
+  aBookWithAnEpub();
+  const screen = await openTheBook();
+
+  await expect.poll(columnCount).toBe('2');
+
+  await openAppearance(screen);
+  await screen.getByRole('switch', { name: 'Single column' }).click();
+
+  await expect.poll(columnCount).toBe('1');
+});
+/**
+ * Below the breakpoint the viewport only ever fits one column, so Readium's own
+ * automatic count is already one and the switch would be a control that changed
+ * nothing visible. The setting itself is untouched — it is global, and still in
+ * force on the desktop it was set from.
+ */
+test('the column switch is not offered where there is no room for a second column', async () => {
+  const screen = await aBookOpenOnAPhone();
+
+  await openAppearance(screen);
+
+  await expect.element(screen.getByRole('button', { name: 'Justified' })).toBeVisible();
+  await expect
+    .element(screen.getByRole('switch', { name: 'Single column' }))
+    .not.toBeInTheDocument();
+});

--- a/frontend/src/pages/ReaderPage/ReaderPage.test.tsx
+++ b/frontend/src/pages/ReaderPage/ReaderPage.test.tsx
@@ -1869,6 +1869,7 @@ test('a landing the navigator refused opens at the start without emphasising any
   await tintsOnThePage().toEqual([YELLOW_TINT]);
   expect(await emphasisAppearsWithin(EMPHASIS_RAMP_MS)).toBe(false);
 }, 30_000);
+
 /**
  * A ReadiumCSS custom property as it stands in the frame the reader is looking
  * at.
@@ -1891,6 +1892,7 @@ const openAppearance = async (screen: Screen) => {
   await screen.getByRole('button', { name: 'Appearance' }).click();
   await expect.element(screen.getByRole('heading', { name: 'Text alignment' })).toBeVisible();
 };
+
 /**
  * Justification is the setting worth proving end to end: unlike a colour or a
  * font size it is one ReadiumCSS applies only when it is *told* to, leaving the
@@ -1908,6 +1910,7 @@ test('an alignment the reader chooses reaches the words on the page', async () =
 
   await expect.poll(() => readiumProperty('--USER__textAlign')).toBe('justify');
 });
+
 /**
  * The whole point of the popover is that it is set once. A reader who justified
  * their text on Monday is not asking to be shown the publisher's ragged right
@@ -1944,6 +1947,7 @@ test('an appearance the reader set is still set when a book is opened again', as
     .element(screen.getByRole('button', { name: 'Justified' }))
     .toHaveAttribute('aria-pressed', 'true');
 }, 30_000);
+
 /**
  * Storage is a place other things write to, and a browser is entitled to hand
  * back whatever is under a key. None of that is the reader's problem: a book
@@ -1964,6 +1968,7 @@ test('an appearance stored as nonsense opens the book on the defaults', async ()
     .element(screen.getByRole('button', { name: 'Light' }))
     .toHaveAttribute('aria-pressed', 'true');
 });
+
 /**
  * A wide screen fills itself with columns, which is more text per line than
  * some people want to read. The switch is what caps it at one.
@@ -1979,6 +1984,7 @@ test('the single-column switch holds a wide page to one column', async () => {
 
   await expect.poll(columnCount).toBe('1');
 });
+
 /**
  * Below the breakpoint the viewport only ever fits one column, so Readium's own
  * automatic count is already one and the switch would be a control that changed
@@ -1994,4 +2000,34 @@ test('the column switch is not offered where there is no room for a second colum
   await expect
     .element(screen.getByRole('switch', { name: 'Single column' }))
     .not.toBeInTheDocument();
+});
+
+/**
+ * A contents list of ninety chapters that says nothing about where you are is a
+ * list you have to search to find yourself in. The mark is resource-granular,
+ * because that is all a reading position reliably says.
+ */
+test('the contents mark the chapter being read, and follow the reader out of it', async () => {
+  aBookWithAnEpub();
+  const screen = await openTheBook();
+
+  await screen.getByRole('button', { name: 'Contents' }).click();
+  const contents = screen.getByRole('navigation', { name: 'Table of contents' });
+  await expect
+    .element(contents.getByRole('button', { name: 'On Attention' }))
+    .toHaveAttribute('aria-current', 'location');
+  await expect
+    .element(contents.getByRole('button', { name: 'On Memory' }))
+    .not.toHaveAttribute('aria-current');
+  await screen.getByRole('button', { name: 'Close contents' }).click();
+
+  await turnThePage(screen);
+
+  await screen.getByRole('button', { name: 'Contents' }).click();
+  await expect
+    .element(contents.getByRole('button', { name: 'On Memory' }))
+    .toHaveAttribute('aria-current', 'location');
+  await expect
+    .element(contents.getByRole('button', { name: 'On Attention' }))
+    .not.toHaveAttribute('aria-current');
 });

--- a/frontend/src/pages/ReaderPage/ReaderPage.test.tsx
+++ b/frontend/src/pages/ReaderPage/ReaderPage.test.tsx
@@ -1,4 +1,5 @@
 import type { Highlight, HighlightLocatorResponse } from '@/api/generated/model';
+import { READER_PREFERENCES_KEY } from '@/components/reader/readerPreferenceStorage.ts';
 import { aBookDetails, aChapter, aHighlight } from '@tests/fixtures/book';
 import { aDetailedPositionList, aManifest, aResumePosition } from '@tests/fixtures/publication';
 import { renderApp } from '@tests/harness/renderApp';
@@ -1906,6 +1907,62 @@ test('an alignment the reader chooses reaches the words on the page', async () =
   await screen.getByRole('button', { name: 'Justified' }).click();
 
   await expect.poll(() => readiumProperty('--USER__textAlign')).toBe('justify');
+});
+/**
+ * The whole point of the popover is that it is set once. A reader who justified
+ * their text on Monday is not asking to be shown the publisher's ragged right
+ * again on Tuesday, and the reader is remounted from scratch every time a book
+ * is opened.
+ */
+test('an appearance the reader set is still set when a book is opened again', async () => {
+  aBookWithAnEpub();
+  const screen = await openTheBook();
+
+  await openAppearance(screen);
+  await screen.getByRole('button', { name: 'Justified' }).click();
+  await expect.poll(() => readiumProperty('--USER__textAlign')).toBe('justify');
+
+  // Out of the reader and back in through the app's own front door, which is
+  // what unmounts the shell, destroys the navigator and builds a new one. The
+  // popover is dismissed first: it is modal, and its backdrop owns every click
+  // aimed at the chrome behind it.
+  await userEvent.keyboard('{Escape}');
+  await expect
+    .element(screen.getByRole('heading', { name: 'Text alignment' }))
+    .not.toBeInTheDocument();
+  await screen.getByRole('button', { name: 'Close reader' }).click();
+  await expect.element(screen.getByRole('heading', { name: 'Structure' })).toBeVisible();
+  await screen.getByRole('link', { name: 'Read' }).click();
+  await expectLandingAt(screen, 'Page 1 of 2');
+
+  // The book opens justified — not merely a control that remembers being
+  // pressed — because the navigator is seeded with the stored preferences
+  // rather than corrected once it has already laid the page out.
+  await expect.poll(() => readiumProperty('--USER__textAlign')).toBe('justify');
+  await openAppearance(screen);
+  await expect
+    .element(screen.getByRole('button', { name: 'Justified' }))
+    .toHaveAttribute('aria-pressed', 'true');
+}, 30_000);
+/**
+ * Storage is a place other things write to, and a browser is entitled to hand
+ * back whatever is under a key. None of that is the reader's problem: a book
+ * still opens, on the defaults, with nothing said about it.
+ */
+test('an appearance stored as nonsense opens the book on the defaults', async () => {
+  aBookWithAnEpub();
+  window.localStorage.setItem(READER_PREFERENCES_KEY, '{ not json at all');
+
+  const screen = await openTheBook();
+
+  await openAppearance(screen);
+  await expect.element(screen.getByText('100%')).toBeVisible();
+  await expect
+    .element(screen.getByRole('button', { name: 'Default' }))
+    .toHaveAttribute('aria-pressed', 'true');
+  await expect
+    .element(screen.getByRole('button', { name: 'Light' }))
+    .toHaveAttribute('aria-pressed', 'true');
 });
 /**
  * A wide screen fills itself with columns, which is more text per line than

--- a/frontend/src/pages/ReaderPage/ReaderPage.test.tsx
+++ b/frontend/src/pages/ReaderPage/ReaderPage.test.tsx
@@ -1948,18 +1948,17 @@ test('an appearance the reader set is still set when a book is opened again', as
     .toHaveAttribute('aria-pressed', 'true');
 }, 30_000);
 
-/**
- * Storage is a place other things write to, and a browser is entitled to hand
- * back whatever is under a key. None of that is the reader's problem: a book
- * still opens, on the defaults, with nothing said about it.
- */
-test('an appearance stored as nonsense opens the book on the defaults', async () => {
+/** The reader opened over an appearance somebody else left in storage. */
+const openTheBookOverStoredPreferences = async (stored: string) => {
   aBookWithAnEpub();
-  window.localStorage.setItem(READER_PREFERENCES_KEY, '{ not json at all');
-
+  window.localStorage.setItem(READER_PREFERENCES_KEY, stored);
   const screen = await openTheBook();
-
   await openAppearance(screen);
+  return screen;
+};
+
+/** Every control back on what a first-time reader would see. */
+const expectTheDefaults = async (screen: Screen) => {
   await expect.element(screen.getByText('100%')).toBeVisible();
   await expect
     .element(screen.getByRole('button', { name: 'Default' }))
@@ -1967,11 +1966,62 @@ test('an appearance stored as nonsense opens the book on the defaults', async ()
   await expect
     .element(screen.getByRole('button', { name: 'Light' }))
     .toHaveAttribute('aria-pressed', 'true');
+};
+
+/**
+ * Storage is a place other things write to, and a browser is entitled to hand
+ * back whatever is under a key. None of that is the reader's problem: a book
+ * still opens, on the defaults, with nothing said about it.
+ */
+test('an appearance stored as nonsense opens the book on the defaults', async () => {
+  await expectTheDefaults(await openTheBookOverStoredPreferences('{ not json at all'));
+});
+
+/**
+ * The envelope can be perfectly good JSON and the typography inside it still
+ * unreadable, which is the case the navigator's own deserialiser is here to
+ * catch: it is what re-checks the font size, the alignment and the column
+ * count, and what refuses a blob that is not preferences at all.
+ */
+test('an appearance whose stored typography is unreadable opens the book on the defaults', async () => {
+  const screen = await openTheBookOverStoredPreferences(
+    JSON.stringify({ version: 1, theme: 'light', epub: 'garbage' })
+  );
+
+  await expectTheDefaults(screen);
+});
+
+/**
+ * The version field would enable the very loss it exists to prevent if a save
+ * ignored it. A reader who has used a newer build — in another tab, or before
+ * this one was served from a stale cache — has a record this code cannot read;
+ * falling back to the defaults is right, and then writing those defaults over
+ * their real settings would destroy them permanently.
+ */
+test('an appearance written by a newer reader is read past, and left alone', async () => {
+  const fromTheFuture = JSON.stringify({
+    version: 2,
+    theme: 'dark',
+    epub: '{"fontSize":1.4}',
+    somethingNewer: true,
+  });
+
+  const screen = await openTheBookOverStoredPreferences(fromTheFuture);
+  await expectTheDefaults(screen);
+
+  // Not merely on mount: a setting changed here must not overwrite it either.
+  await screen.getByRole('button', { name: 'Sepia' }).click();
+  await expect
+    .element(screen.getByRole('button', { name: 'Sepia' }))
+    .toHaveAttribute('aria-pressed', 'true');
+
+  expect(window.localStorage.getItem(READER_PREFERENCES_KEY)).toBe(fromTheFuture);
 });
 
 /**
  * A wide screen fills itself with columns, which is more text per line than
- * some people want to read. The switch is what caps it at one.
+ * some people want to read. The switch is what caps it at one — and it has to
+ * stay on offer once it has been used, or there would be no way back.
  */
 test('the single-column switch holds a wide page to one column', async () => {
   aBookWithAnEpub();
@@ -1983,16 +2033,26 @@ test('the single-column switch holds a wide page to one column', async () => {
   await screen.getByRole('switch', { name: 'Single column' }).click();
 
   await expect.poll(columnCount).toBe('1');
+
+  // The page is now one column because the reader asked for it, which is not a
+  // reason to take the switch away from them.
+  await userEvent.keyboard('{Escape}');
+  await openAppearance(screen);
+  await expect.element(screen.getByRole('switch', { name: 'Single column' })).toBeChecked();
 });
 
 /**
- * Below the breakpoint the viewport only ever fits one column, so Readium's own
- * automatic count is already one and the switch would be a control that changed
- * nothing visible. The setting itself is untouched — it is global, and still in
- * force on the desktop it was set from.
+ * Readium fits as many columns as the optimal line length allows, not as many
+ * as the breakpoint suggests: this viewport is far wider than a phone and
+ * still lays the book out in one column. A switch to force what is already
+ * true is a control that does nothing, so it is not offered.
  */
-test('the column switch is not offered where there is no room for a second column', async () => {
-  const screen = await aBookOpenOnAPhone();
+test('the column switch is not offered where the page is already one column', async () => {
+  aBookWithAnEpub();
+  await page.viewport(1100, 900);
+  const screen = await openTheBook();
+
+  await expect.poll(columnCount).toBe('1');
 
   await openAppearance(screen);
 
@@ -2030,4 +2090,59 @@ test('the contents mark the chapter being read, and follow the reader out of it'
   await expect
     .element(contents.getByRole('button', { name: 'On Attention' }))
     .not.toHaveAttribute('aria-current');
+});
+
+/**
+ * The nearest ancestor of `node` that actually scrolls, whatever it is called.
+ * Asked of the DOM rather than named by class, so this is about the panel the
+ * reader scrolls rather than about which element MUI happens to put it on.
+ */
+const scrollerAbove = (node: HTMLElement): HTMLElement | null => {
+  for (let el = node.parentElement; el; el = el.parentElement) {
+    if (el.scrollHeight > el.clientHeight + 1) return el;
+  }
+  return null;
+};
+
+/** A book whose contents are long enough that the current chapter is off screen. */
+const aBookWithALongToc = () =>
+  aBookWithAPublication({
+    manifest: aManifest({
+      toc: [
+        ...Array.from({ length: 40 }, (_, index) => ({
+          href: `resources/OEBPS/front-matter-${index}.xhtml`,
+          title: `Front matter ${index}`,
+        })),
+        { href: 'resources/OEBPS/chapter1.xhtml', title: 'On Attention' },
+        { href: 'resources/OEBPS/chapter2.xhtml', title: 'On Memory' },
+      ],
+    }),
+  });
+
+/**
+ * Marking the chapter is only half of it. In a book with a real table of
+ * contents the mark is usually below the fold, and a drawer that opens at
+ * entry one has told the reader nothing they can see.
+ *
+ * The assertion is deliberately about where the entry *is* on screen rather
+ * than about the mark: this scrolling was broken for a while behind tests that
+ * passed, because `aria-current` looks exactly the same whether the panel
+ * moved or not.
+ */
+test('the contents open scrolled to the chapter being read', async () => {
+  aBookWithALongToc();
+  const screen = await openTheBook();
+
+  await screen.getByRole('button', { name: 'Contents' }).click();
+  const contents = screen.getByRole('navigation', { name: 'Table of contents' });
+  const marked = contents.getByRole('button', { name: 'On Attention' });
+  await expect.element(marked).toHaveAttribute('aria-current', 'location');
+
+  const node = marked.element() as HTMLElement;
+  await expect.poll(() => scrollerAbove(node)?.scrollTop ?? 0).toBeGreaterThan(0);
+
+  // And it is genuinely on screen, which is the thing the reader gets.
+  const box = node.getBoundingClientRect();
+  expect(box.top).toBeGreaterThanOrEqual(0);
+  expect(box.bottom).toBeLessThanOrEqual(window.innerHeight);
 });

--- a/frontend/tests/setup.ts
+++ b/frontend/tests/setup.ts
@@ -1,6 +1,7 @@
 import { AXIOS_INSTANCE } from '@/api/axios-instance';
 import { API_BASE_URL } from '@/api/base-url';
 import { clearTokens } from '@/api/token-manager';
+import { READER_PREFERENCES_KEY } from '@/components/reader/readerPreferenceStorage';
 import { afterAll, afterEach, beforeAll } from 'vitest';
 import { cleanup } from 'vitest-browser-react';
 import { pendingQueryClients } from './harness/renderApp';
@@ -101,6 +102,10 @@ afterEach(async () => {
 
   worker.resetHandlers();
   clearTokens();
+  // The reader remembers its appearance in the browser itself, and the browser
+  // is one process for the whole file. Cleared by name rather than wholesale so
+  // that a test which puts something else in storage still owns it.
+  window.localStorage.removeItem(READER_PREFERENCES_KEY);
 
   const unhandled = unhandledRequests.splice(0);
   if (unhandled.length > 0) {


### PR DESCRIPTION
Fixes #788 — reader quality-of-life from the maintainer's daily test-driving. All controls in the existing appearance popover.

- **Persistence**: one versioned localStorage key; the `epub` half round-trips `EpubPreferences.serialize/deserialize` so Readium's own guards validate it (its deserialize logs, not silent — documented); a stored record from a NEWER version is never overwritten (an older client previously destroyed it on mount — pinned by test); every failure path defaults silently; stored preferences reach the navigator's first frame.
- **Text alignment**: three-state — Default (publisher's typography wins, `--USER__textAlign` genuinely cleared from live frames), Left (`start`, RTL-correct), Justified.
- **Current chapter in the TOC drawer**: resolved via `Timeline.tocEntryFor` (hand-rolled matching deleted in review — the library's nearest-preceding rules are strictly better), selected + `aria-current`, and actually scrolled into view via a callback ref — the passive-effect version could never fire (MUI Portal's first render after open mounts nothing; proven through react-dom commit ordering, test asserts real scroll position).
- **Single column (desktop)**: `columnCount: 1`; ReadiumCSS centers the narrowed container itself. The control appears only when two columns are actually possible — measured from the navigator's own effective column count at popover open (probing showed the breakpoint gate offered a dead switch at 768–1100 px and at raised font sizes), latched visible while the setting is on so there's always a way back.

Gates: 279 frontend tests + 144 reader tests across Chromium and WebKit, type-check/lint/knip/format clean, jscpd 0.8% (threshold 1.05). Review fixes red-first; the broken-scroll test demonstrably passes its aria-current assertion while failing scroll — the exact blindness the review caught.

🤖 Generated with [Claude Code](https://claude.com/claude-code)