### PR TITLE
Cookie-only auth on manifest, positions and resources (#801)

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -4150,11 +4150,6 @@
         "summary": "Get Readium Manifest",
         "description": "Get the Readium Web Publication Manifest for a book's EPUB.",
         "operationId": "get_readium_manifest",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
         "parameters": [
           {
             "name": "book_id",
@@ -4163,6 +4158,22 @@
             "schema": {
               "type": "integer",
               "title": "Book Id"
+            }
+          },
+          {
+            "name": "publication_access",
+            "in": "cookie",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Publication Access"
             }
           }
         ],
@@ -4198,11 +4209,6 @@
         "summary": "Get Readium Positions",
         "description": "Get the Readium position list for a book's EPUB.\n\nThis is what the manifest's ``position-list`` link resolves to: one Locator\nper synthetic page of the publication, which is how a reader turns \"where am\nI\" into a number it can show and store.",
         "operationId": "get_readium_positions",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
         "parameters": [
           {
             "name": "book_id",
@@ -4211,6 +4217,22 @@
             "schema": {
               "type": "integer",
               "title": "Book Id"
+            }
+          },
+          {
+            "name": "publication_access",
+            "in": "cookie",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Publication Access"
             }
           }
         ],
@@ -4246,11 +4268,6 @@
         "summary": "Get Readium Resource",
         "description": "Get one file of a book's publication, unchanged.\n\n``path`` is a manifest href with the ``resources/`` prefix stripped and\ndecoded once by ASGI, which is the archive member's own name. Only the files\nthe manifest names are reachable.",
         "operationId": "get_readium_resource",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
         "parameters": [
           {
             "name": "book_id",
@@ -4268,6 +4285,22 @@
             "schema": {
               "type": "string",
               "title": "Path"
+            }
+          },
+          {
+            "name": "publication_access",
+            "in": "cookie",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Publication Access"
             }
           }
         ],

--- a/backend/src/infrastructure/identity/__init__.py
+++ b/backend/src/infrastructure/identity/__init__.py
@@ -2,16 +2,20 @@
 
 from src.infrastructure.identity.dependencies import (
     AuthenticatedCaller,
+    UserByIdUseCase,
     get_authenticated_caller,
     get_current_user,
+    load_authenticated_user,
     oauth2_scheme,
 )
 from src.infrastructure.identity.repositories.user_repository import UserRepository
 
 __all__ = [
     "AuthenticatedCaller",
+    "UserByIdUseCase",
     "UserRepository",
     "get_authenticated_caller",
     "get_current_user",
+    "load_authenticated_user",
     "oauth2_scheme",
 ]

--- a/backend/src/infrastructure/identity/dependencies.py
+++ b/backend/src/infrastructure/identity/dependencies.py
@@ -33,14 +33,26 @@ class AuthenticatedCaller:
     access_token_expires_at: datetime
 
 
+async def load_authenticated_user(use_case: GetUserByIdUseCase, user_id: int) -> User:
+    """Load the user a verified credential names.
+
+    A credential that verifies but names nobody is a failed authentication, not
+    a missing entity: it was issued for a user since deleted.
+
+    Raises:
+        AuthenticationError: If no such user exists.
+    """
+    try:
+        return await use_case.get_user(user_id)
+    except UserNotFoundError:
+        raise AuthenticationError(_CREDENTIALS_ERROR) from None
+
+
 async def _authenticated_caller(token: str, use_case: GetUserByIdUseCase) -> AuthenticatedCaller:
     claims = verify_access_token(token)
     if claims is None:
         raise AuthenticationError(_CREDENTIALS_ERROR)
-    try:
-        user = await use_case.get_user(claims.user_id)
-    except UserNotFoundError:
-        raise AuthenticationError(_CREDENTIALS_ERROR) from None
+    user = await load_authenticated_user(use_case, claims.user_id)
     return AuthenticatedCaller(user=user, access_token_expires_at=claims.expires_at)
 
 

--- a/backend/src/infrastructure/web_reader/dependencies.py
+++ b/backend/src/infrastructure/web_reader/dependencies.py
@@ -1,0 +1,44 @@
+"""FastAPI dependencies for the routes a navigator's iframe loads.
+
+An iframe load carries no ``Authorization`` header, so these routes authenticate
+on the publication cookie alone (#800, #801).
+"""
+
+from typing import Annotated
+
+from fastapi import Cookie, Depends
+
+from src.domain.common.exceptions import AuthenticationError
+from src.domain.identity.entities.user import User
+from src.infrastructure.identity import UserByIdUseCase, load_authenticated_user
+from src.infrastructure.web_reader.services.publication_token_service import (
+    PUBLICATION_COOKIE_NAME,
+    verify_publication_token,
+)
+
+# Distinct from identity's wording so a log line says which credential was
+# missing. The client is answered the same generic message either way.
+NO_PUBLICATION_COOKIE = "No valid publication cookie"
+
+
+async def get_publication_reader(
+    book_id: int,
+    use_case: UserByIdUseCase,
+    publication_access: Annotated[str | None, Cookie(alias=PUBLICATION_COOKIE_NAME)] = None,
+) -> User:
+    """Authenticate the reader of one book's publication by its cookie alone.
+
+    Raises:
+        AuthenticationError: If no valid cookie for this book is presented.
+    """
+    if publication_access is None:
+        raise AuthenticationError(NO_PUBLICATION_COOKIE)
+    claims = verify_publication_token(publication_access)
+    # A cookie naming another book is 401 and not 404: the caller has not been
+    # authenticated here at all, and 404 would tell book A's holder of book B.
+    if claims is None or claims.book_id != book_id:
+        raise AuthenticationError(NO_PUBLICATION_COOKIE)
+    return await load_authenticated_user(use_case, claims.user_id)
+
+
+PublicationReader = Annotated[User, Depends(get_publication_reader)]

--- a/backend/src/infrastructure/web_reader/routers/readium.py
+++ b/backend/src/infrastructure/web_reader/routers/readium.py
@@ -27,13 +27,9 @@ from src.application.web_reader.queries.publication_positions import Publication
 from src.config import get_settings
 from src.core import container
 from src.domain.common.exceptions import AuthenticationError
-from src.domain.identity import User
 from src.infrastructure.common.di import inject_use_case
-from src.infrastructure.identity import (
-    AuthenticatedCaller,
-    get_authenticated_caller,
-    get_current_user,
-)
+from src.infrastructure.identity import AuthenticatedCaller, get_authenticated_caller
+from src.infrastructure.web_reader.dependencies import PublicationReader
 from src.infrastructure.web_reader.schemas.locator_builders import served_href
 from src.infrastructure.web_reader.schemas.readium_schemas import (
     POSITION_LIST_MEDIA_TYPE,
@@ -152,7 +148,7 @@ async def start_publication_session(
 async def get_readium_manifest(
     book_id: int,
     request: Request,
-    current_user: Annotated[User, Depends(get_current_user)],
+    reader: PublicationReader,
     use_case: GetPublicationUseCase = Depends(
         inject_use_case(container.web_reader.get_publication_use_case)
     ),
@@ -160,7 +156,7 @@ async def get_readium_manifest(
     """Get the Readium Web Publication Manifest for a book's EPUB."""
     publication = await use_case.get_publication(
         book_id=book_id,
-        user_id=current_user.id.value,
+        user_id=reader.id.value,
     )
     manifest = _manifest(publication, self_href=_self_href(request))
     return WebpubJSONResponse(
@@ -176,7 +172,7 @@ async def get_readium_manifest(
 )
 async def get_readium_positions(
     book_id: int,
-    current_user: Annotated[User, Depends(get_current_user)],
+    reader: PublicationReader,
     use_case: GetPublicationPositionsUseCase = Depends(
         inject_use_case(container.web_reader.get_publication_positions_use_case)
     ),
@@ -189,7 +185,7 @@ async def get_readium_positions(
     """
     positions = await use_case.get_publication_positions(
         book_id=book_id,
-        user_id=current_user.id.value,
+        user_id=reader.id.value,
     )
     document = PositionList(
         total=len(positions),
@@ -216,7 +212,7 @@ async def get_readium_resource(
     book_id: int,
     path: str,
     request: Request,
-    current_user: Annotated[User, Depends(get_current_user)],
+    reader: PublicationReader,
     use_case: GetPublicationResourceUseCase = Depends(
         inject_use_case(container.web_reader.get_publication_resource_use_case)
     ),
@@ -229,7 +225,7 @@ async def get_readium_resource(
     """
     resource = await use_case.get_publication_resource(
         book_id=book_id,
-        user_id=current_user.id.value,
+        user_id=reader.id.value,
         path=path,
         known_versions=_known_versions(request.headers.get("if-none-match")),
     )

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -58,6 +58,7 @@ from src.infrastructure.reading.routers.reader_clock import reader_today
 from src.infrastructure.reading.schemas.ereader_highlight_schemas import (
     KOREADER_DATETIME_FORMAT,
 )
+from src.infrastructure.web_reader.dependencies import get_publication_reader
 from src.main import app
 from src.models import (
     Book,
@@ -434,6 +435,9 @@ async def client(db_session: AsyncSession, test_user: User) -> AsyncGenerator[As
     with app_test_wiring(db_session):
         app.dependency_overrides[get_current_user] = override_get_current_user
         app.dependency_overrides[get_authenticated_caller] = override_get_authenticated_caller
+        # The publication routes authenticate on a cookie; the tests that drive
+        # the cookie itself use `browser_client`, which overrides nothing.
+        app.dependency_overrides[get_publication_reader] = override_get_current_user
 
         transport = ASGITransport(app=app)
         async with AsyncClient(transport=transport, base_url="http://test") as test_client:

--- a/backend/tests/test_readium_cookie_access.py
+++ b/backend/tests/test_readium_cookie_access.py
@@ -1,0 +1,202 @@
+"""Who gets into the three routes a navigator's iframe loads (#801).
+
+An iframe load carries no ``Authorization`` header, so the manifest, the position
+list and the resources take the publication cookie and nothing else -- not even a
+valid Bearer token. Every request here is driven through ``browser_client``,
+which authenticates nothing on its own, so what is asserted is the credential.
+"""
+
+from collections.abc import Callable
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+from httpx import AsyncClient, Cookies, Request
+from sqlalchemy.ext.asyncio import AsyncSession
+from starlette import status
+
+from src import models
+from src.infrastructure.identity.services.token_service import create_access_token
+from src.infrastructure.web_reader.services.publication_token_service import (
+    PUBLICATION_COOKIE_NAME,
+    create_publication_token,
+)
+from tests.conftest import create_test_book
+from tests.readium_helpers import fixture_bytes, manifest_url, positions_url, store_fixture
+from tests.test_readium_resources import CHAPTER_1, resource_url, store_indexed_epub
+from tests.test_readium_session import start_session
+
+# httpx's jar stores a single-label host with ".local" appended, so a cookie
+# planted under plain "test" is silently never sent -- and a test asserting a
+# refusal would be asserting that nothing was offered.
+COOKIE_DOMAIN = "test.local"
+
+ROUTE_URLS: list[Callable[[int], str]] = [
+    manifest_url,
+    positions_url,
+    lambda book_id: resource_url(book_id, CHAPTER_1),
+]
+ROUTE_NAMES = ["manifest", "positions", "resource"]
+
+
+def present(browser_client: AsyncClient, token: str) -> None:
+    """Put ``token`` in the jar under the whole API, replacing whatever is there.
+
+    The path is deliberately wider than the server's: what is under test is what
+    the server makes of a cookie presented where it does not belong, and a jar
+    honouring the cookie's own path would answer by never sending it.
+    """
+    browser_client.cookies.clear()
+    browser_client.cookies.set(PUBLICATION_COOKIE_NAME, token, domain=COOKIE_DOMAIN, path="/")
+
+
+def would_send(jar: Cookies, url: str) -> bool:
+    """Whether a jar honouring ``Path`` offers the publication cookie to ``url``."""
+    request = Request("GET", url)
+    jar.set_cookie_header(request)
+    return PUBLICATION_COOKIE_NAME in request.headers.get("cookie", "")
+
+
+@pytest.fixture
+async def readable_book(
+    db_session: AsyncSession, test_book: models.Book, storage_dir: Path
+) -> models.Book:
+    """The user's own book, indexed and on disk, so all three routes have an answer."""
+    await store_indexed_epub(db_session, test_book, storage_dir, fixture_bytes("nested_toc"))
+    return test_book
+
+
+@pytest.fixture
+async def second_book(
+    db_session: AsyncSession, test_user: models.User, storage_dir: Path
+) -> models.Book:
+    """A second book of the same user's, so a mismatch is never about ownership."""
+    book = await create_test_book(db_session=db_session, user_id=test_user.id, title="Also Mine")
+    await store_fixture(db_session, book, "minimal")
+    return book
+
+
+class TestTheCookieAloneIsEnough:
+    async def test_the_cookie_alone_serves_the_manifest(
+        self, browser_client: AsyncClient, test_user: models.User, readable_book: models.Book
+    ) -> None:
+        await start_session(browser_client, test_user.id, readable_book.id)
+
+        response = await browser_client.get(manifest_url(readable_book.id))
+
+        assert response.status_code == status.HTTP_200_OK, response.text
+        assert response.json()["readingOrder"], response.text
+
+    async def test_the_cookie_alone_serves_the_position_list(
+        self, browser_client: AsyncClient, test_user: models.User, readable_book: models.Book
+    ) -> None:
+        await start_session(browser_client, test_user.id, readable_book.id)
+
+        response = await browser_client.get(positions_url(readable_book.id))
+
+        assert response.status_code == status.HTTP_200_OK, response.text
+        assert response.json()["total"] > 0, response.text
+
+    async def test_the_cookie_alone_serves_a_resource(
+        self, browser_client: AsyncClient, test_user: models.User, readable_book: models.Book
+    ) -> None:
+        await start_session(browser_client, test_user.id, readable_book.id)
+
+        response = await browser_client.get(resource_url(readable_book.id, CHAPTER_1))
+
+        assert response.status_code == status.HTTP_200_OK, response.text
+        assert b"<html" in response.content
+
+
+class TestEveryOtherCredentialIsRefused:
+    @pytest.mark.parametrize("url_for", ROUTE_URLS, ids=ROUTE_NAMES)
+    async def test_no_credential_at_all_is_refused(
+        self,
+        browser_client: AsyncClient,
+        readable_book: models.Book,
+        url_for: Callable[[int], str],
+    ) -> None:
+        response = await browser_client.get(url_for(readable_book.id))
+
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED, response.text
+        assert b"<html" not in response.content
+
+    async def test_a_bearer_token_alone_is_refused(
+        self, browser_client: AsyncClient, test_user: models.User, readable_book: models.Book
+    ) -> None:
+        # The owner's own, perfectly valid access token: these routes take the
+        # cookie or nothing, so the SPA has to mint one before it can read.
+        response = await browser_client.get(
+            manifest_url(readable_book.id),
+            headers={"Authorization": f"Bearer {create_access_token(test_user.id)}"},
+        )
+
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED, response.text
+
+
+class TestACookieOpensOneBook:
+    async def test_a_cookie_minted_for_another_book_is_refused_rather_than_hidden(
+        self,
+        browser_client: AsyncClient,
+        test_user: models.User,
+        readable_book: models.Book,
+        second_book: models.Book,
+    ) -> None:
+        minted = await start_session(browser_client, test_user.id, second_book.id)
+        present(browser_client, minted.cookies[PUBLICATION_COOKIE_NAME])
+
+        refused = await browser_client.get(manifest_url(readable_book.id))
+
+        # 401 and not 404: the caller is unauthenticated here, and 404 would tell
+        # a credential scoped to one book whether another one exists.
+        assert refused.status_code == status.HTTP_401_UNAUTHORIZED, refused.text
+        # The same cookie on its own book works, so it was the mismatch refused.
+        allowed = await browser_client.get(manifest_url(second_book.id))
+        assert allowed.status_code == status.HTTP_200_OK, allowed.text
+
+    async def test_the_browser_sends_the_cookie_only_to_this_books_routes(
+        self, browser_client: AsyncClient, test_user: models.User, readable_book: models.Book
+    ) -> None:
+        minted = await start_session(browser_client, test_user.id, readable_book.id)
+        jar = Cookies()
+        jar.extract_cookies(minted)
+
+        for url_for in ROUTE_URLS:
+            url = f"https://test{url_for(readable_book.id)}"
+            assert would_send(jar, url), f"the jar withheld the cookie from {url}"
+        # A book whose id merely starts with this one's. What this guards is the
+        # book in the cookie's path: scoped to `/readium/` it would reach both.
+        collides = f"https://test{manifest_url(readable_book.id)}".replace(
+            f"/books/{readable_book.id}/", f"/books/{readable_book.id}0/"
+        )
+        assert not would_send(jar, collides)
+        assert not would_send(jar, "https://test/api/v1/users/me")
+
+    async def test_the_cookie_is_not_a_key_to_the_rest_of_the_api(
+        self, browser_client: AsyncClient, test_user: models.User, readable_book: models.Book
+    ) -> None:
+        minted = await start_session(browser_client, test_user.id, readable_book.id)
+        present(browser_client, minted.cookies[PUBLICATION_COOKIE_NAME])
+
+        response = await browser_client.get("/api/v1/users/me")
+
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED, response.text
+
+
+class TestACookieThatIsNoGood:
+    """What the route makes of a cookie the verifier rejects.
+
+    Which cookies it rejects -- expired, tampered, foreign key, wrong type,
+    claim-less -- is ``test_readium_session.TestVerifyingAPublicationToken``.
+    """
+
+    async def test_a_cookie_the_verifier_rejects_is_refused(
+        self, browser_client: AsyncClient, test_user: models.User, readable_book: models.Book
+    ) -> None:
+        already_over = datetime.now(UTC) - timedelta(seconds=1)
+        expired = create_publication_token(test_user.id, readable_book.id, not_after=already_over)
+        present(browser_client, expired.value)
+
+        response = await browser_client.get(manifest_url(readable_book.id))
+
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED, response.text


### PR DESCRIPTION
Closes #801 (R1.8). Part of #792. Follows #818.

The three routes a navigator's iframe loads — `manifest.json`, `positions.json`, `resources/{path}` — now take the publication cookie and **nothing else**, not even a valid Bearer token. An iframe load carries no `Authorization` header, so accepting one as well would mean two ways in where the browser can only use one.

`POST /session` keeps its Bearer token: it is the route that *mints* the cookie, so a cookie must not buy another. That is what keeps the second credential read-only by construction.

Nothing outside the backend calls these three routes yet — no frontend caller, no MCP tool — so removing Bearer breaks no live client. #804 must now POST `/session` before fetching the manifest.

## Two commits

| Commit | What |
|---|---|
| `bb847bf8` | `get_publication_reader`, the three route switches, the shared `load_authenticated_user`, 11 tests |
| `63d99ca4` | OpenAPI schema (the TS client is unchanged — orval doesn't make a cookie an argument) |

## Design notes

**A cookie naming another book is 401, not 404.** The caller has not been authenticated for the book they asked for at all, and 404 would tell a credential scoped to book A whether book B exists.

**The 47 existing readium tests are untouched.** `client` also overrides `get_publication_reader` now, so those tests keep asserting what the routes *serve*; the cookie itself is driven through `browser_client`, which overrides nothing. Removing that override fails 55 tests, so it is load-bearing rather than defensive.

**`load_authenticated_user` is shared by both credentials.** A token that verifies but names nobody is a failed authentication rather than a missing entity, whichever credential carried it.

## Security probes — all refused

An access token in the cookie, a refresh token in the cookie, a publication token signed with a foreign key, one with no `type` claim, an `alg=none` token: **401** every time. This matters because `PUBLICATION_TOKEN_SECRET_KEY` is optional, so by default the cookie is signed with the **same key as access tokens** — the `type` claim is the sole discriminator, and it holds in both directions.

Ownership is still enforced downstream: a cookie forged for another *user* naming this book gets 404 from the repository's `user_id` filter, and dropping that filter fails the three pre-existing `another_users_book` tests.

## Corrections made during review

- **A comment claimed the trailing slash on the cookie path is what separates books 7 and 70.** It isn't — RFC 6265 §5.1.4 already refuses the prefix because the next character is `0`. I removed the slash from the server and the collision test still passed. The assertion is kept (broadening the path to `/readium/` does fail it); the comment now says what it really guards.
- **Three assertions could not fail** (`assert "Authorization" not in browser_client.headers`) — deleted; a real valid Bearer token getting 401 proves the same thing positively.
- **A three-test class died to one mutant** — collapsed to the one fact the route adds, with the verifier's input classes left to their own direct tests.

## Verification

`ruff check` clean · `pyright` 0 errors · `lint-imports` 5 contracts kept · `pytest` **1257 passed** · `tsc --noEmit` clean · `eslint` clean · `jscpd` 2.0% against a 2.1 threshold.

Threshold deliberately **not** lowered: clone count (121) and duplicated lines (1232) are identical before and after; the percentage moved only because ~200 non-duplicated lines were added. The ratchet is for duplication that was removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DZ2vdUGgLAsfUzU1S46PVU