### PR TITLE
Serve publication resources (#798)

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -4190,6 +4190,64 @@
         }
       }
     },
+    "/api/v1/readium/books/{book_id}/resources/{path}": {
+      "get": {
+        "tags": [
+          "readium"
+        ],
+        "summary": "Get Readium Resource",
+        "description": "Get one file of a book's publication, unchanged.\n\n``path`` is a manifest href with the ``resources/`` prefix stripped and\ndecoded once by ASGI, which is the archive member's own name. Only the files\nthe manifest names are reachable.",
+        "operationId": "get_readium_resource",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "book_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Book Id"
+            }
+          },
+          {
+            "name": "path",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Path"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The file, under the media type the publication declares for it.",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/semantic/backfill": {
       "post": {
         "tags": [

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -159,6 +159,7 @@ modules = [
     "src.domain.reading",
     "src.domain.reflection",
     "src.domain.tagging",
+    "src.domain.web_reader",
 ]
 
 [[tool.importlinter.contracts]]

--- a/backend/src/application/web_reader/publications.py
+++ b/backend/src/application/web_reader/publications.py
@@ -62,8 +62,7 @@ class PublicationResource:
             container root and percent-encoded.
         media_type: The media type the package document declares for it.
         size: The uncompressed size the archive declares for the member, in
-            bytes. A conditional request's ``Content-Length`` and the position
-            list are both computed from it.
+            bytes. The position list is computed from it.
         layout: The Readium layout, for reading-order items that state one.
             Always ``None`` for supporting resources, which have no layout.
     """

--- a/backend/src/application/web_reader/queries/get_publication_resource_use_case.py
+++ b/backend/src/application/web_reader/queries/get_publication_resource_use_case.py
@@ -1,0 +1,49 @@
+"""Read model serving one file of a book's publication."""
+
+from src.application.web_reader.queries.get_publication_use_case import GetPublicationUseCase
+from src.application.web_reader.queries.publication_resource import (
+    PublicationResourceQueryProtocol,
+    PublicationResourceView,
+)
+from src.domain.common.value_objects import BookId, UserId
+from src.domain.web_reader.exceptions import PublicationIndexUnavailableError
+
+
+class GetPublicationResourceUseCase:
+    """Serve one file of a book's publication, deriving the index when none is stored."""
+
+    def __init__(
+        self,
+        publication_resource_query: PublicationResourceQueryProtocol,
+        get_publication_use_case: GetPublicationUseCase,
+    ) -> None:
+        self.publication_resource_query = publication_resource_query
+        self.get_publication_use_case = get_publication_use_case
+
+    async def get_publication_resource(
+        self, book_id: int, user_id: int, path: str
+    ) -> PublicationResourceView:
+        """Return the file at ``path`` inside the book's EPUB container.
+
+        Raises:
+            BookNotFoundError: If the user has no such book.
+            EbookFileNotFoundError: If the book has no stored EPUB.
+            InvalidEbookError: If the member cannot be read.
+            PublicationIndexUnavailableError: If the book's index could not be stored.
+            PublicationResourceNotFoundError: If the publication lists no such file.
+        """
+        resource = await self.publication_resource_query.get_publication_resource(
+            BookId(book_id), UserId(user_id), path
+        )
+        if resource is not None:
+            return resource
+        # A book uploaded before indexes existed has no row until one is derived,
+        # and deriving raises BookNotFoundError itself for a book the user does
+        # not own -- so past this point the book exists.
+        await self.get_publication_use_case.get_publication(book_id, user_id)
+        resource = await self.publication_resource_query.get_publication_resource(
+            BookId(book_id), UserId(user_id), path
+        )
+        if resource is None:
+            raise PublicationIndexUnavailableError(book_id)
+        return resource

--- a/backend/src/application/web_reader/queries/publication_resource.py
+++ b/backend/src/application/web_reader/queries/publication_resource.py
@@ -1,0 +1,42 @@
+"""Read model for one file of a publication, served out of the book's EPUB."""
+
+from dataclasses import dataclass
+from typing import Protocol
+
+from src.domain.common.value_objects.ids import BookId, UserId
+
+
+@dataclass(frozen=True)
+class PublicationResourceView:
+    """One file of a publication, byte-for-byte as the archive holds it.
+
+    Attributes:
+        media_type: The media type the stored index declares for the file.
+        content: The member's decompressed bytes.
+    """
+
+    media_type: str
+    content: bytes
+
+
+class PublicationResourceQueryProtocol(Protocol):
+    async def get_publication_resource(
+        self, book_id: BookId, user_id: UserId, path: str
+    ) -> PublicationResourceView | None:
+        """Return one file of a user's publication, or ``None`` when no index is stored.
+
+        ``path`` is the file's path inside the EPUB container, decoded exactly
+        once -- a manifest href with its percent-encoding undone, which is the
+        archive member's own name.
+
+        An absent index is not an absent book: ``None`` covers both a book the
+        user does not own and one whose index has yet to be derived, and the
+        caller is what separates them.
+
+        Raises:
+            EbookFileNotFoundError: If the index is stored but its EPUB is not.
+            InvalidEbookError: If the archive or the member cannot be read.
+            PublicationResourceNotFoundError: If the index lists no such file,
+                or the archive holds no such member.
+        """
+        ...

--- a/backend/src/containers/root.py
+++ b/backend/src/containers/root.py
@@ -105,6 +105,7 @@ class RootContainer(containers.DeclarativeContainer):
         book_repository=shared.book_repository,
         file_repository=shared.file_repository,
         publication_parser=shared.epub_parser_service,
+        publication_resource_query=shared.publication_resource_query,
     )
 
     learning = providers.Container(

--- a/backend/src/containers/shared.py
+++ b/backend/src/containers/shared.py
@@ -79,6 +79,9 @@ from src.infrastructure.semantic.queries.search_hydration_query import SearchHyd
 from src.infrastructure.semantic.queries.semantic_search_query import SemanticSearchQuery
 from src.infrastructure.semantic.repositories.embedding_repository import EmbeddingRepository
 from src.infrastructure.tagging.repositories import TagRepository
+from src.infrastructure.web_reader.queries.publication_resource_query import (
+    PublicationResourceQuery,
+)
 from src.infrastructure.web_reader.repositories.publication_repository import (
     PublicationRepository,
 )
@@ -209,6 +212,11 @@ class SharedContainer(containers.DeclarativeContainer):
         ReadingSessionQuery,
         db=db,
         label_resolution_service=label_resolution_service,
+    )
+    publication_resource_query = providers.Factory(
+        PublicationResourceQuery,
+        db=db,
+        file_repository=file_repository,
     )
 
     # Learning repositories

--- a/backend/src/containers/web_reader.py
+++ b/backend/src/containers/web_reader.py
@@ -3,6 +3,9 @@ from dependency_injector import containers, providers
 from src.application.web_reader.queries.get_publication_positions_use_case import (
     GetPublicationPositionsUseCase,
 )
+from src.application.web_reader.queries.get_publication_resource_use_case import (
+    GetPublicationResourceUseCase,
+)
 from src.application.web_reader.queries.get_publication_use_case import GetPublicationUseCase
 
 
@@ -14,6 +17,7 @@ class WebReaderContainer(containers.DeclarativeContainer):
     book_repository = providers.Dependency()
     file_repository = providers.Dependency()
     publication_parser = providers.Dependency()
+    publication_resource_query = providers.Dependency()
 
     # Read models
     get_publication_use_case = providers.Factory(
@@ -25,5 +29,10 @@ class WebReaderContainer(containers.DeclarativeContainer):
     )
     get_publication_positions_use_case = providers.Factory(
         GetPublicationPositionsUseCase,
+        get_publication_use_case=get_publication_use_case,
+    )
+    get_publication_resource_use_case = providers.Factory(
+        GetPublicationResourceUseCase,
+        publication_resource_query=publication_resource_query,
         get_publication_use_case=get_publication_use_case,
     )

--- a/backend/src/domain/web_reader/__init__.py
+++ b/backend/src/domain/web_reader/__init__.py
@@ -1,0 +1,1 @@
+"""Web reader domain layer."""

--- a/backend/src/domain/web_reader/exceptions.py
+++ b/backend/src/domain/web_reader/exceptions.py
@@ -1,0 +1,21 @@
+"""Web reader domain exceptions."""
+
+from src.domain.common.exceptions import DomainError, EntityNotFoundError
+
+
+class PublicationResourceNotFoundError(EntityNotFoundError):
+    """Raised when a publication does not contain the requested file."""
+
+    def __init__(self, path: str) -> None:
+        super().__init__("Publication resource", path)
+
+
+class PublicationIndexUnavailableError(DomainError):
+    """Raised when a book's index cannot be read back after being derived.
+
+    Deriving an index stores it best-effort, so a failed write leaves a book
+    that exists but has nothing to serve from -- a server fault, not a 404.
+    """
+
+    def __init__(self, book_id: int) -> None:
+        super().__init__(f"No publication index could be stored for book {book_id}")

--- a/backend/src/infrastructure/web_reader/publication_rows.py
+++ b/backend/src/infrastructure/web_reader/publication_rows.py
@@ -1,0 +1,23 @@
+"""The statement that reads a book's stored publication index."""
+
+from sqlalchemy import Select, select
+
+from src.domain.common.value_objects.ids import BookId, UserId
+from src.infrastructure.library.orm.book_model import Book as BookORM
+from src.infrastructure.web_reader.orm.book_publication_model import (
+    BookPublication as BookPublicationORM,
+)
+
+
+def publication_row(book_id: BookId, user_id: UserId) -> Select[tuple[BookPublicationORM]]:
+    """Select one book's index row, matching nothing when the book is someone else's.
+
+    The ownership join is the access rule for every reader of this row, so it
+    lives here rather than being restated at each of them.
+    """
+    return (
+        select(BookPublicationORM)
+        .join(BookORM, BookPublicationORM.book_id == BookORM.id)
+        .where(BookPublicationORM.book_id == book_id.value)
+        .where(BookORM.user_id == user_id.value)
+    )

--- a/backend/src/infrastructure/web_reader/queries/publication_resource_query.py
+++ b/backend/src/infrastructure/web_reader/queries/publication_resource_query.py
@@ -1,0 +1,77 @@
+"""Query adapter serving one file out of a book's stored publication index and EPUB."""
+
+import asyncio
+import zipfile
+from io import BytesIO
+from urllib.parse import unquote
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.application.library.protocols.file_repository import FileRepositoryProtocol
+from src.application.web_reader.publications import ParsedPublication
+from src.application.web_reader.queries.publication_resource import PublicationResourceView
+from src.domain.common.value_objects.ids import BookId, UserId
+from src.domain.library.exceptions import EbookFileNotFoundError, InvalidEbookError
+from src.domain.web_reader.exceptions import PublicationResourceNotFoundError
+from src.infrastructure.common.zip_members import read_bounded_member
+from src.infrastructure.web_reader.mappers.publication_json import publication_from_json
+from src.infrastructure.web_reader.publication_rows import publication_row
+
+
+class PublicationResourceQuery:
+    """Serves one file of a book's publication, byte-for-byte as the EPUB holds it."""
+
+    def __init__(self, db: AsyncSession, file_repository: FileRepositoryProtocol) -> None:
+        self.db = db
+        self.file_repository = file_repository
+
+    async def get_publication_resource(
+        self, book_id: BookId, user_id: UserId, path: str
+    ) -> PublicationResourceView | None:
+        """Return one file of a user's publication, or ``None`` when no index is stored."""
+        result = await self.db.execute(publication_row(book_id, user_id))
+        orm = result.scalar_one_or_none()
+        if orm is None:
+            return None
+
+        publication = publication_from_json(orm.publication, orm.content_hash)
+        media_type = _media_types(publication).get(path)
+        if media_type is None:
+            raise PublicationResourceNotFoundError(path)
+
+        content = await self.file_repository.get_epub(orm.file_name)
+        if content is None:
+            raise EbookFileNotFoundError(book_id.value)
+
+        member = await asyncio.to_thread(_read_member, content, path)
+        return PublicationResourceView(media_type=media_type, content=member)
+
+
+def _media_types(publication: ParsedPublication) -> dict[str, str]:
+    """Map each file the publication offers to the media type declared for it.
+
+    Membership here is the whole access rule: the package document, ``META-INF/``
+    and any path climbing out of the container are absent from these two lists
+    and so need no separate traversal guard. Decoding an href exactly once
+    matches what ASGI already did to the URL path.
+    """
+    return {
+        unquote(resource.href): resource.media_type
+        for resource in (*publication.reading_order, *publication.resources)
+    }
+
+
+def _read_member(content: bytes, path: str) -> bytes:
+    try:
+        archive = zipfile.ZipFile(BytesIO(content))
+    except (OSError, zipfile.BadZipFile) as e:
+        raise InvalidEbookError(f"stored archive cannot be opened: {e!s}", "epub") from e
+    with archive:
+        try:
+            entry = archive.getinfo(path)
+        except KeyError:
+            # The index is derived from the package document rather than from
+            # the archive's file list, so a manifest may name a member the
+            # container does not hold.
+            raise PublicationResourceNotFoundError(path) from None
+        return read_bounded_member(archive, entry)

--- a/backend/src/infrastructure/web_reader/repositories/publication_repository.py
+++ b/backend/src/infrastructure/web_reader/repositories/publication_repository.py
@@ -2,12 +2,10 @@
 
 from datetime import UTC, datetime
 
-from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.application.web_reader.publications import ParsedPublication
 from src.domain.common.value_objects.ids import BookId, UserId
-from src.infrastructure.library.orm.book_model import Book as BookORM
 from src.infrastructure.web_reader.mappers.publication_json import (
     publication_from_json,
     publication_to_json,
@@ -15,6 +13,7 @@ from src.infrastructure.web_reader.mappers.publication_json import (
 from src.infrastructure.web_reader.orm.book_publication_model import (
     BookPublication as BookPublicationORM,
 )
+from src.infrastructure.web_reader.publication_rows import publication_row
 
 
 class PublicationRepository:
@@ -29,13 +28,7 @@ class PublicationRepository:
         A book someone else owns reads as absent rather than as an error: the
         caller may not learn that the row exists.
         """
-        stmt = (
-            select(BookPublicationORM)
-            .join(BookORM, BookPublicationORM.book_id == BookORM.id)
-            .where(BookPublicationORM.book_id == book_id.value)
-            .where(BookORM.user_id == user_id.value)
-        )
-        result = await self.db.execute(stmt)
+        result = await self.db.execute(publication_row(book_id, user_id))
         orm = result.scalar_one_or_none()
         if orm is None:
             return None

--- a/backend/src/infrastructure/web_reader/routers/readium.py
+++ b/backend/src/infrastructure/web_reader/routers/readium.py
@@ -1,8 +1,9 @@
-"""API router serving a book's Readium Web Publication Manifest and position list."""
+"""API router serving a book's Readium Web Publication Manifest, position list and files."""
 
+import re
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Depends, Request, Response
 from fastapi.responses import JSONResponse
 from starlette import status
 
@@ -13,6 +14,9 @@ from src.application.web_reader.publications import (
 )
 from src.application.web_reader.queries.get_publication_positions_use_case import (
     GetPublicationPositionsUseCase,
+)
+from src.application.web_reader.queries.get_publication_resource_use_case import (
+    GetPublicationResourceUseCase,
 )
 from src.application.web_reader.queries.get_publication_use_case import GetPublicationUseCase
 from src.application.web_reader.queries.publication_positions import PublicationPosition
@@ -45,6 +49,21 @@ POSITION_LIST_HREF = "positions.json"
 # A table-of-contents heading that links nowhere. A Readium Link must have an
 # href, so the entry keeps its title and points at the manifest itself.
 UNLINKED_TOC_HREF = "#"
+
+# A publication is one user's book, so a shared cache must not hold it.
+RESOURCE_CACHE_CONTROL = "private"
+
+# Readium reads a resource with `fetch()` and frames a blob it builds from the
+# text, so this header never reaches the path the reader takes. A browser
+# navigating straight at the URL gets same-origin markup the user uploaded, and
+# `sandbox` with no tokens leaves that document an opaque origin with no
+# scripts, no forms and no top-level navigation.
+RESOURCE_CONTENT_SECURITY_POLICY = "sandbox"
+
+# A plain `type/subtype`, no parameters, and deliberately narrower than RFC 9110
+# §8.3.1's `token` -- which an EPUB's package document has no use for.
+_MEDIA_TYPE = re.compile(r"[A-Za-z0-9][A-Za-z0-9!#$&^_.+-]*/[A-Za-z0-9][A-Za-z0-9!#$&^_.+-]*")
+FALLBACK_MEDIA_TYPE = "application/octet-stream"
 
 
 class WebpubJSONResponse(JSONResponse):
@@ -114,6 +133,58 @@ async def get_readium_positions(
     return PositionListJSONResponse(
         content=document.model_dump(mode="json", by_alias=True, exclude_none=True)
     )
+
+
+@router.get(
+    "/books/{book_id}/resources/{path:path}",
+    response_class=Response,
+    status_code=status.HTTP_200_OK,
+    responses={
+        status.HTTP_200_OK: {
+            "content": {"*/*": {"schema": {"type": "string", "format": "binary"}}},
+            "description": "The file, under the media type the publication declares for it.",
+        },
+    },
+)
+async def get_readium_resource(
+    book_id: int,
+    path: str,
+    current_user: Annotated[User, Depends(get_current_user)],
+    use_case: GetPublicationResourceUseCase = Depends(
+        inject_use_case(container.web_reader.get_publication_resource_use_case)
+    ),
+) -> Response:
+    """Get one file of a book's publication, unchanged.
+
+    ``path`` is a manifest href with the ``resources/`` prefix stripped and
+    decoded once by ASGI, which is the archive member's own name. Only the files
+    the manifest names are reachable.
+    """
+    resource = await use_case.get_publication_resource(
+        book_id=book_id,
+        user_id=current_user.id.value,
+        path=path,
+    )
+    # Content-Type is a raw header rather than `media_type`, which would append
+    # `; charset=utf-8` to every `text/*` type. The bytes go out unchanged and an
+    # EPUB's documents declare their own encoding.
+    return Response(
+        content=resource.content,
+        headers={
+            "Content-Type": _servable_media_type(resource.media_type),
+            "Cache-Control": RESOURCE_CACHE_CONTROL,
+            "Content-Security-Policy": RESOURCE_CONTENT_SECURITY_POLICY,
+        },
+    )
+
+
+def _servable_media_type(declared: str) -> str:
+    """Keep a package document's media type out of the response unless it is one.
+
+    The value is copied from a file the user uploaded: one carrying a newline
+    would smuggle a second header, one outside Latin-1 would fail to encode.
+    """
+    return declared if _MEDIA_TYPE.fullmatch(declared) else FALLBACK_MEDIA_TYPE
 
 
 def _self_href(request: Request) -> str:

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -307,17 +307,20 @@ class SecurityHeadersMiddleware:
                 if settings.ENVIRONMENT != "development":
                     headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
                     headers["Strict-Transport-Security"] = "max-age=31536000; includeSubDomains"
-                    headers["Content-Security-Policy"] = (
-                        "default-src 'self'; "
-                        "script-src 'self'; "
-                        "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; "
-                        "img-src 'self' data: blob:; "
-                        "font-src 'self' https://fonts.gstatic.com; "
-                        "connect-src 'self'; "
-                        "frame-ancestors 'none'; "
-                        "base-uri 'self'; "
-                        "form-action 'self'"
-                    )
+                    # `MutableHeaders` assignment replaces rather than appends,
+                    # so a route that set its own, narrower policy keeps it.
+                    if "content-security-policy" not in headers:
+                        headers["Content-Security-Policy"] = (
+                            "default-src 'self'; "
+                            "script-src 'self'; "
+                            "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; "
+                            "img-src 'self' data: blob:; "
+                            "font-src 'self' https://fonts.gstatic.com; "
+                            "connect-src 'self'; "
+                            "frame-ancestors 'none'; "
+                            "base-uri 'self'; "
+                            "form-action 'self'"
+                        )
             await send(message)
 
         await self.app(scope, receive, wrapped_send)

--- a/backend/tests/epub_builders.py
+++ b/backend/tests/epub_builders.py
@@ -1,0 +1,84 @@
+"""Hand-built EPUBs, for the shapes no fixture on disk has.
+
+Shared by the parser's unit tests and the Readium endpoints' API tests, which
+need the same broken and hostile publications from either side.
+"""
+
+import zipfile
+from collections.abc import Mapping
+from io import BytesIO
+
+DEFAULT_IDENTIFIERS = '<dc:identifier id="bookid">urn:uuid:hand-built</dc:identifier>'
+DOCUMENT = (
+    b'<?xml version="1.0" encoding="UTF-8"?>'
+    b'<html xmlns="http://www.w3.org/1999/xhtml"><head><title>Page</title></head>'
+    b"<body><p>Hi there.</p></body></html>"
+)
+
+NAV_ITEM = '<item id="nav" href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/>'
+
+
+def container_xml(rootfile: str = '<rootfile full-path="content.opf"/>') -> str:
+    return (
+        '<?xml version="1.0" encoding="UTF-8"?>'
+        '<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">'
+        f"<rootfiles>{rootfile}</rootfiles></container>"
+    )
+
+
+def nav_document(
+    list_items: str, attributes: str = 'epub:type="toc"', preceded_by: str = ""
+) -> str:
+    return (
+        '<?xml version="1.0" encoding="UTF-8"?>'
+        '<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops">'
+        "<head><title>Contents</title></head>"
+        f"<body>{preceded_by}<nav {attributes}><ol>{list_items}</ol></nav></body></html>"
+    )
+
+
+def build_epub(
+    manifest_items: str,
+    spine: str,
+    files: tuple[str, ...] = (),
+    unique_identifier: str = "bookid",
+    identifiers: str = DEFAULT_IDENTIFIERS,
+    extra_metadata: str = "",
+    opf_name: str = "content.opf",
+    container: str | None = None,
+    spine_toc: str | None = None,
+    documents: Mapping[str, str] | None = None,
+) -> bytes:
+    """Assemble an EPUB by hand, so a broken or hostile one reads as such in the diff.
+
+    What the archive really holds (``files``, and ``documents`` for a member
+    whose content matters) is deliberately separate from what the manifest
+    promises: a manifest naming a file that is not there is one of the shapes
+    under test.
+    """
+    package = (
+        '<?xml version="1.0" encoding="UTF-8"?>'
+        '<package xmlns="http://www.idpf.org/2007/opf" version="3.0" '
+        f'unique-identifier="{unique_identifier}">'
+        '<metadata xmlns:dc="http://purl.org/dc/elements/1.1/">'
+        f"{identifiers}<dc:title>Hand Built</dc:title><dc:language>en</dc:language>"
+        f"{extra_metadata}</metadata>"
+        f"<manifest>{manifest_items}</manifest>"
+        f"<spine{f' toc="{spine_toc}"' if spine_toc is not None else ''}>{spine}</spine></package>"
+    )
+
+    out = BytesIO()
+    with zipfile.ZipFile(out, "w") as archive:
+        archive.writestr(zipfile.ZipInfo("mimetype"), "application/epub+zip", zipfile.ZIP_STORED)
+        archive.writestr(
+            "META-INF/container.xml",
+            container
+            if container is not None
+            else container_xml(f'<rootfile full-path="{opf_name}"/>'),
+        )
+        archive.writestr(opf_name, package)
+        for name in files:
+            archive.writestr(name, DOCUMENT)
+        for name, content in (documents or {}).items():
+            archive.writestr(name, content)
+    return out.getvalue()

--- a/backend/tests/readium_helpers.py
+++ b/backend/tests/readium_helpers.py
@@ -12,6 +12,9 @@ manifest links to. Both sets read the same fixture EPUBs:
   observable rather than incidental.
 - ``fixed_layout.epub``: ``rendition:layout`` stated for the publication and
   overridden on one spine item.
+
+``build_epub`` assembles adversarial publications by hand, for the shapes no
+fixture on disk has.
 """
 
 from pathlib import Path
@@ -24,6 +27,8 @@ from src.domain.common.value_objects import BookId
 from src.infrastructure.library.services.epub_publication_parser import read_publication
 from src.infrastructure.web_reader.repositories.publication_repository import PublicationRepository
 from tests.conftest import create_test_book
+from tests.epub_builders import NAV_ITEM, nav_document
+from tests.epub_builders import build_epub as _build_epub
 
 FIXTURES = Path(__file__).parent / "fixtures"
 
@@ -59,6 +64,31 @@ async def store_publication(
 
 async def store_fixture(db_session: AsyncSession, book: models.Book, name: str) -> None:
     await store_publication(db_session, book, parse_fixture(name), f"{name}.epub")
+
+
+def build_epub(
+    manifest_items: str, spine: str, nav_links: str, files: tuple[str, ...] = ()
+) -> bytes:
+    """Assemble an EPUB by hand, with the navigation document its manifest names."""
+    return _build_epub(
+        manifest_items=f"{NAV_ITEM}{manifest_items}",
+        spine=spine,
+        files=files,
+        documents={"nav.xhtml": nav_document(nav_links)},
+    )
+
+
+# A publication whose one spine document is really named `chapter%20one.xhtml`
+# -- a literal percent sign in the file name, which the OPF therefore writes as
+# `chapter%2520one.xhtml`.
+LITERAL_PERCENT_EPUB = build_epub(
+    manifest_items=(
+        '<item id="c1" href="chapter%2520one.xhtml" media-type="application/xhtml+xml"/>'
+    ),
+    spine='<itemref idref="c1"/>',
+    nav_links='<li><a href="chapter%2520one.xhtml">Chapter One</a></li>',
+    files=("chapter%20one.xhtml",),
+)
 
 
 async def another_users_book(db_session: AsyncSession) -> models.Book:

--- a/backend/tests/test_readium_resources.py
+++ b/backend/tests/test_readium_resources.py
@@ -1,0 +1,333 @@
+"""Tests for the endpoint serving a publication's own files to the web reader.
+
+The paths asked for here are the manifest's hrefs with ``resources/`` stripped,
+because that is exactly how a navigator reaches them: it resolves each href
+against the manifest URL and fetches what comes out. So the fixtures are the
+manifest's fixtures, and a name that survives the round trip through the URL is
+the point rather than a detail -- ``nested_toc.epub`` carries a space and
+non-ASCII letters, and ``LITERAL_PERCENT_EPUB`` carries a real percent sign,
+which is the one name that a decode too many turns into a different file.
+
+Only the files the manifest lists are reachable. The package document,
+``META-INF/`` and the archive's ``mimetype`` member are in every EPUB and in no
+publication, and the endpoint must not serve them.
+"""
+
+import zipfile
+from io import BytesIO
+from pathlib import Path
+
+import pytest
+from httpx import AsyncClient, Response
+from sqlalchemy.exc import OperationalError
+from sqlalchemy.ext.asyncio import AsyncSession
+from starlette import status
+
+from src import models
+from src.infrastructure.library.services.epub_publication_parser import read_publication
+from src.infrastructure.web_reader.repositories.publication_repository import PublicationRepository
+from src.main import settings as main_settings
+from tests.readium_helpers import (
+    LITERAL_PERCENT_EPUB,
+    another_users_book,
+    build_epub,
+    fixture_bytes,
+    manifest_url,
+    store_publication,
+)
+from tests.test_readium_manifest import store_epub
+
+CHAPTER_1 = "EPUB/text/chapter%201.xhtml"
+CHAPTER_AANI = "EPUB/text/luku-%C3%A4%C3%A4ni.xhtml"
+STYLESHEET = "EPUB/styles/main.css"
+COVER_ART = "EPUB/images/cover%20art.png"
+
+
+def resource_url(book_id: int, href: str) -> str:
+    """The URL a navigator resolves for a manifest href, ``resources/`` and all."""
+    return f"/api/v1/readium/books/{book_id}/resources/{href}"
+
+
+async def store_indexed_epub(
+    db_session: AsyncSession,
+    book: models.Book,
+    storage_dir: Path,
+    content: bytes,
+    filename: str = "book.epub",
+) -> None:
+    """Give a book an EPUB on disk and the index row that names it.
+
+    The endpoint reads the file name off the index row, so a book with only one
+    of the two is a book in mid-upload rather than one ready to be read.
+    """
+    await store_epub(db_session, book, storage_dir, content, filename)
+    await store_publication(db_session, book, read_publication(content), filename)
+
+
+async def serve_every_manifest_href(
+    client: AsyncClient, book_id: int
+) -> list[tuple[dict[str, str], Response]]:
+    """Fetch every file the manifest names, paired with the link that named it.
+
+    A manifest that advertises an href this endpoint will not serve is the
+    failure the two of them can only have together, so the manifest is what
+    drives the requests rather than a list copied out of it.
+    """
+    manifest = (await client.get(manifest_url(book_id))).json()
+    links: list[dict[str, str]] = manifest["readingOrder"] + manifest["resources"]
+    return [
+        (link, await client.get(resource_url(book_id, link["href"].removeprefix("resources/"))))
+        for link in links
+    ]
+
+
+def member_bytes(epub_content: bytes, name: str) -> bytes:
+    """What the archive really holds under ``name``, to compare a response against."""
+    with zipfile.ZipFile(BytesIO(epub_content)) as archive:
+        return archive.read(name)
+
+
+@pytest.fixture
+async def nested_toc_book(
+    db_session: AsyncSession, test_book: models.Book, storage_dir: Path
+) -> models.Book:
+    """A book whose EPUB has awkward file names, styles and an image."""
+    await store_indexed_epub(db_session, test_book, storage_dir, fixture_bytes("nested_toc"))
+    return test_book
+
+
+class TestServingPublicationFiles:
+    """What GET /api/v1/readium/books/{id}/resources/{path} returns for a real book."""
+
+    async def test_serves_a_chapter_unchanged(
+        self, client: AsyncClient, nested_toc_book: models.Book
+    ) -> None:
+        """Should return the archive's own bytes under the declared media type."""
+        response = await client.get(resource_url(nested_toc_book.id, CHAPTER_1))
+
+        assert response.status_code == status.HTTP_200_OK, response.text
+        assert response.content == member_bytes(
+            fixture_bytes("nested_toc"), "EPUB/text/chapter 1.xhtml"
+        )
+        assert b"<html" in response.content
+        assert response.headers["content-type"] == "application/xhtml+xml"
+        assert response.headers["cache-control"] == "private"
+
+    async def test_serves_a_stylesheet(
+        self, client: AsyncClient, nested_toc_book: models.Book
+    ) -> None:
+        """Should serve a supporting resource, not only the reading order."""
+        response = await client.get(resource_url(nested_toc_book.id, STYLESHEET))
+
+        assert response.status_code == status.HTTP_200_OK, response.text
+        assert response.headers["content-type"] == "text/css"
+        assert response.content == member_bytes(fixture_bytes("nested_toc"), "EPUB/styles/main.css")
+
+    async def test_serves_a_png_byte_for_byte(
+        self, client: AsyncClient, nested_toc_book: models.Book
+    ) -> None:
+        """Should not re-encode binary content on its way out."""
+        response = await client.get(resource_url(nested_toc_book.id, COVER_ART))
+
+        assert response.status_code == status.HTTP_200_OK, response.text
+        assert response.headers["content-type"] == "image/png"
+        assert response.content.startswith(b"\x89PNG\r\n\x1a\n")
+        assert response.content == member_bytes(
+            fixture_bytes("nested_toc"), "EPUB/images/cover art.png"
+        )
+
+    async def test_serves_a_name_with_non_ascii_letters(
+        self, client: AsyncClient, nested_toc_book: models.Book
+    ) -> None:
+        """Should reach a UTF-8 file name through its percent-encoded href."""
+        response = await client.get(resource_url(nested_toc_book.id, CHAPTER_AANI))
+
+        assert response.status_code == status.HTTP_200_OK, response.text
+        assert response.content == member_bytes(
+            fixture_bytes("nested_toc"), "EPUB/text/luku-ääni.xhtml"
+        )
+
+    async def test_serves_a_file_whose_name_contains_a_percent_sign(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        test_book: models.Book,
+        storage_dir: Path,
+    ) -> None:
+        """Should decode the path exactly once, reaching the file that exists.
+
+        The publication's one chapter is really named ``chapter%20one.xhtml``,
+        so the manifest publishes ``chapter%2520one.xhtml``. Decoding that twice
+        would name ``chapter one.xhtml``, which no EPUB here contains -- the
+        request would 404 while the manifest kept advertising the href.
+        """
+        await store_indexed_epub(db_session, test_book, storage_dir, LITERAL_PERCENT_EPUB)
+
+        response = await client.get(resource_url(test_book.id, "chapter%2520one.xhtml"))
+
+        assert response.status_code == status.HTTP_200_OK, response.text
+        assert response.headers["content-type"] == "application/xhtml+xml"
+        assert response.content == member_bytes(LITERAL_PERCENT_EPUB, "chapter%20one.xhtml")
+
+    async def test_the_manifests_hrefs_all_resolve(
+        self, client: AsyncClient, nested_toc_book: models.Book
+    ) -> None:
+        """Should serve every file the manifest names, with the type it named."""
+        served = await serve_every_manifest_href(client, nested_toc_book.id)
+        assert len(served) == 5
+
+        for link, response in served:
+            assert response.status_code == status.HTTP_200_OK, link["href"]
+            assert response.headers["content-type"] == link["type"], link["href"]
+            assert response.content, link["href"]
+
+    async def test_an_index_that_cannot_be_stored_is_a_server_fault(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        test_book: models.Book,
+        storage_dir: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Should answer 500 rather than 404 when the derived index cannot be kept.
+
+        Serving a file needs the row, which a book uploaded before indexes
+        existed only gets on first read. The book is whole -- the manifest still
+        renders it -- so a 404 would tell the reader its book had gone missing.
+        """
+        await store_epub(db_session, test_book, storage_dir, fixture_bytes("nested_toc"))
+
+        async def failing_save(*_args: object, **_kwargs: object) -> None:
+            raise OperationalError("INSERT INTO book_publications", {}, Exception("locked"))
+
+        monkeypatch.setattr(PublicationRepository, "save", failing_save)
+
+        response = await client.get(resource_url(test_book.id, CHAPTER_1))
+        manifest = await client.get(manifest_url(test_book.id))
+
+        assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR, response.text
+        assert manifest.status_code == status.HTTP_200_OK, manifest.text
+
+
+class TestServedResourcesCarryASandboxPolicy:
+    """The policy that makes a resource harmless when a browser loads it directly."""
+
+    async def test_a_chapter_is_served_under_a_sandbox_policy(
+        self, client: AsyncClient, nested_toc_book: models.Book
+    ) -> None:
+        """Should send the policy with the markup the reader's frames are built from."""
+        response = await client.get(resource_url(nested_toc_book.id, CHAPTER_1))
+
+        assert response.status_code == status.HTTP_200_OK, response.text
+        assert response.headers["content-security-policy"] == "sandbox"
+        assert response.headers["x-content-type-options"] == "nosniff"
+
+    async def test_the_app_wide_policy_does_not_overwrite_it(
+        self,
+        client: AsyncClient,
+        nested_toc_book: models.Book,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Should keep the resource's own policy where the app sets one of its own.
+
+        ``SecurityHeadersMiddleware`` sends the app's policy outside development,
+        and ``MutableHeaders`` assignment replaces rather than appends -- so a
+        middleware that did not defer would quietly widen this endpoint back to
+        ``script-src 'self'`` in every environment that matters, and only there.
+        """
+        monkeypatch.setattr(main_settings, "ENVIRONMENT", "production")
+
+        resource = await client.get(resource_url(nested_toc_book.id, CHAPTER_1))
+        manifest = await client.get(manifest_url(nested_toc_book.id))
+
+        assert resource.headers["content-security-policy"] == "sandbox"
+        # The app policy still reaches a response that expresses none of its own.
+        assert "default-src 'self'" in manifest.headers["content-security-policy"]
+
+
+class TestOnlyPublicationFilesAreReachable:
+    """What the endpoint refuses, which is everything the manifest does not name."""
+
+    @pytest.mark.parametrize(
+        ("path", "why"),
+        [
+            ("EPUB/package.opf", "the package document is not part of the publication"),
+            ("META-INF/container.xml", "container metadata is not part of the publication"),
+            ("mimetype", "the archive's own marker is not part of the publication"),
+            ("EPUB/text/nowhere.xhtml", "no such member"),
+            ("", "the resource root is not a file"),
+        ],
+    )
+    async def test_a_path_the_manifest_does_not_list_is_not_found(
+        self, client: AsyncClient, nested_toc_book: models.Book, path: str, why: str
+    ) -> None:
+        """Should serve only what the manifest advertises, whatever else the zip holds."""
+        response = await client.get(resource_url(nested_toc_book.id, path))
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND, why
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "..%2F..%2Fmanifest.json",
+            "..%2F..%2F..%2F..%2Fetc%2Fpasswd",
+            "/etc/passwd",
+            "EPUB%2F..%2F..%2Fmanifest.json",
+        ],
+    )
+    async def test_a_path_climbing_out_of_the_container_is_not_found(
+        self, client: AsyncClient, nested_toc_book: models.Book, path: str
+    ) -> None:
+        """Should never resolve a path outside the publication, encoded or not.
+
+        The membership check is the guard: the manifest's hrefs are already
+        known not to escape the container, so nothing that escapes can be in the
+        list, and there is no second normalisation step to get wrong.
+        """
+        response = await client.get(resource_url(nested_toc_book.id, path))
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND, response.text
+
+    async def test_another_users_publication_is_not_found(
+        self, client: AsyncClient, db_session: AsyncSession, storage_dir: Path
+    ) -> None:
+        """Should refuse a book the caller does not own, index row and EPUB and all."""
+        theirs = await another_users_book(db_session)
+        await store_indexed_epub(db_session, theirs, storage_dir, fixture_bytes("nested_toc"))
+
+        response = await client.get(resource_url(theirs.id, CHAPTER_1))
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND, response.text
+
+    async def test_a_media_type_that_is_not_one_is_not_echoed_back(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        test_book: models.Book,
+        storage_dir: Path,
+    ) -> None:
+        """Should not put a package document's text into a header unaltered.
+
+        The media type is copied from a file the user uploaded. A value with a
+        newline in it would smuggle a second header into the response, so
+        anything that is not a plain ``type/subtype`` is replaced by one the
+        browser will not act on.
+        """
+        await store_indexed_epub(
+            db_session,
+            test_book,
+            storage_dir,
+            build_epub(
+                manifest_items=(
+                    '<item id="c1" href="c1.xhtml" media-type="text/html&#10;Set-Cookie: pwned=1"/>'
+                ),
+                spine='<itemref idref="c1"/>',
+                nav_links='<li><a href="c1.xhtml">One</a></li>',
+                files=("c1.xhtml",),
+            ),
+        )
+
+        response = await client.get(resource_url(test_book.id, "c1.xhtml"))
+
+        assert response.status_code == status.HTTP_200_OK, response.text
+        assert response.headers["content-type"] == "application/octet-stream"

--- a/backend/tests/unit/infrastructure/library/services/test_epub_publication_parser.py
+++ b/backend/tests/unit/infrastructure/library/services/test_epub_publication_parser.py
@@ -11,7 +11,6 @@ import logging
 import struct
 import tracemalloc
 import zipfile
-from collections.abc import Mapping
 from io import BytesIO
 from pathlib import Path
 
@@ -27,6 +26,13 @@ from src.domain.library.exceptions import InvalidEbookError
 from src.infrastructure.library.services import epub_publication_parser
 from src.infrastructure.library.services.epub_parser_service import EpubParserService
 from src.infrastructure.library.services.epub_publication_parser import read_publication
+from tests.epub_builders import (
+    DOCUMENT,
+    NAV_ITEM,
+    build_epub,
+    container_xml,
+    nav_document,
+)
 
 _: PublicationParserProtocol = EpubParserService()
 
@@ -35,15 +41,7 @@ MINIMAL_EPUB = FIXTURES / "minimal.epub"
 NESTED_TOC_EPUB = FIXTURES / "nested_toc.epub"
 FIXED_LAYOUT_EPUB = FIXTURES / "fixed_layout.epub"
 
-DEFAULT_IDENTIFIERS = '<dc:identifier id="bookid">urn:uuid:hand-built</dc:identifier>'
-DOCUMENT = (
-    b'<?xml version="1.0" encoding="UTF-8"?>'
-    b'<html xmlns="http://www.w3.org/1999/xhtml"><head><title>Page</title></head>'
-    b"<body><p>Hi there.</p></body></html>"
-)
-
 CHAPTER_ITEM = '<item id="ch1" href="chapter1.xhtml" media-type="application/xhtml+xml"/>'
-NAV_ITEM = '<item id="nav" href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/>'
 NCX_ITEM = '<item id="ncx" href="toc.ncx" media-type="application/x-dtbncx+xml"/>'
 CHAPTER_SPINE = '<itemref idref="ch1"/>'
 
@@ -54,25 +52,6 @@ EOCD_ENTRY_COUNT_OFFSET = 10
 OVERFULL_ENTRIES = 70_000
 # Measured: `zipfile.ZipFile` peaks here building its `ZipInfo` per member.
 COST_OF_OPENING_OVERFULL = 38 * 1024**2
-
-
-def container_xml(rootfile: str = '<rootfile full-path="content.opf"/>') -> str:
-    return (
-        '<?xml version="1.0" encoding="UTF-8"?>'
-        '<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">'
-        f"<rootfiles>{rootfile}</rootfiles></container>"
-    )
-
-
-def nav_document(
-    list_items: str, attributes: str = 'epub:type="toc"', preceded_by: str = ""
-) -> str:
-    return (
-        '<?xml version="1.0" encoding="UTF-8"?>'
-        '<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops">'
-        "<head><title>Contents</title></head>"
-        f"<body>{preceded_by}<nav {attributes}><ol>{list_items}</ol></nav></body></html>"
-    )
 
 
 def ncx_document(nav_points: str) -> str:
@@ -88,53 +67,6 @@ def nav_point(label: str, src: str, children: str = "") -> str:
         f"<navPoint><navLabel><text>{label}</text></navLabel>"
         f'<content src="{src}"/>{children}</navPoint>'
     )
-
-
-def build_epub(
-    manifest_items: str,
-    spine: str,
-    files: tuple[str, ...] = (),
-    unique_identifier: str = "bookid",
-    identifiers: str = DEFAULT_IDENTIFIERS,
-    extra_metadata: str = "",
-    opf_name: str = "content.opf",
-    container: str | None = None,
-    spine_toc: str | None = None,
-    documents: Mapping[str, str] | None = None,
-) -> bytes:
-    """Assemble an EPUB by hand, so a broken or hostile one reads as such in the diff.
-
-    What the archive really holds (``files``, and ``documents`` for a member
-    whose content matters) is deliberately separate from what the manifest
-    promises: a manifest naming a file that is not there is one of the shapes
-    under test.
-    """
-    package = (
-        '<?xml version="1.0" encoding="UTF-8"?>'
-        '<package xmlns="http://www.idpf.org/2007/opf" version="3.0" '
-        f'unique-identifier="{unique_identifier}">'
-        '<metadata xmlns:dc="http://purl.org/dc/elements/1.1/">'
-        f"{identifiers}<dc:title>Hand Built</dc:title><dc:language>en</dc:language>"
-        f"{extra_metadata}</metadata>"
-        f"<manifest>{manifest_items}</manifest>"
-        f"<spine{f' toc="{spine_toc}"' if spine_toc is not None else ''}>{spine}</spine></package>"
-    )
-
-    out = BytesIO()
-    with zipfile.ZipFile(out, "w") as archive:
-        archive.writestr(zipfile.ZipInfo("mimetype"), "application/epub+zip", zipfile.ZIP_STORED)
-        archive.writestr(
-            "META-INF/container.xml",
-            container
-            if container is not None
-            else container_xml(f'<rootfile full-path="{opf_name}"/>'),
-        )
-        archive.writestr(opf_name, package)
-        for name in files:
-            archive.writestr(name, DOCUMENT)
-        for name, content in (documents or {}).items():
-            archive.writestr(name, content)
-    return out.getvalue()
 
 
 def epub_with_nav(nav: str) -> bytes:

--- a/backend/tests/unit/infrastructure/web_reader/queries/test_publication_resource_query.py
+++ b/backend/tests/unit/infrastructure/web_reader/queries/test_publication_resource_query.py
@@ -1,0 +1,241 @@
+"""Tests for the publication-resource read model."""
+
+import zipfile
+from dataclasses import replace
+from io import BytesIO
+from pathlib import Path
+from urllib.parse import quote
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.application.web_reader.publications import (
+    ParsedPublication,
+    PublicationMetadata,
+    PublicationResource,
+)
+from src.domain.common.value_objects.ids import BookId, UserId
+from src.domain.library.exceptions import EbookFileNotFoundError, InvalidEbookError
+from src.domain.web_reader.exceptions import PublicationResourceNotFoundError
+from src.infrastructure.library.repositories.file_repository import FileRepository
+from src.infrastructure.web_reader.queries.publication_resource_query import (
+    PublicationResourceQuery,
+)
+from src.models import Book
+from tests.conftest import create_test_book
+from tests.readium_helpers import (
+    another_users_book,
+    fixture_bytes,
+    parse_fixture,
+    store_publication,
+)
+
+DEFAULT_USER_ID = 1
+FILE_NAME = "nested_toc.epub"
+XHTML = "application/xhtml+xml"
+
+
+@pytest.fixture
+def query(db_session: AsyncSession) -> PublicationResourceQuery:
+    return PublicationResourceQuery(db=db_session, file_repository=FileRepository())
+
+
+@pytest.fixture
+async def nested_toc_book(db_session: AsyncSession, test_book: Book, storage_dir: Path) -> Book:
+    await store_nested_toc(db_session, test_book, storage_dir)
+    return test_book
+
+
+async def store_nested_toc(db_session: AsyncSession, book: Book, storage_dir: Path) -> None:
+    await store_publication(db_session, book, parse_fixture("nested_toc"), FILE_NAME)
+    write_epub(storage_dir, fixture_bytes("nested_toc"))
+
+
+def member_of(name: str, path: str) -> bytes:
+    with zipfile.ZipFile(BytesIO(fixture_bytes(name))) as archive:
+        return archive.read(path)
+
+
+def write_epub(storage_dir: Path, content: bytes) -> None:
+    storage_dir.mkdir(parents=True, exist_ok=True)
+    (storage_dir / FILE_NAME).write_bytes(content)
+
+
+def archive_of(members: dict[str, bytes]) -> bytes:
+    out = BytesIO()
+    with zipfile.ZipFile(out, "w") as archive:
+        for name, body in members.items():
+            archive.writestr(name, body)
+    return out.getvalue()
+
+
+def publication_of(*resources: PublicationResource) -> ParsedPublication:
+    """An index written by hand, for archives no fixture EPUB describes."""
+    return ParsedPublication(
+        metadata=PublicationMetadata(
+            title="Hand Built", author=None, language="en", identifier=None
+        ),
+        reading_order=resources,
+        resources=(),
+        toc=(),
+        content_hash="0" * 64,
+    )
+
+
+async def test_reading_order_document_is_served_verbatim(
+    query: PublicationResourceQuery, nested_toc_book: Book
+) -> None:
+    view = await query.get_publication_resource(
+        BookId(nested_toc_book.id), UserId(DEFAULT_USER_ID), "EPUB/text/chapter 1.xhtml"
+    )
+
+    assert view is not None
+    assert view.content == member_of("nested_toc", "EPUB/text/chapter 1.xhtml")
+    assert view.media_type == "application/xhtml+xml"
+
+
+async def test_supporting_resource_is_served(
+    query: PublicationResourceQuery, nested_toc_book: Book
+) -> None:
+    view = await query.get_publication_resource(
+        BookId(nested_toc_book.id), UserId(DEFAULT_USER_ID), "EPUB/styles/main.css"
+    )
+
+    assert view is not None
+    assert view.content == member_of("nested_toc", "EPUB/styles/main.css")
+    assert view.media_type == "text/css"
+
+
+async def test_member_with_non_ascii_name_is_reached_by_its_decoded_path(
+    query: PublicationResourceQuery, nested_toc_book: Book
+) -> None:
+    view = await query.get_publication_resource(
+        BookId(nested_toc_book.id), UserId(DEFAULT_USER_ID), "EPUB/text/luku-ääni.xhtml"
+    )
+
+    assert view is not None
+    assert view.content == member_of("nested_toc", "EPUB/text/luku-ääni.xhtml")
+
+
+@pytest.mark.parametrize(
+    "path",
+    ["EPUB/package.opf", "META-INF/container.xml", "mimetype", "../../etc/passwd"],
+)
+async def test_path_the_publication_does_not_list_is_not_found(
+    query: PublicationResourceQuery, nested_toc_book: Book, path: str
+) -> None:
+    with pytest.raises(PublicationResourceNotFoundError):
+        await query.get_publication_resource(
+            BookId(nested_toc_book.id), UserId(DEFAULT_USER_ID), path
+        )
+
+
+async def test_listed_resource_the_archive_lacks_is_not_found(
+    query: PublicationResourceQuery,
+    db_session: AsyncSession,
+    test_book: Book,
+    storage_dir: Path,
+) -> None:
+    publication = parse_fixture("minimal")
+    missing = PublicationResource(
+        href="OEBPS/promised.xhtml", media_type="application/xhtml+xml", size=10
+    )
+    await store_publication(
+        db_session,
+        test_book,
+        replace(publication, resources=(*publication.resources, missing)),
+        FILE_NAME,
+    )
+    write_epub(storage_dir, fixture_bytes("minimal"))
+
+    with pytest.raises(PublicationResourceNotFoundError):
+        await query.get_publication_resource(
+            BookId(test_book.id), UserId(DEFAULT_USER_ID), "OEBPS/promised.xhtml"
+        )
+
+
+async def test_another_users_book_reads_as_absent(
+    query: PublicationResourceQuery, db_session: AsyncSession, storage_dir: Path
+) -> None:
+    book = await another_users_book(db_session)
+    await store_nested_toc(db_session, book, storage_dir)
+
+    view = await query.get_publication_resource(
+        BookId(book.id), UserId(DEFAULT_USER_ID), "EPUB/text/chapter 1.xhtml"
+    )
+
+    assert view is None
+
+
+async def test_member_whose_name_contains_a_percent_sign_round_trips(
+    query: PublicationResourceQuery,
+    db_session: AsyncSession,
+    test_book: Book,
+    storage_dir: Path,
+) -> None:
+    member = "chapter%20one.xhtml"
+    body = b"<html><body>Literal percent.</body></html>"
+    await store_publication(
+        db_session,
+        test_book,
+        publication_of(PublicationResource(href=quote(member), media_type=XHTML, size=len(body))),
+        FILE_NAME,
+    )
+    write_epub(storage_dir, archive_of({member: body}))
+
+    view = await query.get_publication_resource(
+        BookId(test_book.id), UserId(DEFAULT_USER_ID), member
+    )
+
+    assert view is not None
+    assert view.content == body
+
+
+async def test_the_requested_books_index_is_the_one_read(
+    query: PublicationResourceQuery,
+    db_session: AsyncSession,
+    test_book: Book,
+    nested_toc_book: Book,
+    storage_dir: Path,
+) -> None:
+    other = await create_test_book(
+        db_session, user_id=DEFAULT_USER_ID, title="Minimal", author="Nobody"
+    )
+    await store_publication(db_session, other, parse_fixture("minimal"), "minimal.epub")
+    (storage_dir / "minimal.epub").write_bytes(fixture_bytes("minimal"))
+
+    view = await query.get_publication_resource(
+        BookId(other.id), UserId(DEFAULT_USER_ID), "OEBPS/chapter1.xhtml"
+    )
+
+    assert view is not None
+    assert view.content == member_of("minimal", "OEBPS/chapter1.xhtml")
+
+
+async def test_stored_file_that_is_not_an_archive_is_an_invalid_ebook(
+    query: PublicationResourceQuery,
+    db_session: AsyncSession,
+    test_book: Book,
+    storage_dir: Path,
+) -> None:
+    await store_publication(db_session, test_book, parse_fixture("nested_toc"), FILE_NAME)
+    write_epub(storage_dir, b"not a zip at all")
+
+    with pytest.raises(InvalidEbookError):
+        await query.get_publication_resource(
+            BookId(test_book.id), UserId(DEFAULT_USER_ID), "EPUB/text/chapter 1.xhtml"
+        )
+
+
+async def test_index_whose_epub_is_not_stored_raises(
+    query: PublicationResourceQuery,
+    db_session: AsyncSession,
+    test_book: Book,
+    storage_dir: Path,
+) -> None:
+    await store_publication(db_session, test_book, parse_fixture("nested_toc"), FILE_NAME)
+
+    with pytest.raises(EbookFileNotFoundError):
+        await query.get_publication_resource(
+            BookId(test_book.id), UserId(DEFAULT_USER_ID), "EPUB/text/chapter 1.xhtml"
+        )

--- a/frontend/src/api/generated/readium/readium.ts
+++ b/frontend/src/api/generated/readium/readium.ts
@@ -283,3 +283,131 @@ export function useGetReadiumPositions<
 
   return withQueryKey(query, queryOptions.queryKey);
 }
+
+/**
+ * Get one file of a book's publication, unchanged.
+ *
+ * ``path`` is a manifest href with the ``resources/`` prefix stripped and
+ * decoded once by ASGI, which is the archive member's own name. Only the files
+ * the manifest names are reachable.
+ * @summary Get Readium Resource
+ */
+export const getReadiumResource = (bookId: number, path: string, signal?: AbortSignal) => {
+  return axiosInstance<Blob>({
+    url: `/api/v1/readium/books/${bookId}/resources/${path}`,
+    method: 'GET',
+    responseType: 'blob',
+    signal,
+  });
+};
+
+export const getGetReadiumResourceQueryKey = (bookId: number, path: string) => {
+  return [`/api/v1/readium/books/${bookId}/resources/${path}`] as const;
+};
+
+export const getGetReadiumResourceQueryOptions = <
+  TData = Awaited<ReturnType<typeof getReadiumResource>>,
+  TError = HTTPValidationError,
+>(
+  bookId: number,
+  path: string,
+  options?: {
+    query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof getReadiumResource>>, TError, TData>>;
+  }
+) => {
+  const { query: queryOptions } = options ?? {};
+
+  const queryKey = queryOptions?.queryKey ?? getGetReadiumResourceQueryKey(bookId, path);
+
+  const queryFn: QueryFunction<Awaited<ReturnType<typeof getReadiumResource>>> = ({ signal }) =>
+    getReadiumResource(bookId, path, signal);
+
+  return {
+    queryKey,
+    queryFn,
+    enabled: bookId !== null && bookId !== undefined && path !== null && path !== undefined,
+    ...queryOptions,
+  } as UseQueryOptions<Awaited<ReturnType<typeof getReadiumResource>>, TError, TData> & {
+    queryKey: DataTag<QueryKey, TData, TError>;
+  };
+};
+
+export type GetReadiumResourceQueryResult = NonNullable<
+  Awaited<ReturnType<typeof getReadiumResource>>
+>;
+export type GetReadiumResourceQueryError = HTTPValidationError;
+
+export function useGetReadiumResource<
+  TData = Awaited<ReturnType<typeof getReadiumResource>>,
+  TError = HTTPValidationError,
+>(
+  bookId: number,
+  path: string,
+  options: {
+    query: Partial<UseQueryOptions<Awaited<ReturnType<typeof getReadiumResource>>, TError, TData>> &
+      Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof getReadiumResource>>,
+          TError,
+          Awaited<ReturnType<typeof getReadiumResource>>
+        >,
+        'initialData'
+      >;
+  },
+  queryClient?: QueryClient
+): DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+export function useGetReadiumResource<
+  TData = Awaited<ReturnType<typeof getReadiumResource>>,
+  TError = HTTPValidationError,
+>(
+  bookId: number,
+  path: string,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getReadiumResource>>, TError, TData>
+    > &
+      Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof getReadiumResource>>,
+          TError,
+          Awaited<ReturnType<typeof getReadiumResource>>
+        >,
+        'initialData'
+      >;
+  },
+  queryClient?: QueryClient
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+export function useGetReadiumResource<
+  TData = Awaited<ReturnType<typeof getReadiumResource>>,
+  TError = HTTPValidationError,
+>(
+  bookId: number,
+  path: string,
+  options?: {
+    query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof getReadiumResource>>, TError, TData>>;
+  },
+  queryClient?: QueryClient
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+/**
+ * @summary Get Readium Resource
+ */
+
+export function useGetReadiumResource<
+  TData = Awaited<ReturnType<typeof getReadiumResource>>,
+  TError = HTTPValidationError,
+>(
+  bookId: number,
+  path: string,
+  options?: {
+    query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof getReadiumResource>>, TError, TData>>;
+  },
+  queryClient?: QueryClient
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+  const queryOptions = getGetReadiumResourceQueryOptions(bookId, path, options);
+
+  const query = useQuery(queryOptions, queryClient) as UseQueryResult<TData, TError> & {
+    queryKey: DataTag<QueryKey, TData, TError>;
+  };
+
+  return withQueryKey(query, queryOptions.queryKey);
+}


### PR DESCRIPTION
Closes #798. R1.5 of #792 (R1 — Publication streaming, second pass).

`GET /api/v1/readium/books/{id}/resources/{path:path}` hands back one member of a book's EPUB unchanged, under the media type the stored index declares for it.

## The three commits

| Commit | What |
|---|---|
| `eeaf00ea` | Read path: query port, adapter, use case, domain exceptions |
| `5c93d649` | The route, its three headers, the middleware guard, 20 API tests |
| `902dfb38` | Regenerated `openapi.json` and the orval client |

## How access works

Membership in the `book_publications` row is the whole access rule. The keys come from the reading order and the resource list, so the package document, `META-INF/`, the `mimetype` member and any path climbing out of the container are absent by construction — there is no second normalisation step to get wrong.

## The response headers

**`Content-Type`** is a raw header rather than `Response(media_type=...)`, which would append `; charset=utf-8` to every `text/*` type. The bytes go out unchanged and an EPUB's documents declare their own encoding. The declared type is replaced unless it is a plain `type/subtype`: it is copied from a file the user uploaded, and a newline in it would smuggle a second header into the response.

**`Cache-Control: private`** — a publication is one user's book.

**`Content-Security-Policy: sandbox`** is for the request the frontend hardening cannot see. Readium fetches a resource and frames a blob built from the text, so this header never reaches the path the reader takes. A browser navigating straight at the URL is the case it exists for: same-origin markup the user uploaded, given an opaque origin with no scripts, forms or top-level navigation.

`SecurityHeadersMiddleware` now defers to a policy a route already set. `MutableHeaders` assignment replaces rather than appends, so without the guard the app-wide policy would widen this endpoint back to `script-src 'self'` outside development — and only there.

## Two departures worth a reviewer's eye

**The read is bounded by the archive's own `ZipInfo`, not the row's `size`,** against the ticket's wording. With no per-member cap in play the row's number buys nothing over the member's own declaration, and a stale row would make the read truncate silently. Knock-on: `PublicationResource.size` no longer claims to be the source of a conditional request's `Content-Length`.

**`tests/epub_builders.py` moves hand-built-EPUB helpers out of `test_epub_publication_parser.py`,** which is otherwise unrelated to this ticket. The API tests needed the same builders, and a fourth hand-rolled copy was the alternative. Mechanical move, no call site changed.

## Two bugs the review passes caught

Both confirmed by running them before acting:

- A failed index write answered `BookNotFoundError` for a book that plainly exists. `GetPublicationUseCase._store` swallows write failures by design, so the manifest served that book normally while every resource request 404'd. Now `PublicationIndexUnavailableError`, which maps to 500 and logs with a traceback.
- A corrupt stored EPUB escaped as `zipfile.BadZipFile`, past a docstring promising `InvalidEbookError`. The `ZipFile(...)` construction sat outside the guarded region.

Four tests that could not fail were deleted, each after re-running the mutations to confirm it was redundant rather than load-bearing.

## Out of scope

- **ETags and 304** — #799, unblocked by this.
- **The app-wide CSP's `blob:` directives** — #802.
- **Cookie auth on this route** — #800/#801. Bearer-only here.
- **A per-member size cap** — #815, filed against the upload boundary. A 0.39 MiB EPUB whose one member inflates to 400 MiB (800 MiB peak) is admissible today; the boundary that admits the artefact is the only place that can refuse it outright.

## Verification

```
ruff check src tests      All checks passed!
ruff format --check       715 files already formatted
pyright                   0 errors, 0 warnings, 0 informations
lint-imports              Contracts: 5 kept, 0 broken
pytest                    1207 passed, 31 warnings in 22.17s
make duplication-check    121 clones · 2.1%   (threshold 2.55, untouched)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DZ2vdUGgLAsfUzU1S46PVU