### PR TITLE
App-wide CSP for the reader's blob frames (#802)

### DIFF
--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -312,12 +312,26 @@ class SecurityHeadersMiddleware:
                     if "content-security-policy" not in headers:
                         headers["Content-Security-Policy"] = (
                             "default-src 'self'; "
-                            "script-src 'self'; "
-                            "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; "
+                            # Readium injects its own scripts as
+                            # `<script src="blob:...">` and its CSS as a blob
+                            # stylesheet. A book's own scripts take nothing from
+                            # this: they are inline or same-origin.
+                            "script-src 'self' blob:; "
+                            "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com blob:; "
                             "img-src 'self' data: blob:; "
                             "font-src 'self' https://fonts.gstatic.com; "
                             "connect-src 'self'; "
-                            "frame-ancestors 'none'; "
+                            # Readium frames each publication resource as a
+                            # blob document.
+                            "frame-src 'self' blob:; "
+                            # A blob document inherits the policy of the context
+                            # that created it, and WebKit enforces the inherited
+                            # `frame-ancestors` against that document's own
+                            # ancestor -- so `'none'` makes Safari refuse every
+                            # publication frame the reader builds. This also
+                            # supersedes `X-Frame-Options` above, which a browser
+                            # ignores once a response carries `frame-ancestors`.
+                            "frame-ancestors 'self'; "
                             "base-uri 'self'; "
                             "form-action 'self'"
                         )

--- a/backend/tests/test_readium_resources.py
+++ b/backend/tests/test_readium_resources.py
@@ -245,6 +245,27 @@ class TestServedResourcesCarryASandboxPolicy:
         # The app policy still reaches a response that expresses none of its own.
         assert "default-src 'self'" in manifest.headers["content-security-policy"]
 
+    async def test_the_app_policy_lets_the_reader_frame_its_own_documents(
+        self,
+        client: AsyncClient,
+        nested_toc_book: models.Book,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Should not forbid this page from framing the reader's blob documents.
+
+        Chromium does not apply an inherited ``frame-ancestors`` to blob
+        children, so no desktop run ever reaches this.
+        """
+        monkeypatch.setattr(main_settings, "ENVIRONMENT", "production")
+
+        manifest = await client.get(manifest_url(nested_toc_book.id))
+
+        policy = manifest.headers["content-security-policy"]
+        assert "frame-ancestors 'self'" in policy
+        assert "frame-src 'self' blob:" in policy
+        assert "script-src 'self' blob:" in policy
+        assert "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com blob:" in policy
+
 
 class TestOnlyPublicationFilesAreReachable:
     """What the endpoint refuses, which is everything the manifest does not name."""


### PR DESCRIPTION
Closes #802.

`SecurityHeadersMiddleware`'s non-development policy now grants the four things the Readium reader needs, and nothing else.

| Directive | Before | After | Why |
|---|---|---|---|
| `script-src` | `'self'` | `'self' blob:` | Readium injects its own scripts as `<script src="blob:...">` |
| `style-src` | `'self' 'unsafe-inline' https://fonts.googleapis.com` | … `blob:` | its CSS arrives as a blob stylesheet |
| `frame-src` | absent (fell back to `default-src 'self'`) | `'self' blob:` | each publication resource is framed as a blob document |
| `frame-ancestors` | `'none'` | `'self'` | a blob document inherits its creator's CSP, and WebKit enforces the inherited `frame-ancestors` against the blob's own ancestor — `'none'` made Safari refuse every publication frame |

The R1.5 guard is untouched: a response carrying its own policy still keeps it, so `/readium/.../resources/*` stays on `Content-Security-Policy: sandbox`.

## The ticket is wrong about `X-Frame-Options`

The ticket and the spike both say "`X-Frame-Options: DENY` still refuses framing of the app itself." It does not. A browser ignores `X-Frame-Options` on any response that also carries a `frame-ancestors` directive (CSP2 §7.4), so XFO is inert on every non-development response here. Measured in Chromium — one page framing a same-origin page, varying only the framed page's headers:

| Framed response's headers | Frame |
|---|---|
| none | LOADED |
| `X-Frame-Options: DENY` | BLOCKED |
| `XFO: DENY` + `frame-ancestors 'none'` | BLOCKED |
| `XFO: DENY` + `frame-ancestors 'self'` | **LOADED** |

So this **does** widen framing of the app: same-origin pages may now frame it, where `'none'` refused everyone. `frame-ancestors 'self'` — not XFO — is what refuses the cross-origin ones.

Judged acceptable: a framing page must live on the app's own origin, and the one same-origin HTML the app serves from user content goes out under `Content-Security-Policy: sandbox`, so it has an opaque origin and no scripts. The comment in `main.py` records this rather than repeating the untrue claim.

## Verification

- Mutation check, all four killed — `frame-src 'self' blob:; ` deleted; `script-src 'self' blob:` → `'self'`; `fonts.googleapis.com blob:` → without; `frame-ancestors 'self'` → `'none'`. Each failed exactly one test.
- Full suite 1258 passed · pyright 0 errors · ruff check + format clean · `lint-imports` 5 contracts kept · jscpd 2.0% against the 2.1 threshold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DZ2vdUGgLAsfUzU1S46PVU