### PR TITLE
Conditional requests for publication resources (#799)

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -4235,6 +4235,9 @@
               }
             }
           },
+          "304": {
+            "description": "The caller already holds this version."
+          },
           "422": {
             "description": "Validation Error",
             "content": {

--- a/backend/src/application/web_reader/queries/get_publication_resource_use_case.py
+++ b/backend/src/application/web_reader/queries/get_publication_resource_use_case.py
@@ -21,7 +21,7 @@ class GetPublicationResourceUseCase:
         self.get_publication_use_case = get_publication_use_case
 
     async def get_publication_resource(
-        self, book_id: int, user_id: int, path: str
+        self, book_id: int, user_id: int, path: str, known_versions: frozenset[str] | None
     ) -> PublicationResourceView:
         """Return the file at ``path`` inside the book's EPUB container.
 
@@ -33,7 +33,7 @@ class GetPublicationResourceUseCase:
             PublicationResourceNotFoundError: If the publication lists no such file.
         """
         resource = await self.publication_resource_query.get_publication_resource(
-            BookId(book_id), UserId(user_id), path
+            BookId(book_id), UserId(user_id), path, known_versions
         )
         if resource is not None:
             return resource
@@ -42,7 +42,7 @@ class GetPublicationResourceUseCase:
         # not own -- so past this point the book exists.
         await self.get_publication_use_case.get_publication(book_id, user_id)
         resource = await self.publication_resource_query.get_publication_resource(
-            BookId(book_id), UserId(user_id), path
+            BookId(book_id), UserId(user_id), path, known_versions
         )
         if resource is None:
             raise PublicationIndexUnavailableError(book_id)

--- a/backend/src/application/web_reader/queries/publication_resource.py
+++ b/backend/src/application/web_reader/queries/publication_resource.py
@@ -12,22 +12,28 @@ class PublicationResourceView:
 
     Attributes:
         media_type: The media type the stored index declares for the file.
-        content: The member's decompressed bytes.
+        content: The member's decompressed bytes, or ``None`` when the caller
+            already holds this version -- in which case the member was never
+            read, which is the point of asking rather than an optimisation.
+        version: An opaque token for the stored EPUB these bytes came from.
     """
 
     media_type: str
-    content: bytes
+    content: bytes | None
+    version: str
 
 
 class PublicationResourceQueryProtocol(Protocol):
     async def get_publication_resource(
-        self, book_id: BookId, user_id: UserId, path: str
+        self, book_id: BookId, user_id: UserId, path: str, known_versions: frozenset[str] | None
     ) -> PublicationResourceView | None:
         """Return one file of a user's publication, or ``None`` when no index is stored.
 
         ``path`` is the file's path inside the EPUB container, decoded exactly
         once -- a manifest href with its percent-encoding undone, which is the
-        archive member's own name.
+        archive member's own name. ``known_versions`` holds the versions the
+        caller already has; ``None`` is a caller that holds whatever version
+        there is, and is not a version itself so that no version can spell it.
 
         An absent index is not an absent book: ``None`` covers both a book the
         user does not own and one whose index has yet to be derived, and the
@@ -38,5 +44,8 @@ class PublicationResourceQueryProtocol(Protocol):
             InvalidEbookError: If the archive or the member cannot be read.
             PublicationResourceNotFoundError: If the index lists no such file,
                 or the archive holds no such member.
+
+        Neither the missing EPUB nor the missing member is reached once a
+        version matched, which is answered before the file store is read.
         """
         ...

--- a/backend/src/infrastructure/web_reader/queries/publication_resource_query.py
+++ b/backend/src/infrastructure/web_reader/queries/publication_resource_query.py
@@ -26,7 +26,7 @@ class PublicationResourceQuery:
         self.file_repository = file_repository
 
     async def get_publication_resource(
-        self, book_id: BookId, user_id: UserId, path: str
+        self, book_id: BookId, user_id: UserId, path: str, known_versions: frozenset[str] | None
     ) -> PublicationResourceView | None:
         """Return one file of a user's publication, or ``None`` when no index is stored."""
         result = await self.db.execute(publication_row(book_id, user_id))
@@ -36,15 +36,23 @@ class PublicationResourceQuery:
 
         publication = publication_from_json(orm.publication, orm.content_hash)
         media_type = _media_types(publication).get(path)
+        # Membership is checked first so that a path the publication does not
+        # list is a 404 rather than a 304: a precondition narrows a request that
+        # would otherwise succeed (RFC 9110 §13.2), never turns a refusal into
+        # "your copy is current".
         if media_type is None:
             raise PublicationResourceNotFoundError(path)
+
+        version = publication.content_hash
+        if known_versions is None or version in known_versions:
+            return PublicationResourceView(media_type=media_type, content=None, version=version)
 
         content = await self.file_repository.get_epub(orm.file_name)
         if content is None:
             raise EbookFileNotFoundError(book_id.value)
 
         member = await asyncio.to_thread(_read_member, content, path)
-        return PublicationResourceView(media_type=media_type, content=member)
+        return PublicationResourceView(media_type=media_type, content=member, version=version)
 
 
 def _media_types(publication: ParsedPublication) -> dict[str, str]:

--- a/backend/src/infrastructure/web_reader/routers/readium.py
+++ b/backend/src/infrastructure/web_reader/routers/readium.py
@@ -65,6 +65,11 @@ RESOURCE_CONTENT_SECURITY_POLICY = "sandbox"
 _MEDIA_TYPE = re.compile(r"[A-Za-z0-9][A-Za-z0-9!#$&^_.+-]*/[A-Za-z0-9][A-Za-z0-9!#$&^_.+-]*")
 FALLBACK_MEDIA_TYPE = "application/octet-stream"
 
+# An entity-tag as RFC 9110 §8.8.3 spells one: an optionally `W/`-prefixed
+# quoted string, whose content is any visible character but the quote itself.
+# The comparison for a GET is weak, so the prefix is read and discarded.
+_ENTITY_TAG = re.compile(r'(?:W/)?"(?P<version>[\x21\x23-\x7e]*)"')
+
 
 class WebpubJSONResponse(JSONResponse):
     """JSON served as ``application/webpub+json``, which is what a navigator looks for."""
@@ -144,11 +149,13 @@ async def get_readium_positions(
             "content": {"*/*": {"schema": {"type": "string", "format": "binary"}}},
             "description": "The file, under the media type the publication declares for it.",
         },
+        status.HTTP_304_NOT_MODIFIED: {"description": "The caller already holds this version."},
     },
 )
 async def get_readium_resource(
     book_id: int,
     path: str,
+    request: Request,
     current_user: Annotated[User, Depends(get_current_user)],
     use_case: GetPublicationResourceUseCase = Depends(
         inject_use_case(container.web_reader.get_publication_resource_use_case)
@@ -164,18 +171,44 @@ async def get_readium_resource(
         book_id=book_id,
         user_id=current_user.id.value,
         path=path,
+        known_versions=_known_versions(request.headers.get("if-none-match")),
     )
+    # A 304 updates the headers of the copy a cache already holds (RFC 9111
+    # §4.3.4), so a policy left off one is a policy revalidation strips from a
+    # stored response.
+    headers = {
+        "ETag": f'"{resource.version}"',
+        "Cache-Control": RESOURCE_CACHE_CONTROL,
+        "Content-Security-Policy": RESOURCE_CONTENT_SECURITY_POLICY,
+    }
+    if resource.content is None:
+        return Response(status_code=status.HTTP_304_NOT_MODIFIED, headers=headers)
     # Content-Type is a raw header rather than `media_type`, which would append
     # `; charset=utf-8` to every `text/*` type. The bytes go out unchanged and an
     # EPUB's documents declare their own encoding.
-    return Response(
-        content=resource.content,
-        headers={
-            "Content-Type": _servable_media_type(resource.media_type),
-            "Cache-Control": RESOURCE_CACHE_CONTROL,
-            "Content-Security-Policy": RESOURCE_CONTENT_SECURITY_POLICY,
-        },
-    )
+    content_type = _servable_media_type(resource.media_type)
+    return Response(content=resource.content, headers=headers | {"Content-Type": content_type})
+
+
+def _known_versions(if_none_match: str | None) -> frozenset[str] | None:
+    """Read the versions a caller says it already holds out of ``If-None-Match``.
+
+    ``None`` is the wildcard, and is deliberately not a version: ``*`` is a
+    legal entity-tag character, so a sentinel inside the set would make the
+    quoted tag ``"*"`` indistinguishable from it.
+
+    Anything that is not an entity-tag (RFC 9110 §8.8.3) is dropped rather than
+    repaired: answering 304 to a validator the standard does not define tells a
+    reader its copy is current on no authority, where serving the file does not.
+    """
+    if not if_none_match:
+        return frozenset()
+    # `*` stands for any current representation (RFC 9110 §13.1.2), and only on
+    # its own -- mixed with tags it is not a header the grammar defines.
+    if if_none_match.strip() == "*":
+        return None
+    parsed = (_ENTITY_TAG.fullmatch(tag.strip()) for tag in if_none_match.split(","))
+    return frozenset(tag.group("version") for tag in parsed if tag is not None)
 
 
 def _servable_media_type(declared: str) -> str:

--- a/backend/tests/test_readium_resources.py
+++ b/backend/tests/test_readium_resources.py
@@ -24,6 +24,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from starlette import status
 
 from src import models
+from src.infrastructure.library.repositories.file_repository import FileRepository
 from src.infrastructure.library.services.epub_publication_parser import read_publication
 from src.infrastructure.web_reader.repositories.publication_repository import PublicationRepository
 from src.main import settings as main_settings
@@ -331,3 +332,179 @@ class TestOnlyPublicationFilesAreReachable:
 
         assert response.status_code == status.HTTP_200_OK, response.text
         assert response.headers["content-type"] == "application/octet-stream"
+
+
+def one_chapter_epub(toc_title: str) -> bytes:
+    """A publication whose one chapter is fixed and whose book's bytes are not.
+
+    The chapter is identical across titles, so a reader holding it is only
+    re-served if the tag follows the book rather than the member.
+    """
+    return build_epub(
+        manifest_items='<item id="c1" href="c1.xhtml" media-type="application/xhtml+xml"/>',
+        spine='<itemref idref="c1"/>',
+        nav_links=f'<li><a href="c1.xhtml">{toc_title}</a></li>',
+        files=("c1.xhtml",),
+    )
+
+
+class TestConditionalRequests:
+    """The entity tag, and what a reader that already holds a file is told."""
+
+    async def test_a_matching_if_none_match_is_answered_304(
+        self, client: AsyncClient, nested_toc_book: models.Book
+    ) -> None:
+        """Should send the headers and no body when the caller's copy is current."""
+        etag = (await client.get(resource_url(nested_toc_book.id, CHAPTER_1))).headers["etag"]
+
+        response = await client.get(
+            resource_url(nested_toc_book.id, CHAPTER_1), headers={"If-None-Match": etag}
+        )
+
+        assert response.status_code == status.HTTP_304_NOT_MODIFIED
+        assert response.content == b""
+        assert response.headers["etag"] == etag
+        assert etag.startswith('"'), "a weak response tag would still match itself"
+        assert response.headers["cache-control"] == "private"
+        assert response.headers["content-security-policy"] == "sandbox"
+
+    async def test_a_weak_validator_still_matches(
+        self, client: AsyncClient, nested_toc_book: models.Book
+    ) -> None:
+        """Should compare tags weakly, as RFC 9110 requires for a GET."""
+        etag = (await client.get(resource_url(nested_toc_book.id, CHAPTER_1))).headers["etag"]
+
+        response = await client.get(
+            resource_url(nested_toc_book.id, CHAPTER_1), headers={"If-None-Match": f"W/{etag}"}
+        )
+
+        assert response.status_code == status.HTTP_304_NOT_MODIFIED
+
+    async def test_a_stale_if_none_match_is_answered_with_the_file(
+        self, client: AsyncClient, nested_toc_book: models.Book
+    ) -> None:
+        """Should serve the file when the caller holds some other version."""
+        response = await client.get(
+            resource_url(nested_toc_book.id, CHAPTER_1),
+            headers={"If-None-Match": '"not-the-one-we-serve"'},
+        )
+
+        assert response.status_code == status.HTTP_200_OK, response.text
+        assert response.content
+
+    async def test_a_wildcard_validator_matches(
+        self, client: AsyncClient, nested_toc_book: models.Book
+    ) -> None:
+        """Should read a lone ``*`` as any current representation (RFC 9110 §13.1.2)."""
+        response = await client.get(
+            resource_url(nested_toc_book.id, CHAPTER_1), headers={"If-None-Match": "*"}
+        )
+
+        assert response.status_code == status.HTTP_304_NOT_MODIFIED
+
+    async def test_a_quoted_star_is_a_tag_rather_than_the_wildcard(
+        self, client: AsyncClient, nested_toc_book: models.Book
+    ) -> None:
+        """Should serve the file to a caller holding the entity-tag ``"*"``.
+
+        ``*`` is a legal entity-tag character, so a wildcard carried inside the
+        set of known versions would be indistinguishable from this tag.
+        """
+        response = await client.get(
+            resource_url(nested_toc_book.id, CHAPTER_1), headers={"If-None-Match": '"*"'}
+        )
+
+        assert response.status_code == status.HTTP_200_OK, response.text
+        assert response.content
+
+    async def test_the_etag_changes_when_the_books_epub_is_replaced(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        test_book: models.Book,
+        storage_dir: Path,
+    ) -> None:
+        """Should re-tag a chapter whose own bytes are unchanged but whose book's are not."""
+        await store_indexed_epub(db_session, test_book, storage_dir, one_chapter_epub("One"))
+        before = await client.get(resource_url(test_book.id, "c1.xhtml"))
+
+        await store_indexed_epub(db_session, test_book, storage_dir, one_chapter_epub("Two"))
+        after = await client.get(
+            resource_url(test_book.id, "c1.xhtml"),
+            headers={"If-None-Match": before.headers["etag"]},
+        )
+
+        assert after.status_code == status.HTTP_200_OK, after.text
+        assert after.content == before.content
+        assert after.headers["etag"] != before.headers["etag"]
+
+    @pytest.mark.parametrize(
+        ("validator", "why"),
+        [
+            ("{version}", "a bare token is not an entity-tag"),
+            ('"x", *', "`*` is only a wildcard on its own"),
+        ],
+    )
+    async def test_a_malformed_validator_does_not_match(
+        self, client: AsyncClient, nested_toc_book: models.Book, validator: str, why: str
+    ) -> None:
+        """Should serve the file when the validator is not an entity-tag.
+
+        RFC 9110 §8.8.3 spells an entity-tag as an optionally ``W/``-prefixed
+        *quoted* string, so unwrapping optional quotes instead of reading the
+        grammar would tell a client that dropped them its copy was current.
+        """
+        etag = (await client.get(resource_url(nested_toc_book.id, CHAPTER_1))).headers["etag"]
+        malformed = validator.format(version=etag.strip('"'))
+        assert malformed != etag
+
+        response = await client.get(
+            resource_url(nested_toc_book.id, CHAPTER_1), headers={"If-None-Match": malformed}
+        )
+
+        assert response.status_code == status.HTTP_200_OK, why
+        assert response.content
+
+    async def test_a_conditional_request_reads_no_file(
+        self,
+        client: AsyncClient,
+        nested_toc_book: models.Book,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Should answer 304 without fetching the EPUB at all.
+
+        Only the ordering of the version check against the file read separates
+        the two from outside, so the spy is the assertion.
+        """
+        etag = (await client.get(resource_url(nested_toc_book.id, CHAPTER_1))).headers["etag"]
+        calls: list[str | None] = []
+        original = FileRepository.get_epub
+
+        async def counting(self: FileRepository, filename: str | None) -> bytes | None:
+            calls.append(filename)
+            return await original(self, filename)
+
+        monkeypatch.setattr(FileRepository, "get_epub", counting)
+
+        response = await client.get(
+            resource_url(nested_toc_book.id, CHAPTER_1), headers={"If-None-Match": etag}
+        )
+
+        assert response.status_code == status.HTTP_304_NOT_MODIFIED
+        assert calls == []
+
+    async def test_a_path_the_publication_does_not_list_is_not_found_however_it_is_asked_for(
+        self, client: AsyncClient, nested_toc_book: models.Book
+    ) -> None:
+        """Should 404 a path the manifest omits even to a caller holding the book's tag.
+
+        A precondition narrows a request that would otherwise succeed (RFC 9110
+        §13.2); it must not turn a refusal into "your copy is current".
+        """
+        etag = (await client.get(resource_url(nested_toc_book.id, CHAPTER_1))).headers["etag"]
+
+        response = await client.get(
+            resource_url(nested_toc_book.id, "EPUB/package.opf"), headers={"If-None-Match": etag}
+        )
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND, response.text

--- a/backend/tests/unit/infrastructure/web_reader/queries/test_publication_resource_query.py
+++ b/backend/tests/unit/infrastructure/web_reader/queries/test_publication_resource_query.py
@@ -86,7 +86,10 @@ async def test_reading_order_document_is_served_verbatim(
     query: PublicationResourceQuery, nested_toc_book: Book
 ) -> None:
     view = await query.get_publication_resource(
-        BookId(nested_toc_book.id), UserId(DEFAULT_USER_ID), "EPUB/text/chapter 1.xhtml"
+        BookId(nested_toc_book.id),
+        UserId(DEFAULT_USER_ID),
+        "EPUB/text/chapter 1.xhtml",
+        known_versions=frozenset(),
     )
 
     assert view is not None
@@ -98,7 +101,10 @@ async def test_supporting_resource_is_served(
     query: PublicationResourceQuery, nested_toc_book: Book
 ) -> None:
     view = await query.get_publication_resource(
-        BookId(nested_toc_book.id), UserId(DEFAULT_USER_ID), "EPUB/styles/main.css"
+        BookId(nested_toc_book.id),
+        UserId(DEFAULT_USER_ID),
+        "EPUB/styles/main.css",
+        known_versions=frozenset(),
     )
 
     assert view is not None
@@ -110,7 +116,10 @@ async def test_member_with_non_ascii_name_is_reached_by_its_decoded_path(
     query: PublicationResourceQuery, nested_toc_book: Book
 ) -> None:
     view = await query.get_publication_resource(
-        BookId(nested_toc_book.id), UserId(DEFAULT_USER_ID), "EPUB/text/luku-ääni.xhtml"
+        BookId(nested_toc_book.id),
+        UserId(DEFAULT_USER_ID),
+        "EPUB/text/luku-ääni.xhtml",
+        known_versions=frozenset(),
     )
 
     assert view is not None
@@ -126,7 +135,7 @@ async def test_path_the_publication_does_not_list_is_not_found(
 ) -> None:
     with pytest.raises(PublicationResourceNotFoundError):
         await query.get_publication_resource(
-            BookId(nested_toc_book.id), UserId(DEFAULT_USER_ID), path
+            BookId(nested_toc_book.id), UserId(DEFAULT_USER_ID), path, known_versions=frozenset()
         )
 
 
@@ -150,7 +159,10 @@ async def test_listed_resource_the_archive_lacks_is_not_found(
 
     with pytest.raises(PublicationResourceNotFoundError):
         await query.get_publication_resource(
-            BookId(test_book.id), UserId(DEFAULT_USER_ID), "OEBPS/promised.xhtml"
+            BookId(test_book.id),
+            UserId(DEFAULT_USER_ID),
+            "OEBPS/promised.xhtml",
+            known_versions=frozenset(),
         )
 
 
@@ -161,7 +173,10 @@ async def test_another_users_book_reads_as_absent(
     await store_nested_toc(db_session, book, storage_dir)
 
     view = await query.get_publication_resource(
-        BookId(book.id), UserId(DEFAULT_USER_ID), "EPUB/text/chapter 1.xhtml"
+        BookId(book.id),
+        UserId(DEFAULT_USER_ID),
+        "EPUB/text/chapter 1.xhtml",
+        known_versions=frozenset(),
     )
 
     assert view is None
@@ -184,7 +199,7 @@ async def test_member_whose_name_contains_a_percent_sign_round_trips(
     write_epub(storage_dir, archive_of({member: body}))
 
     view = await query.get_publication_resource(
-        BookId(test_book.id), UserId(DEFAULT_USER_ID), member
+        BookId(test_book.id), UserId(DEFAULT_USER_ID), member, known_versions=frozenset()
     )
 
     assert view is not None
@@ -205,7 +220,10 @@ async def test_the_requested_books_index_is_the_one_read(
     (storage_dir / "minimal.epub").write_bytes(fixture_bytes("minimal"))
 
     view = await query.get_publication_resource(
-        BookId(other.id), UserId(DEFAULT_USER_ID), "OEBPS/chapter1.xhtml"
+        BookId(other.id),
+        UserId(DEFAULT_USER_ID),
+        "OEBPS/chapter1.xhtml",
+        known_versions=frozenset(),
     )
 
     assert view is not None
@@ -223,7 +241,10 @@ async def test_stored_file_that_is_not_an_archive_is_an_invalid_ebook(
 
     with pytest.raises(InvalidEbookError):
         await query.get_publication_resource(
-            BookId(test_book.id), UserId(DEFAULT_USER_ID), "EPUB/text/chapter 1.xhtml"
+            BookId(test_book.id),
+            UserId(DEFAULT_USER_ID),
+            "EPUB/text/chapter 1.xhtml",
+            known_versions=frozenset(),
         )
 
 
@@ -237,5 +258,8 @@ async def test_index_whose_epub_is_not_stored_raises(
 
     with pytest.raises(EbookFileNotFoundError):
         await query.get_publication_resource(
-            BookId(test_book.id), UserId(DEFAULT_USER_ID), "EPUB/text/chapter 1.xhtml"
+            BookId(test_book.id),
+            UserId(DEFAULT_USER_ID),
+            "EPUB/text/chapter 1.xhtml",
+            known_versions=frozenset(),
         )

--- a/frontend/src/api/generated/readium/readium.ts
+++ b/frontend/src/api/generated/readium/readium.ts
@@ -307,7 +307,7 @@ export const getGetReadiumResourceQueryKey = (bookId: number, path: string) => {
 
 export const getGetReadiumResourceQueryOptions = <
   TData = Awaited<ReturnType<typeof getReadiumResource>>,
-  TError = HTTPValidationError,
+  TError = void | HTTPValidationError,
 >(
   bookId: number,
   path: string,
@@ -335,11 +335,11 @@ export const getGetReadiumResourceQueryOptions = <
 export type GetReadiumResourceQueryResult = NonNullable<
   Awaited<ReturnType<typeof getReadiumResource>>
 >;
-export type GetReadiumResourceQueryError = HTTPValidationError;
+export type GetReadiumResourceQueryError = void | HTTPValidationError;
 
 export function useGetReadiumResource<
   TData = Awaited<ReturnType<typeof getReadiumResource>>,
-  TError = HTTPValidationError,
+  TError = void | HTTPValidationError,
 >(
   bookId: number,
   path: string,
@@ -358,7 +358,7 @@ export function useGetReadiumResource<
 ): DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
 export function useGetReadiumResource<
   TData = Awaited<ReturnType<typeof getReadiumResource>>,
-  TError = HTTPValidationError,
+  TError = void | HTTPValidationError,
 >(
   bookId: number,
   path: string,
@@ -379,7 +379,7 @@ export function useGetReadiumResource<
 ): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
 export function useGetReadiumResource<
   TData = Awaited<ReturnType<typeof getReadiumResource>>,
-  TError = HTTPValidationError,
+  TError = void | HTTPValidationError,
 >(
   bookId: number,
   path: string,
@@ -394,7 +394,7 @@ export function useGetReadiumResource<
 
 export function useGetReadiumResource<
   TData = Awaited<ReturnType<typeof getReadiumResource>>,
-  TError = HTTPValidationError,
+  TError = void | HTTPValidationError,
 >(
   bookId: number,
   path: string,


### PR DESCRIPTION
Closes #799. R1.6 of #792 (R1 — Publication streaming, second pass).

A reader re-opening a book no longer re-downloads every chapter. The `ETag` is the stored index's `content_hash`; a matching `If-None-Match` answers 304 without touching the file store.

**You have not seen this diff in revdiff** — it was finished and pushed while you were away, so this description carries what a revdiff description would have. Nothing is merged.

## Three design points worth a look

**One tag per book, not per member.** The row's `content_hash` covers every file of a publication. Legal because entity tags are compared per URL (RFC 9110 §8.8.1), so a cache never carries chapter 1's tag to chapter 2's URL on its own. The spike hashed the member path in too; the ticket dropped that deliberately. The practical cost is that a re-upload invalidates every member at once, which is the safe direction to be wrong.

**`known_versions` reaches the query, not just the router.** The file store is the expensive half of this read and only the query touches it, so the version check has to live there to be worth anything. That is why `PublicationResourceView.content` is now optional — not reading the member is what a caller buys by asking, rather than an optimisation applied after the fact.

**The membership check stays above the version check.** A path the publication does not list is a 404 however the caller asks. A precondition narrows a request that would otherwise succeed (RFC 9110 §13.2); it must never turn a refusal into "your copy is current" and leave a reader trusting a file it can never fetch. One test pins this and nothing else does.

## A real bug the review pass caught

`If-None-Match: "*"` — a perfectly legal entity-tag — was read as the wildcard. `ANY_VERSION` was the bare string `"*"`, and `*` is inside `etagc` (RFC 9110 §8.8.3), so the parser reduced the quoted tag to the same value the sentinel used. The sentinel lived inside the value space it was compared against.

Verified before the fix, on a resource the client had never fetched:

```
bare star   '*'   -> frozenset({'*'})
quoted star '"*"' -> frozenset({'*'})
GET with quoted star, never fetched before -> 304
```

A caller sending `If-None-Match: "*"` got an unconditional 304 with no body for every member of every book.

Fixed by making the wildcard `None` rather than a member of the set — a value no version can spell. That also deleted the constant, its four-line comment and both imports, so the fix is a net simplification. `test_a_quoted_star_is_a_tag_rather_than_the_wildcard` pins it.

## Three tests that bought nothing, removed

- `test_the_etag_is_stable_across_requests` — the 304 test already requires a stable, quoted tag, so `first == second` could not fail while it passed. Its one assertion with independent reach (`startswith('"')`, which catches a weak `W/"…"` response tag) moved into the 304 test.
- Two malformed-validator cases, `""` and `","` — both reach the parser through the same path the bare-token case already proves, all three yielding `frozenset()`.

## Mutation evidence

Every mutation below was run after the deletions above, to confirm the remaining tests carry the weight:

| Mutation | Test that failed |
|---|---|
| Version check moved above the membership check | `test_a_path_the_publication_does_not_list_is_not_found_however_it_is_asked_for` |
| Drop `Content-Security-Policy` from the 304 | `test_a_matching_if_none_match_is_answered_304` |
| Compare tags strongly (`W/"x"` ≠ `"x"`) | `test_a_weak_validator_still_matches` (+1) |
| Accept a bare unquoted token | `test_a_malformed_validator_does_not_match[{version}]` (+1) |
| Delete the wildcard branch | `test_a_wildcard_validator_matches` |
| Put the wildcard back inside the version set | `test_a_quoted_star_is_a_tag_rather_than_the_wildcard` |
| Return content on a version match | `test_a_conditional_request_reads_no_file` (+3) |

## Two things checked and deliberately left

**`If-None-Match: *` answers 304 where no representation exists.** RFC 9110 §13.1.2 makes `*` false when the origin has no current representation, so a listed-but-absent member and a deleted EPUB file should proceed to their 404. Both answer 304 under `*` instead. Detecting either means touching the file store, which is exactly what the ticket forbids before the version check — so this is bought, not broken. Harmless with a real entity tag: no client can hold a cached 200 for a URL that never served one.

**`nosniff` and the other middleware headers do reach the 304.** I checked a live 304's headers rather than assuming; the middleware runs on every response. Starlette also omits `content-length` on a 304 by itself.

## Verification

```
ruff check src tests      All checks passed!
ruff format --check       715 files already formatted
pyright                   0 errors, 0 warnings, 0 informations
lint-imports              Contracts: 5 kept, 0 broken
pytest                    1217 passed, 31 warnings in 21.73s
make duplication-check    121 clones · 2.1%   (threshold 2.55, untouched)
```

1217 is 1219 as first written, minus the shadowed stability test and two duplicate parametrize cases, plus the quoted-star regression test.

## Out of scope

- **Cookie auth on this route** — #800/#801. Bearer-only here.
- **The app-wide CSP's `blob:` directives** — #802.
- **A per-member size cap** — #815, filed against the upload boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DZ2vdUGgLAsfUzU1S46PVU