### PR TITLE
R1.11 Frontend: minimal web reader behind the EbookReader seam (#804)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,6 +27,8 @@
     "@mui/icons-material": "^9.3.1",
     "@mui/material": "^9.4.0",
     "@mui/x-date-pickers": "^9.12.0",
+    "@readium/navigator": "2.10.0",
+    "@readium/shared": "2.5.0",
     "@tanstack/react-query": "^5.101.4",
     "@tanstack/react-router": "^1.170.32",
     "axios": "^1.20.0",

--- a/frontend/src/components/reader/EbookReader.ts
+++ b/frontend/src/components/reader/EbookReader.ts
@@ -1,0 +1,68 @@
+/**
+ * The seam between the UI and whatever engine puts a book on screen.
+ *
+ * Every command and event here is JSON-serialisable, so a `RemoteReader` in a
+ * separate origin can implement the same interface over `postMessage`; the
+ * trigger for building one is a book readable by someone other than its
+ * uploader (#807). `onPageTurnRequested` is the contract that an arrow key
+ * pressed anywhere while the reader is open reaches the UI as a request rather
+ * than a turn: the UI decides whether to act on it.
+ */
+
+/** Where the reader is in the book, as JSON that can cross a postMessage boundary. */
+export interface EbookLocation {
+  href: string;
+  type: string;
+  title?: string;
+  locations: {
+    position?: number;
+    progression?: number;
+    totalProgression?: number;
+    fragments?: string[];
+  };
+}
+
+/** One heading of the book's table of contents. */
+export interface EbookTocEntry {
+  href: string;
+  title: string;
+  children: EbookTocEntry[];
+}
+
+/** What a book says about itself once it is on screen. */
+export interface OpenedEbook {
+  pageCount: number;
+  toc: EbookTocEntry[];
+  location: EbookLocation;
+}
+
+/** Which way a page turn was asked to go. */
+export type PageTurnDirection = 'next' | 'previous';
+
+/** Whether the book has no publication at all, or one that could not be read. */
+export type PublicationUnavailableReason = 'missing' | 'error';
+
+/** There is nothing to open: the book has no publication, or fetching it failed. */
+export class PublicationUnavailableError extends Error {
+  constructor(readonly reason: PublicationUnavailableReason) {
+    super(`The publication is unavailable (${reason}).`);
+    this.name = 'PublicationUnavailableError';
+  }
+}
+
+/** A book on screen, and the ways the UI moves through it. */
+export interface EbookReader {
+  /**
+   * Loads the book named by a Readium manifest URL into the host element. Call once.
+   *
+   * `signal` is the caller's cancellation (an unmount, a remount, a boot watchdog via
+   * `AbortSignal.timeout`); every await inside observes it, composed with the reader's destruction.
+   */
+  open(manifestUrl: string, signal?: AbortSignal): Promise<OpenedEbook>;
+  next(): Promise<void>;
+  previous(): Promise<void>;
+  goTo(location: EbookLocation): Promise<void>;
+  onLocationChanged(listener: (location: EbookLocation) => void): () => void;
+  onPageTurnRequested(listener: (direction: PageTurnDirection) => void): () => void;
+  destroy(): Promise<void>;
+}

--- a/frontend/src/components/reader/OpenInReaderButton.tsx
+++ b/frontend/src/components/reader/OpenInReaderButton.tsx
@@ -1,0 +1,27 @@
+import { ReaderIcon } from '@/theme/Icons.tsx';
+import { IconButton, Tooltip, type IconButtonProps } from '@mui/material';
+import { createLink } from '@tanstack/react-router';
+
+// A link rather than a click handler, so the reader can be opened in a new tab
+// and its address copied.
+const ReaderLinkButton = createLink(IconButton);
+
+export interface OpenInReaderButtonProps {
+  bookId: number;
+  size?: IconButtonProps['size'];
+  sx?: IconButtonProps['sx'];
+}
+
+export const OpenInReaderButton = ({ bookId, size, sx }: OpenInReaderButtonProps) => (
+  <Tooltip title="Open in reader">
+    <ReaderLinkButton
+      to="/book/$bookId/read"
+      params={{ bookId: String(bookId) }}
+      aria-label="Open in reader"
+      size={size}
+      sx={sx}
+    >
+      <ReaderIcon />
+    </ReaderLinkButton>
+  </Tooltip>
+);

--- a/frontend/src/components/reader/ReaderShell.test.tsx
+++ b/frontend/src/components/reader/ReaderShell.test.tsx
@@ -1,0 +1,148 @@
+import { ReaderShell, type ReaderShellProps } from '@/components/reader/ReaderShell.tsx';
+import { FakeEbookReader, aFakeLocation } from '@tests/fakes/FakeEbookReader';
+import { readiumApi } from '@tests/msw/readiumApi';
+import { worker } from '@tests/msw/worker';
+import { HttpResponse, delay, http } from 'msw';
+import { beforeEach, expect, test } from 'vitest';
+import { render } from 'vitest-browser-react';
+
+const SESSION_PATH = '/api/v1/readium/books/:bookId/session';
+const RESOURCE_PATH = '/api/v1/readium/books/:bookId/resources/*';
+const MANIFEST_URL = `${window.location.origin}/api/v1/readium/books/1/manifest.json`;
+
+const readers: FakeEbookReader[] = [];
+
+const createReader = () => {
+  const reader = new FakeEbookReader();
+  readers.push(reader);
+  return reader;
+};
+
+beforeEach(() => {
+  readers.length = 0;
+});
+
+const aSlowSession = (ms: number) =>
+  http.post(SESSION_PATH, async () => {
+    await delay(ms);
+    return HttpResponse.json({ expires_in: 900 });
+  });
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const renderShell = async (props: Partial<ReaderShellProps> = {}) =>
+  await render(
+    <ReaderShell
+      bookId={1}
+      title="The Pragmatic Reader"
+      onClose={() => {}}
+      createReader={createReader}
+      {...props}
+    />
+  );
+
+type Screen = Awaited<ReturnType<typeof renderShell>>;
+
+/** The shell with the book on screen at its first page. */
+const anOpenBook = async () => {
+  const screen = await renderShell();
+  await expect.poll(() => readers.length).toBe(1);
+  readers[0].resolveOpen();
+  await expect.element(screen.getByText('Page 1 of 2')).toBeVisible();
+  return screen;
+};
+
+const expectReconnecting = (screen: Screen) =>
+  expect.element(screen.getByText('Reconnecting…')).toBeVisible();
+
+test('the shell waits for the cookie before opening the book', async () => {
+  worker.use(aSlowSession(500));
+
+  const screen = await renderShell();
+
+  expect(readers).toHaveLength(0);
+  await expect.poll(() => readers.length).toBe(1);
+  expect(readers[0].openedWith).toEqual([MANIFEST_URL]);
+  await expect.element(screen.getByLabelText('Loading the book')).toBeVisible();
+});
+
+test('a page turn asked for by the book is forwarded', async () => {
+  worker.use(...readiumApi());
+
+  await anOpenBook();
+
+  readers[0].requestPageTurn('next');
+  expect(readers[0].nextCalls).toBe(1);
+
+  readers[0].requestPageTurn('previous');
+  expect(readers[0].previousCalls).toBe(1);
+});
+
+test('a page turn asked for while the cookie is being renewed is dropped', async () => {
+  // A one-second cookie has genuinely lapsed by the time the tab comes back,
+  // and the scheduled renewal cannot interfere: its floor is five.
+  worker.use(...readiumApi({ expiresIn: 1 }));
+
+  const screen = await anOpenBook();
+
+  await sleep(1_200);
+  worker.use(aSlowSession(2_000));
+  window.dispatchEvent(new Event('focus'));
+
+  await expectReconnecting(screen);
+  readers[0].requestPageTurn('next');
+  expect(readers[0].nextCalls).toBe(0);
+
+  await expect
+    .element(screen.getByText('Reconnecting…'), { timeout: 5_000 })
+    .not.toBeInTheDocument();
+  readers[0].requestPageTurn('next');
+  expect(readers[0].nextCalls).toBe(1);
+});
+
+test('a book that never appears times out and can be retried', async () => {
+  worker.use(...readiumApi());
+
+  const screen = await renderShell({ bootTimeoutMs: 300 });
+
+  await expect
+    .element(screen.getByText('This book could not be opened in the reader.'))
+    .toBeVisible();
+
+  await screen.getByRole('button', { name: 'Try again' }).click();
+
+  await expect.poll(() => readers.length).toBe(2);
+  expect(readers[0].destroyed).toBe(true);
+  // The abandoned first reader rejects as it is aborted, and that rejection
+  // must not be read as the second attempt having failed.
+  await expect.element(screen.getByLabelText('Loading the book')).toBeVisible();
+
+  readers[1].resolveOpen({ location: aFakeLocation(2) });
+  await expect.element(screen.getByText('Page 2 of 2')).toBeVisible();
+});
+
+test('a book whose chapters never arrive times out and can be retried', async () => {
+  worker.use(...readiumApi());
+  worker.use(http.get(RESOURCE_PATH, () => delay('infinite')));
+
+  const screen = await renderShell({ createReader: undefined, bootTimeoutMs: 500 });
+
+  await expect
+    .element(screen.getByText('This book could not be opened in the reader.'), { timeout: 3_000 })
+    .toBeVisible();
+  await expect.element(screen.getByRole('button', { name: 'Try again' })).toBeVisible();
+
+  worker.use(...readiumApi());
+  await screen.getByRole('button', { name: 'Try again' }).click();
+
+  await expect.element(screen.getByText('Page 1 of 2'), { timeout: 5_000 }).toBeVisible();
+});
+
+test('closing the shell destroys the reader', async () => {
+  worker.use(...readiumApi());
+
+  const screen = await anOpenBook();
+  screen.unmount();
+
+  await expect.poll(() => readers[0].destroyed).toBe(true);
+});

--- a/frontend/src/components/reader/ReaderShell.tsx
+++ b/frontend/src/components/reader/ReaderShell.tsx
@@ -1,31 +1,69 @@
 import { IconButtonWithTooltip } from '@/components/buttons/IconButtonWithTooltip.tsx';
+import { useReaderSession } from '@/components/reader/useReaderSession.ts';
 import { useBodyScrollLock } from '@/hooks/useBodyScrollLock.ts';
 import { CloseIcon } from '@/theme/Icons.tsx';
 import { ICON_SIZE } from '@/theme/iconSizes.ts';
-import { Box, Toolbar, Typography } from '@mui/material';
+import { Box, Button, Toolbar, Typography, type SxProps, type Theme } from '@mui/material';
 
 export interface ReaderShellProps {
+  bookId: number;
   title: string;
   onClose: () => void;
 }
 
-/** The reader's full-viewport frame: a title bar, a way out, and the viewport. */
-export const ReaderShell = ({ title, onClose }: ReaderShellProps) => {
-  // A fixed overlay never scrolls the body, which is what arms pull-to-refresh.
-  useBodyScrollLock(true);
+const overlaySx: SxProps<Theme> = {
+  position: 'fixed',
+  inset: 0,
+  zIndex: (t) => t.zIndex.appBar + 1,
+  display: 'flex',
+  flexDirection: 'column',
+  backgroundColor: 'background.default',
+  color: 'text.primary',
+};
 
-  return (
+interface ReaderMessageProps {
+  children: string;
+  onClose: () => void;
+}
+
+const ReaderMessage = ({ children, onClose }: ReaderMessageProps) => (
+  <Box sx={overlaySx}>
     <Box
       sx={{
-        position: 'fixed',
-        inset: 0,
-        zIndex: (t) => t.zIndex.appBar + 1,
+        flex: 1,
         display: 'flex',
         flexDirection: 'column',
-        backgroundColor: 'background.default',
-        color: 'text.primary',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 2,
+        p: 3,
+        textAlign: 'center',
       }}
     >
+      <Typography>{children}</Typography>
+      <Button variant="outlined" onClick={onClose}>
+        Back to book
+      </Button>
+    </Box>
+  </Box>
+);
+
+/** The reader's full-viewport frame: a title bar, a way out, and the viewport. */
+export const ReaderShell = ({ bookId, title, onClose }: ReaderShellProps) => {
+  // A fixed overlay never scrolls the body, which is what arms pull-to-refresh.
+  useBodyScrollLock(true);
+  const { status } = useReaderSession(bookId);
+
+  if (status === 'error') {
+    return (
+      <ReaderMessage onClose={onClose}>
+        The reader could not start a session for this book. Please try again later.
+      </ReaderMessage>
+    );
+  }
+
+  return (
+    <Box sx={overlaySx}>
       <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
         <Toolbar variant="dense" sx={{ gap: 1 }}>
           <Typography variant="h6" component="h1" noWrap sx={{ flex: 1, minWidth: 0 }}>

--- a/frontend/src/components/reader/ReaderShell.tsx
+++ b/frontend/src/components/reader/ReaderShell.tsx
@@ -1,15 +1,34 @@
+import { API_BASE_URL } from '@/api/base-url.ts';
 import { IconButtonWithTooltip } from '@/components/buttons/IconButtonWithTooltip.tsx';
+import { useEbookReader, type UseEbookReaderOptions } from '@/components/reader/useEbookReader.ts';
 import { useReaderSession } from '@/components/reader/useReaderSession.ts';
 import { useBodyScrollLock } from '@/hooks/useBodyScrollLock.ts';
-import { CloseIcon } from '@/theme/Icons.tsx';
+import { CloseIcon, NextPageIcon, PreviousPageIcon } from '@/theme/Icons.tsx';
 import { ICON_SIZE } from '@/theme/iconSizes.ts';
-import { Box, Button, Toolbar, Typography, type SxProps, type Theme } from '@mui/material';
+import {
+  Box,
+  Button,
+  IconButton,
+  Skeleton,
+  Stack,
+  Toolbar,
+  Typography,
+  type SxProps,
+  type Theme,
+} from '@mui/material';
+import { useRef } from 'react';
 
 export interface ReaderShellProps {
   bookId: number;
   title: string;
   onClose: () => void;
+  /** Both only for tests: a fake engine, and a watchdog short enough to wait for. */
+  createReader?: UseEbookReaderOptions['createReader'];
+  bootTimeoutMs?: number;
 }
+
+/** The width the page-turn buttons need beside the text on anything but a phone. */
+const PAGE_TURN_GUTTER = '48px';
 
 const overlaySx: SxProps<Theme> = {
   position: 'fixed',
@@ -21,12 +40,40 @@ const overlaySx: SxProps<Theme> = {
   color: 'text.primary',
 };
 
+const manifestUrlFor = (bookId: number) =>
+  new URL(`${API_BASE_URL}/api/v1/readium/books/${bookId}/manifest.json`, window.location.origin)
+    .href;
+
+interface PageTurnButtonProps {
+  edge: 'left' | 'right';
+  onClick: () => void;
+  disabled: boolean;
+}
+
+const PageTurnButton = ({ edge, onClick, disabled }: PageTurnButtonProps) => (
+  <IconButton
+    onClick={onClick}
+    disabled={disabled}
+    color="inherit"
+    aria-label={edge === 'left' ? 'Previous page' : 'Next page'}
+    sx={{ position: 'absolute', top: '50%', transform: 'translateY(-50%)', [edge]: 4, zIndex: 1 }}
+  >
+    {edge === 'left' ? (
+      <PreviousPageIcon sx={{ fontSize: ICON_SIZE.prominent }} />
+    ) : (
+      <NextPageIcon sx={{ fontSize: ICON_SIZE.prominent }} />
+    )}
+  </IconButton>
+);
+
 interface ReaderMessageProps {
   children: string;
   onClose: () => void;
+  /** Offered only where trying again could plausibly work. */
+  onRetry?: () => void;
 }
 
-const ReaderMessage = ({ children, onClose }: ReaderMessageProps) => (
+const ReaderMessage = ({ children, onClose, onRetry }: ReaderMessageProps) => (
   <Box sx={overlaySx}>
     <Box
       sx={{
@@ -41,34 +88,89 @@ const ReaderMessage = ({ children, onClose }: ReaderMessageProps) => (
       }}
     >
       <Typography>{children}</Typography>
-      <Button variant="outlined" onClick={onClose}>
-        Back to book
-      </Button>
+      <Stack direction="row" spacing={2}>
+        <Button variant="outlined" onClick={onClose}>
+          Back to book
+        </Button>
+        {onRetry && (
+          <Button variant="contained" onClick={onRetry}>
+            Try again
+          </Button>
+        )}
+      </Stack>
     </Box>
   </Box>
 );
 
-/** The reader's full-viewport frame: a title bar, a way out, and the viewport. */
-export const ReaderShell = ({ bookId, title, onClose }: ReaderShellProps) => {
+/** The reader's full-viewport frame: a title bar, a way out, and the book. */
+export const ReaderShell = ({
+  bookId,
+  title,
+  onClose,
+  createReader,
+  bootTimeoutMs,
+}: ReaderShellProps) => {
   // A fixed overlay never scrolls the body, which is what arms pull-to-refresh.
   useBodyScrollLock(true);
-  const { status } = useReaderSession(bookId);
+  const { status: sessionStatus, isRenewing } = useReaderSession(bookId);
+  const host = useRef<HTMLDivElement | null>(null);
+  const book = useEbookReader({
+    host,
+    manifestUrl: manifestUrlFor(bookId),
+    enabled: sessionStatus === 'ready',
+    holdPageTurns: isRenewing,
+    createReader,
+    bootTimeoutMs,
+  });
 
-  if (status === 'error') {
+  if (sessionStatus === 'error') {
     return (
       <ReaderMessage onClose={onClose}>
         The reader could not start a session for this book. Please try again later.
       </ReaderMessage>
     );
   }
+  if (book.status === 'missing') {
+    return (
+      <ReaderMessage onClose={onClose}>
+        This book has no EPUB file, so there is nothing to read here yet. Upload one to read it in
+        the browser.
+      </ReaderMessage>
+    );
+  }
+  if (book.status === 'error') {
+    return (
+      <ReaderMessage onClose={onClose} onRetry={book.retry}>
+        The book could not be opened. Please try again later.
+      </ReaderMessage>
+    );
+  }
+  if (book.status === 'timeout') {
+    return (
+      <ReaderMessage onClose={onClose} onRetry={book.retry}>
+        This book could not be opened in the reader.
+      </ReaderMessage>
+    );
+  }
+
+  const isOpen = book.status === 'open';
+  const pageTurnsDisabled = isRenewing || !isOpen;
+  const position = book.location?.locations.position;
 
   return (
     <Box sx={overlaySx}>
       <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
         <Toolbar variant="dense" sx={{ gap: 1 }}>
-          <Typography variant="h6" component="h1" noWrap sx={{ flex: 1, minWidth: 0 }}>
-            {title}
-          </Typography>
+          <Stack sx={{ flex: 1, minWidth: 0 }}>
+            <Typography variant="h6" component="h1" noWrap>
+              {title}
+            </Typography>
+            {book.pageCount > 0 && position !== undefined && (
+              <Typography variant="body2" noWrap sx={{ color: 'text.secondary' }}>
+                Page {position} of {book.pageCount}
+              </Typography>
+            )}
+          </Stack>
           <IconButtonWithTooltip
             label="Close reader"
             onClick={onClose}
@@ -78,7 +180,53 @@ export const ReaderShell = ({ bookId, title, onClose }: ReaderShellProps) => {
         </Toolbar>
       </Box>
 
-      <Box sx={{ flex: 1, minHeight: 0, position: 'relative' }} />
+      <Box sx={{ flex: 1, minHeight: 0, position: 'relative' }}>
+        <PageTurnButton edge="left" onClick={book.previous} disabled={pageTurnsDisabled} />
+        <PageTurnButton edge="right" onClick={book.next} disabled={pageTurnsDisabled} />
+
+        {/* Hidden rather than unmounted: the engine measures this box to lay
+            the book out, and a box that is not there has no size to measure. */}
+        <Box
+          ref={host}
+          sx={{
+            height: '100%',
+            px: { xs: 0, sm: PAGE_TURN_GUTTER },
+            visibility: isOpen ? 'visible' : 'hidden',
+          }}
+        />
+
+        {!isOpen && (
+          <Stack
+            aria-label="Loading the book"
+            aria-busy="true"
+            sx={{ position: 'absolute', inset: 0, p: 4, alignItems: 'center' }}
+          >
+            <Box sx={{ width: '100%', maxWidth: 640 }}>
+              {Array.from({ length: 12 }, (_, index) => (
+                <Skeleton key={index} height={28} width={index % 5 === 4 ? '55%' : '100%'} />
+              ))}
+            </Box>
+          </Stack>
+        )}
+
+        {/* Mounted for as long as the book is: a live region that appears
+            together with its text announces nothing. */}
+        {isOpen && (
+          <Stack
+            aria-live="polite"
+            sx={{
+              position: 'absolute',
+              inset: 0,
+              alignItems: 'center',
+              justifyContent: 'center',
+              pointerEvents: isRenewing ? 'auto' : 'none',
+              ...(isRenewing && { backgroundColor: 'background.default', opacity: 0.9 }),
+            }}
+          >
+            {isRenewing && <Typography variant="body2">Reconnecting…</Typography>}
+          </Stack>
+        )}
+      </Box>
     </Box>
   );
 };

--- a/frontend/src/components/reader/ReaderShell.tsx
+++ b/frontend/src/components/reader/ReaderShell.tsx
@@ -1,0 +1,46 @@
+import { IconButtonWithTooltip } from '@/components/buttons/IconButtonWithTooltip.tsx';
+import { useBodyScrollLock } from '@/hooks/useBodyScrollLock.ts';
+import { CloseIcon } from '@/theme/Icons.tsx';
+import { ICON_SIZE } from '@/theme/iconSizes.ts';
+import { Box, Toolbar, Typography } from '@mui/material';
+
+export interface ReaderShellProps {
+  title: string;
+  onClose: () => void;
+}
+
+/** The reader's full-viewport frame: a title bar, a way out, and the viewport. */
+export const ReaderShell = ({ title, onClose }: ReaderShellProps) => {
+  // A fixed overlay never scrolls the body, which is what arms pull-to-refresh.
+  useBodyScrollLock(true);
+
+  return (
+    <Box
+      sx={{
+        position: 'fixed',
+        inset: 0,
+        zIndex: (t) => t.zIndex.appBar + 1,
+        display: 'flex',
+        flexDirection: 'column',
+        backgroundColor: 'background.default',
+        color: 'text.primary',
+      }}
+    >
+      <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
+        <Toolbar variant="dense" sx={{ gap: 1 }}>
+          <Typography variant="h6" component="h1" noWrap sx={{ flex: 1, minWidth: 0 }}>
+            {title}
+          </Typography>
+          <IconButtonWithTooltip
+            label="Close reader"
+            onClick={onClose}
+            edge="end"
+            icon={<CloseIcon sx={{ fontSize: ICON_SIZE.ui }} />}
+          />
+        </Toolbar>
+      </Box>
+
+      <Box sx={{ flex: 1, minHeight: 0, position: 'relative' }} />
+    </Box>
+  );
+};

--- a/frontend/src/components/reader/ReadiumReader.test.tsx
+++ b/frontend/src/components/reader/ReadiumReader.test.tsx
@@ -1,0 +1,250 @@
+import {
+  PublicationUnavailableError,
+  type PageTurnDirection,
+} from '@/components/reader/EbookReader.ts';
+import { ReadiumReader } from '@/components/reader/ReadiumReader.ts';
+import { aManifest, aPositionList } from '@tests/fixtures/publication';
+import { noPublication, readiumApi } from '@tests/msw/readiumApi';
+import { worker } from '@tests/msw/worker';
+import { http, HttpResponse } from 'msw';
+import { afterEach, beforeEach, expect, test } from 'vitest';
+import { userEvent } from 'vitest/browser';
+
+const MANIFEST_PATH = '/api/v1/readium/books/:bookId/manifest.json';
+const MANIFEST_URL = `${window.location.origin}/api/v1/readium/books/1/manifest.json`;
+
+let host: HTMLDivElement;
+let reader: ReadiumReader;
+
+const recordEvents = () => {
+  const positions: (number | undefined)[] = [];
+  const turns: PageTurnDirection[] = [];
+  reader.onLocationChanged((location) => positions.push(location.locations.position));
+  reader.onPageTurnRequested((direction) => turns.push(direction));
+  return {
+    positions,
+    turns,
+    clear: () => {
+      positions.length = 0;
+      turns.length = 0;
+    },
+  };
+};
+
+const frame = () => host.querySelector('iframe');
+
+const frameText = () => frame()?.contentDocument?.body.textContent ?? '';
+
+beforeEach(() => {
+  host = document.createElement('div');
+  host.style.width = '800px';
+  host.style.height = '600px';
+  document.body.appendChild(host);
+  reader = new ReadiumReader(host);
+});
+
+afterEach(async () => {
+  await reader.destroy();
+  host.remove();
+});
+
+test('opens the book at its first page and names its chapters', async () => {
+  worker.use(...readiumApi());
+
+  const opened = await reader.open(MANIFEST_URL);
+
+  expect(opened.pageCount).toBe(2);
+  expect(opened.location.locations.position).toBe(1);
+  expect(opened.toc.map((entry) => entry.title)).toEqual(['On Attention', 'Part two']);
+  expect(opened.toc[1].children.map((entry) => entry.title)).toEqual(['On Memory']);
+  expect(frame()).not.toBeNull();
+});
+
+test('next and previous turn the page and report where the reader is', async () => {
+  worker.use(...readiumApi());
+  await reader.open(MANIFEST_URL);
+  const recorded = recordEvents();
+
+  await reader.next();
+  await expect.poll(() => recorded.positions).toContain(2);
+
+  recorded.clear();
+  await reader.previous();
+  await expect.poll(() => recorded.positions).toContain(1);
+});
+
+test('goTo lands on the location it is given', async () => {
+  worker.use(...readiumApi());
+  await reader.open(MANIFEST_URL);
+  const recorded = recordEvents();
+
+  await reader.goTo(aPositionList().positions[1]);
+
+  await expect.poll(() => recorded.positions).toContain(2);
+});
+
+test('goTo rejects a location the book does not contain', async () => {
+  worker.use(...readiumApi());
+  await reader.open(MANIFEST_URL);
+
+  await expect(
+    reader.goTo({
+      href: 'resources/OEBPS/nowhere.xhtml',
+      type: 'application/xhtml+xml',
+      locations: {},
+    })
+  ).rejects.toThrow();
+});
+
+test('a manifest that claims another origin still has its chapters resolve against ours', async () => {
+  worker.use(
+    ...readiumApi({
+      manifest: aManifest({
+        links: [
+          {
+            href: 'https://elsewhere.example/api/v1/readium/books/1/manifest.json',
+            rel: 'self',
+            type: 'application/webpub+json',
+          },
+          {
+            href: 'positions.json',
+            rel: 'http://readium.org/position-list',
+            type: 'application/vnd.readium.position-list+json',
+          },
+        ],
+      }),
+    })
+  );
+
+  await reader.open(MANIFEST_URL);
+  await expect.poll(frameText).toContain('On Attention');
+
+  const base = frame()!.contentDocument!.querySelector('base')!.href;
+  expect(base.startsWith(window.location.origin)).toBe(true);
+});
+
+test('the manifest and the resources are asked for without a bearer token', async () => {
+  const requests: Request[] = [];
+  worker.use(...readiumApi({ onRequest: (request) => requests.push(request) }));
+
+  await reader.open(MANIFEST_URL);
+
+  const paths = requests.map((request) => new URL(request.url).pathname);
+  expect(paths.some((path) => path.includes('/readium/books/1/resources/'))).toBe(true);
+  expect(requests.filter((request) => request.headers.has('authorization'))).toEqual([]);
+});
+
+test('a book with no publication is reported as missing, an unreadable one as an error', async () => {
+  worker.use(...noPublication);
+
+  const missing = await reader.open(MANIFEST_URL).catch((error: unknown) => error);
+
+  expect(missing).toBeInstanceOf(PublicationUnavailableError);
+  expect((missing as PublicationUnavailableError).reason).toBe('missing');
+  expect(host.children).toHaveLength(0);
+
+  worker.use(http.get(MANIFEST_PATH, () => new HttpResponse(null, { status: 500 })));
+  const broken = new ReadiumReader(host);
+  const failed = await broken.open(MANIFEST_URL).catch((error: unknown) => error);
+
+  expect(failed).toBeInstanceOf(PublicationUnavailableError);
+  expect((failed as PublicationUnavailableError).reason).toBe('error');
+  expect(host.children).toHaveLength(0);
+
+  worker.use(http.get(MANIFEST_PATH, () => HttpResponse.html('<!doctype html>')));
+  const notAManifest = new ReadiumReader(host);
+  const garbled = await notAManifest.open(MANIFEST_URL).catch((error: unknown) => error);
+
+  expect(garbled).toBeInstanceOf(PublicationUnavailableError);
+  expect((garbled as PublicationUnavailableError).reason).toBe('error');
+  expect(host.children).toHaveLength(0);
+});
+
+test('an arrow key pressed inside the book asks for a page turn', async () => {
+  worker.use(...readiumApi());
+  await reader.open(MANIFEST_URL);
+  await expect.poll(frameText).toContain('On Attention');
+  const recorded = recordEvents();
+
+  frame()!.contentWindow!.focus();
+  await userEvent.keyboard('{ArrowRight}');
+  await expect.poll(() => recorded.turns).toEqual(['next']);
+
+  await userEvent.keyboard('{ArrowLeft}');
+  await expect.poll(() => recorded.turns).toEqual(['next', 'previous']);
+
+  expect(recorded.positions).toEqual([]);
+
+  recorded.clear();
+  frame()!.blur();
+  await userEvent.keyboard('{ArrowRight}');
+  await expect.poll(() => recorded.turns).toEqual(['next']);
+});
+
+test('a book cannot run its own scripts against the page that opened it', async () => {
+  worker.use(...readiumApi({ hostile: true }));
+
+  // Unsanitised, the chapter's meta refresh navigates the frame away and the
+  // open never settles; the assertions below are what has to report that.
+  void reader.open(MANIFEST_URL).catch(() => undefined);
+  await expect.poll(frameText, { timeout: 5_000 }).toContain('On Attention');
+
+  expect(document.body.getAttribute('data-pwned')).toBeNull();
+  expect(frame()!.contentWindow!.location.href).toMatch(/^blob:/);
+});
+
+test('destroy removes the book from the page and can be called twice', async () => {
+  worker.use(...readiumApi());
+  await reader.open(MANIFEST_URL);
+
+  await reader.destroy();
+
+  expect(frame()).toBeNull();
+  expect(host.children).toHaveLength(0);
+  await expect(reader.destroy()).resolves.toBeUndefined();
+});
+
+test('aborting an open leaves nothing behind', async () => {
+  const controller = new AbortController();
+  worker.use(
+    ...readiumApi({
+      onRequest: (request) => {
+        if (request.url.includes('/resources/')) controller.abort();
+      },
+    })
+  );
+
+  await expect(reader.open(MANIFEST_URL, controller.signal)).rejects.toThrow();
+
+  expect(frame()).toBeNull();
+  expect(host.children).toHaveLength(0);
+});
+
+test(
+  'aborting while the host has no size settles instead of hanging',
+  { timeout: 3_000 },
+  async () => {
+    worker.use(...readiumApi());
+    host.style.width = '0';
+    host.style.height = '0';
+    const controller = new AbortController();
+
+    const opening = reader.open(MANIFEST_URL, controller.signal);
+    setTimeout(() => controller.abort(), 100);
+
+    await expect(opening).rejects.toThrow();
+    expect(host.children).toHaveLength(0);
+  }
+);
+
+test('destroying while the host has no size settles the open', { timeout: 3_000 }, async () => {
+  worker.use(...readiumApi());
+  host.style.width = '0';
+  host.style.height = '0';
+
+  const opening = reader.open(MANIFEST_URL);
+  setTimeout(() => void reader.destroy(), 100);
+
+  await expect(opening).rejects.toThrow();
+  expect(host.children).toHaveLength(0);
+});

--- a/frontend/src/components/reader/ReadiumReader.ts
+++ b/frontend/src/components/reader/ReadiumReader.ts
@@ -1,0 +1,299 @@
+import {
+  PublicationUnavailableError,
+  type EbookLocation,
+  type EbookReader,
+  type EbookTocEntry,
+  type OpenedEbook,
+  type PageTurnDirection,
+} from '@/components/reader/EbookReader.ts';
+import { sanitizeResponse } from '@/components/reader/sanitizeResponse.ts';
+import {
+  EpubNavigator,
+  type EpubNavigatorListeners,
+  type IKeyboardPeripheralsConfig,
+} from '@readium/navigator';
+import { HttpFetcher, Locator, Manifest, Publication, type Link } from '@readium/shared';
+
+const DESTROY_TIMEOUT_MS = 2000;
+
+const CONTAINER_MARKER = 'data-ebook-reader';
+
+// Readium appends its frames with no dimensions at all, so every one of them
+// would render at the browser's default 300x150 box. Only the reflowable pool
+// appends them to the container; the fixed-layout one positions its own wrappers.
+const FRAME_STYLE = `[${CONTAINER_MARKER}] > .readium-navigator-iframe {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  border: none;
+}`;
+
+/** ArrowRight and ArrowLeft, by the legacy key codes Readium's matcher compares. */
+const PAGE_TURN_KEYS: IKeyboardPeripheralsConfig = [
+  { type: 'next_page', keyCombos: [{ keyCode: 39, suppressOnInteractiveElement: true }] },
+  { type: 'previous_page', keyCombos: [{ keyCode: 37, suppressOnInteractiveElement: true }] },
+];
+
+const toLocation = (locator: Locator): EbookLocation => ({
+  href: locator.href,
+  type: locator.type,
+  title: locator.title,
+  locations: {
+    position: locator.locations.position,
+    progression: locator.locations.progression,
+    totalProgression: locator.locations.totalProgression,
+    fragments: locator.locations.fragments,
+  },
+});
+
+const fromLocation = (location: EbookLocation): Locator => {
+  const locator = Locator.deserialize(location);
+  if (!locator) throw new Error('That location does not name a place in a publication.');
+  return locator;
+};
+
+const tocEntriesFrom = (links: Link[]): EbookTocEntry[] =>
+  links.map((link) => ({
+    href: link.href,
+    title: link.title ?? '',
+    children: tocEntriesFrom(link.children?.items ?? []),
+  }));
+
+const whenSized = (element: HTMLElement, signal: AbortSignal) =>
+  new Promise<void>((resolve, reject) => {
+    const isSized = () => element.clientWidth > 0 && element.clientHeight > 0;
+    if (isSized()) {
+      resolve();
+      return;
+    }
+    if (signal.aborted) {
+      reject(signal.reason as Error);
+      return;
+    }
+    const observer = new ResizeObserver(() => {
+      if (!isSized()) return;
+      observer.disconnect();
+      resolve();
+    });
+    // An element that never gains a size would leave the wait pending for as
+    // long as the page lives.
+    signal.addEventListener(
+      'abort',
+      () => {
+        observer.disconnect();
+        reject(signal.reason as Error);
+      },
+      { once: true }
+    );
+    observer.observe(element);
+  });
+
+/** The reader engine on `@readium/navigator`'s `EpubNavigator`. Single-use. */
+export class ReadiumReader implements EbookReader {
+  private readonly locationListeners = new Set<(location: EbookLocation) => void>();
+  private readonly pageTurnListeners = new Set<(direction: PageTurnDirection) => void>();
+  private readonly destruction = new AbortController();
+  private navigator: EpubNavigator | undefined;
+  private wrapper: HTMLDivElement | undefined;
+  private isOpened = false;
+  private isDestroyed = false;
+
+  constructor(private readonly host: HTMLElement) {}
+
+  async open(manifestUrl: string, signal?: AbortSignal): Promise<OpenedEbook> {
+    signal?.throwIfAborted();
+    if (this.isOpened) throw new Error('A reader opens one book; build another one.');
+    this.isOpened = true;
+
+    const publication = await this.publicationFrom(manifestUrl, signal);
+    await this.checkpoint(signal);
+
+    // A book with no position list is still readable; it just has no page numbers.
+    const positions = await publication.positionsFromManifest().catch(() => []);
+    await this.checkpoint(signal);
+
+    // Readium sizes its frames from the container's parent and never recovers
+    // from a 0x0 start.
+    await whenSized(this.host, this.until(signal));
+    await this.checkpoint(signal);
+
+    const navigator = new EpubNavigator(
+      this.mountContainer(),
+      publication,
+      this.navigatorListeners(),
+      positions,
+      undefined,
+      { preferences: {}, defaults: {}, keyboardPeripherals: PAGE_TURN_KEYS }
+    );
+    this.navigator = navigator;
+
+    await navigator.load();
+    // The frame pool lays out from measurements that are final only once the
+    // browser has painted the frames it just added.
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+    await navigator.resizeHandler();
+    await this.checkpoint(signal);
+
+    return {
+      pageCount: positions.length,
+      toc: tocEntriesFrom(publication.toc?.items ?? []),
+      location: toLocation(navigator.currentLocator),
+    };
+  }
+
+  async next(): Promise<void> {
+    // At the last page Readium reports the same `false` it reports for a
+    // location it cannot find, and running out of book is not a failure.
+    await this.move((navigator, done) => navigator.goForward(true, done));
+  }
+
+  async previous(): Promise<void> {
+    await this.move((navigator, done) => navigator.goBackward(true, done));
+  }
+
+  async goTo(location: EbookLocation): Promise<void> {
+    const locator = fromLocation(location);
+    const arrived = await this.move((navigator, done) => navigator.go(locator, false, done));
+    if (!arrived) throw new Error('That location does not name a place in this book.');
+  }
+
+  onLocationChanged(listener: (location: EbookLocation) => void): () => void {
+    return this.subscribe(this.locationListeners, listener);
+  }
+
+  onPageTurnRequested(listener: (direction: PageTurnDirection) => void): () => void {
+    return this.subscribe(this.pageTurnListeners, listener);
+  }
+
+  async destroy(): Promise<void> {
+    if (this.isDestroyed) return;
+    this.isDestroyed = true;
+    this.destruction.abort();
+
+    const abandoned = this.navigator;
+    this.navigator = undefined;
+    if (abandoned) {
+      // A destroy can hang for the same reason a load did; give it a moment,
+      // then let it go.
+      let timeout: ReturnType<typeof setTimeout> | undefined;
+      await Promise.race([
+        abandoned.destroy().catch(() => undefined),
+        new Promise((resolve) => {
+          timeout = setTimeout(resolve, DESTROY_TIMEOUT_MS);
+        }),
+      ]);
+      clearTimeout(timeout);
+    }
+    this.wrapper?.remove();
+    this.wrapper = undefined;
+    this.locationListeners.clear();
+    this.pageTurnListeners.clear();
+  }
+
+  /** The wrapper Readium's ResizeObserver may keep, and the container it draws into. */
+  private mountContainer(): HTMLDivElement {
+    // Readium's own ResizeObserver watches the container's parent for as long as
+    // that parent lives, so the parent has to be ours to throw away.
+    const wrapper = document.createElement('div');
+    wrapper.style.position = 'relative';
+    wrapper.style.height = '100%';
+    this.wrapper = wrapper;
+
+    const container = document.createElement('div');
+    container.setAttribute(CONTAINER_MARKER, '');
+    container.style.position = 'relative';
+    container.style.height = '100%';
+    container.style.margin = '0 auto';
+    const frameStyle = document.createElement('style');
+    frameStyle.textContent = FRAME_STYLE;
+    container.appendChild(frameStyle);
+    wrapper.appendChild(container);
+    this.host.appendChild(wrapper);
+
+    return container;
+  }
+
+  private async publicationFrom(manifestUrl: string, signal?: AbortSignal): Promise<Publication> {
+    const response = await fetch(manifestUrl, { signal });
+    if (response.status === 404) throw new PublicationUnavailableError('missing');
+    if (!response.ok) throw new PublicationUnavailableError('error');
+
+    const manifest = await response
+      .json()
+      .then((payload: unknown) => Manifest.deserialize(payload))
+      .catch(() => null);
+    if (!manifest) throw new PublicationUnavailableError('error');
+
+    // The self link is the publication's base URL, which Readium injects as
+    // `<base href>` into every chapter, so the book's own relative URLs are ours.
+    manifest.setSelfLink(manifestUrl);
+    const fetchSanitized: typeof fetch = async (input, init) =>
+      sanitizeResponse(await fetch(input, init));
+    return new Publication({
+      manifest,
+      fetcher: new HttpFetcher(fetchSanitized, manifestUrl),
+    });
+  }
+
+  private navigatorListeners(): EpubNavigatorListeners {
+    return {
+      frameLoaded: () => {},
+      positionChanged: (locator) => this.notify(this.locationListeners, toLocation(locator)),
+      timelineItemChanged: () => {},
+      // Claimed so Readium's own quarter-screen pager does not turn pages
+      // behind the UI's back.
+      tap: () => true,
+      click: () => true,
+      zoom: () => {},
+      miscPointer: () => {},
+      scroll: () => {},
+      customEvent: () => {},
+      handleLocator: () => false,
+      textSelected: () => {},
+      contentProtection: () => {},
+      contextMenu: () => {},
+      peripheral: (event) => {
+        if (event.type === 'next_page') this.notify(this.pageTurnListeners, 'next');
+        if (event.type === 'previous_page') this.notify(this.pageTurnListeners, 'previous');
+      },
+    };
+  }
+
+  private move(
+    command: (navigator: EpubNavigator, done: (ok: boolean) => void) => void
+  ): Promise<boolean> {
+    const navigator = this.navigator;
+    // A reader with no book has nowhere to go, which is not the same answer as
+    // a book without the place asked for.
+    if (!navigator) return Promise.resolve(true);
+    return new Promise((resolve) => command(navigator, resolve));
+  }
+
+  private subscribe<T>(listeners: Set<(value: T) => void>, listener: (value: T) => void) {
+    listeners.add(listener);
+    return () => listeners.delete(listener);
+  }
+
+  private notify<T>(listeners: Set<(value: T) => void>, value: T): void {
+    for (const listener of [...listeners]) {
+      try {
+        listener(value);
+      } catch {
+        // A subscriber that throws must not reject Readium's in-flight navigation.
+      }
+    }
+  }
+
+  /** The caller's signal and this reader's own destruction, as one. */
+  private until(signal?: AbortSignal): AbortSignal {
+    if (!signal) return this.destruction.signal;
+    return AbortSignal.any([signal, this.destruction.signal]);
+  }
+
+  private async checkpoint(signal?: AbortSignal): Promise<void> {
+    if (!signal?.aborted && !this.isDestroyed) return;
+    await this.destroy();
+    throw signal?.reason ?? new DOMException('Aborted', 'AbortError');
+  }
+}

--- a/frontend/src/components/reader/sanitizeResponse.test.tsx
+++ b/frontend/src/components/reader/sanitizeResponse.test.tsx
@@ -1,0 +1,58 @@
+import { sanitizeResponse } from '@/components/reader/sanitizeResponse.ts';
+import { expect, test } from 'vitest';
+
+const A_HOSTILE_CHAPTER = `<?xml version="1.0" encoding="utf-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <title>On Attention</title>
+    <script>parent.document.body.setAttribute('data-pwned', 'inline')</script>
+    <meta http-equiv="refresh" content="0; url=escape-hatch.xhtml" />
+  </head>
+  <body onload="parent.document.body.setAttribute('data-pwned', 'onload')">
+    <a href="javascript:parent.document.body.setAttribute('data-pwned','href')">A link.</a>
+  </body>
+</html>`;
+
+const sanitizedText = async (body: string, contentType: string, status = 200) => {
+  const response = await sanitizeResponse(
+    new Response(body, { status, headers: { 'Content-Type': contentType } })
+  );
+  return response.text();
+};
+
+test('a chapter arrives with no way left to name executable code', async () => {
+  const sanitized = await sanitizedText(A_HOSTILE_CHAPTER, 'application/xhtml+xml');
+
+  expect(sanitized).not.toContain('<script');
+  expect(sanitized).not.toContain('onload=');
+  expect(sanitized).not.toContain('javascript:');
+  expect(sanitized).not.toContain('refresh');
+});
+
+test('a chapter arrives under a policy that allows only the navigator its scripts', async () => {
+  const sanitized = await sanitizedText(A_HOSTILE_CHAPTER, 'application/xhtml+xml');
+
+  const head = new DOMParser().parseFromString(sanitized, 'application/xhtml+xml').head;
+  expect(head.firstElementChild?.getAttribute('http-equiv')).toBe('Content-Security-Policy');
+  expect(head.firstElementChild?.getAttribute('content')).toBe(
+    "script-src blob:; object-src 'none'; child-src 'none'"
+  );
+});
+
+test('a stylesheet passes through byte-identical', async () => {
+  const stylesheet = 'body { margin: 0; }\n/* onload= javascript: */';
+
+  expect(await sanitizedText(stylesheet, 'text/css')).toBe(stylesheet);
+});
+
+test('a chapter that does not parse is handed on as it was written', async () => {
+  const unparsable = '<html><head><unclosed></html>';
+
+  expect(await sanitizedText(unparsable, 'application/xhtml+xml')).toBe(unparsable);
+});
+
+test('a chapter the server refused to serve is handed on untouched', async () => {
+  expect(await sanitizedText(A_HOSTILE_CHAPTER, 'application/xhtml+xml', 502)).toBe(
+    A_HOSTILE_CHAPTER
+  );
+});

--- a/frontend/src/components/reader/sanitizeResponse.ts
+++ b/frontend/src/components/reader/sanitizeResponse.ts
@@ -1,0 +1,75 @@
+/**
+ * Strips a publication's own JavaScript before Readium ever frames it.
+ *
+ * Readium frames each chapter as a same-origin `blob:` document with
+ * `allow-same-origin allow-scripts`, so a `<script>` in a book would run as the
+ * signed-in user. `script-src blob:` keeps Readium's own injected scripts —
+ * they are `blob:` URLs — and nothing else; removing `allow-scripts` would kill
+ * those injectables too.
+ */
+
+// `child-src`/`object-src` are closed because a nested browsing context loaded
+// from the API origin would be a fresh same-origin document carrying no policy.
+const CONTENT_POLICY = ['script-src blob:', "object-src 'none'", "child-src 'none'"].join('; ');
+
+const parserTypeFor = (contentType: string): DOMParserSupportedType | null => {
+  const type = contentType.split(';')[0].trim().toLowerCase();
+  if (type === 'application/xhtml+xml') return 'application/xhtml+xml';
+  if (type === 'text/html') return 'text/html';
+  return null;
+};
+
+const isEventHandler = (name: string) => name.toLowerCase().startsWith('on');
+
+const isJavascriptUrl = (value: string) => /^\s*javascript:/i.test(value);
+
+const disarm = (doc: Document): void => {
+  doc.querySelectorAll('script').forEach((script) => script.remove());
+
+  // A declarative refresh resolves against the base Readium injects and lands
+  // the frame on a plain API response: no blob, no policy, never sanitised.
+  doc.querySelectorAll('meta').forEach((meta) => {
+    const pragma = meta.getAttribute('http-equiv')?.trim().toLowerCase();
+    if (pragma === 'refresh') meta.remove();
+  });
+
+  doc.querySelectorAll('*').forEach((element) => {
+    for (const attribute of Array.from(element.attributes)) {
+      const isUrlAttribute = attribute.name === 'href' || attribute.name === 'src';
+      if (isEventHandler(attribute.name) || (isUrlAttribute && isJavascriptUrl(attribute.value))) {
+        element.removeAttribute(attribute.name);
+      }
+    }
+  });
+};
+
+const sanitize = (text: string, parserType: DOMParserSupportedType): string => {
+  const doc = new DOMParser().parseFromString(text, parserType);
+  // A document that does not parse is Readium's to complain about, in its own
+  // words, rather than ours to hand back as a mangled serialisation.
+  if (doc.querySelector('parsererror')) return text;
+
+  disarm(doc);
+
+  const head = doc.head as HTMLHeadElement | null;
+  if (head) {
+    const meta = doc.createElement('meta');
+    meta.setAttribute('http-equiv', 'Content-Security-Policy');
+    meta.setAttribute('content', CONTENT_POLICY);
+    head.prepend(meta);
+  }
+
+  return new XMLSerializer().serializeToString(doc);
+};
+
+/** Returns the response with any markup document in it disarmed; anything else untouched. */
+export const sanitizeResponse = async (response: Response): Promise<Response> => {
+  const parserType = parserTypeFor(response.headers.get('content-type') ?? '');
+  if (!response.ok || parserType === null) return response;
+
+  return new Response(sanitize(await response.text(), parserType), {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+  });
+};

--- a/frontend/src/components/reader/useEbookReader.ts
+++ b/frontend/src/components/reader/useEbookReader.ts
@@ -1,0 +1,134 @@
+import {
+  PublicationUnavailableError,
+  type EbookLocation,
+  type EbookReader,
+  type OpenedEbook,
+} from '@/components/reader/EbookReader.ts';
+import { ReadiumReader } from '@/components/reader/ReadiumReader.ts';
+import { useCallback, useEffect, useRef, useState, type RefObject } from 'react';
+
+/** How long a book has to appear before the reader is told it never will. */
+const BOOT_TIMEOUT_MS = 15_000;
+
+/** How an attempt at a book ended. */
+type EbookReaderOutcome = 'open' | 'missing' | 'error' | 'timeout';
+
+/** Whether the book is on screen, on its way there, or out of reach and why. */
+type EbookReaderStatus = 'idle' | 'opening' | EbookReaderOutcome;
+
+export interface UseEbookReaderOptions {
+  host: RefObject<HTMLElement | null>;
+  manifestUrl: string;
+  /** False until the publication cookie exists; nothing is fetched before then. */
+  enabled: boolean;
+  /** True while a lapsed cookie is being replaced: a page fetched with a dead
+   * credential comes back blank. */
+  holdPageTurns: boolean;
+  /** Must be referentially stable: an inline arrow rebuilds the reader every render. */
+  createReader?: (host: HTMLElement) => EbookReader;
+  bootTimeoutMs?: number;
+}
+
+export interface EbookReaderState {
+  status: EbookReaderStatus;
+  pageCount: number;
+  location: EbookLocation | null;
+  next: () => void;
+  previous: () => void;
+  retry: () => void;
+}
+
+const aReadiumReader = (host: HTMLElement): EbookReader => new ReadiumReader(host);
+
+const outcomeOfFailure = (error: unknown): EbookReaderOutcome => {
+  if (error instanceof PublicationUnavailableError) return error.reason;
+  if (error instanceof DOMException && error.name === 'TimeoutError') return 'timeout';
+  return 'error';
+};
+
+/** One book opened into a host element, and where the reader is in it. */
+export const useEbookReader = ({
+  host,
+  manifestUrl,
+  enabled,
+  holdPageTurns,
+  createReader = aReadiumReader,
+  bootTimeoutMs = BOOT_TIMEOUT_MS,
+}: UseEbookReaderOptions): EbookReaderState => {
+  const [outcome, setOutcome] = useState<EbookReaderOutcome | null>(null);
+  const [pageCount, setPageCount] = useState(0);
+  const [location, setLocation] = useState<EbookLocation | null>(null);
+  const [attempt, setAttempt] = useState(0);
+  const readerRef = useRef<EbookReader | null>(null);
+  // Through a ref, so a hold that starts mid-book never rebuilds the reader.
+  const holdRef = useRef(holdPageTurns);
+  useEffect(() => {
+    holdRef.current = holdPageTurns;
+  }, [holdPageTurns]);
+
+  useEffect(() => {
+    const element = host.current;
+    if (!enabled || !element) return;
+
+    const reader = createReader(element);
+    readerRef.current = reader;
+    const cancel = new AbortController();
+    const signal = AbortSignal.any([cancel.signal, AbortSignal.timeout(bootTimeoutMs)]);
+    let isOpen = false;
+    const unsubscribes = [
+      reader.onLocationChanged(setLocation),
+      reader.onPageTurnRequested((direction) => {
+        // Readium's pager sets a navigating flag it never clears when it has no
+        // frames yet, so one key before the book is up kills every later turn.
+        if (holdRef.current || !isOpen) return;
+        void (direction === 'next' ? reader.next() : reader.previous());
+      }),
+    ];
+
+    const onOpened = (opened: OpenedEbook) => {
+      if (cancel.signal.aborted) return;
+      isOpen = true;
+      setPageCount(opened.pageCount);
+      setLocation(opened.location);
+      setOutcome('open');
+    };
+    const onFailed = (error: unknown) => {
+      // The one rejection that means nothing: this effect was cleaned up.
+      if (cancel.signal.aborted) return;
+      setOutcome(outcomeOfFailure(error));
+    };
+
+    // The engine cannot cancel a fetch Readium itself started, so a hanging
+    // resource would leave `open` pending long past the watchdog's deadline.
+    const abortedFirst = new Promise<never>((_, reject) => {
+      signal.addEventListener('abort', () => reject(signal.reason as Error), { once: true });
+    });
+    Promise.race([reader.open(manifestUrl, signal), abortedFirst]).then(onOpened, onFailed);
+
+    return () => {
+      cancel.abort();
+      for (const unsubscribe of unsubscribes) unsubscribe();
+      // Never awaited, and a reader is single-use, so the next run builds a
+      // fresh one: that is what makes StrictMode's double mount harmless.
+      void reader.destroy();
+      readerRef.current = null;
+    };
+  }, [enabled, manifestUrl, attempt, createReader, bootTimeoutMs, host]);
+
+  const next = useCallback(() => void readerRef.current?.next(), []);
+  const previous = useCallback(() => void readerRef.current?.previous(), []);
+  // Both, and in one go: the host is unmounted behind the message this is
+  // offered on, and has to be back in the tree before the new attempt looks for it.
+  const retry = useCallback(() => {
+    setOutcome(null);
+    // Otherwise the last attempt's page label sits over the new attempt's skeleton.
+    setPageCount(0);
+    setAttempt((count) => count + 1);
+  }, []);
+
+  // Derived rather than stored, so that starting an attempt is not itself a
+  // render: an effect that set the status would cascade one on every open.
+  const status: EbookReaderStatus = enabled ? (outcome ?? 'opening') : 'idle';
+
+  return { status, pageCount, location, next, previous, retry };
+};

--- a/frontend/src/components/reader/useReaderSession.test.tsx
+++ b/frontend/src/components/reader/useReaderSession.test.tsx
@@ -1,0 +1,142 @@
+import { useReaderSession, type ReaderSession } from '@/components/reader/useReaderSession.ts';
+import { worker } from '@tests/msw/worker';
+import { http, HttpResponse } from 'msw';
+import { useEffect } from 'react';
+import { beforeEach, expect, test } from 'vitest';
+import { render } from 'vitest-browser-react';
+
+const SESSION_PATH = '/api/v1/readium/books/:bookId/session';
+const REFRESH_PATH = '/api/v1/auth/refresh';
+
+const posts: string[] = [];
+const renewals: boolean[] = [];
+
+beforeEach(() => {
+  posts.length = 0;
+  renewals.length = 0;
+});
+
+const aSessionLasting = (seconds: number) =>
+  http.post(SESSION_PATH, () => {
+    posts.push('minted');
+    return HttpResponse.json({ expires_in: seconds });
+  });
+
+const aRefusedSession = (status: number, options?: { once: boolean }) =>
+  http.post(
+    SESSION_PATH,
+    () => {
+      posts.push('refused');
+      return new HttpResponse(null, { status });
+    },
+    options
+  );
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const Probe = () => {
+  const { status, isRenewing } = useReaderSession(1);
+
+  useEffect(() => {
+    if (renewals[renewals.length - 1] !== isRenewing) renewals.push(isRenewing);
+  }, [isRenewing]);
+
+  return (
+    <>
+      <output data-testid="status">{status}</output>
+      <output data-testid="renewing">{String(isRenewing)}</output>
+    </>
+  );
+};
+
+type Screen = Awaited<ReturnType<typeof render>>;
+
+const expectStatus = (screen: Screen, status: ReaderSession['status']) =>
+  expect.element(screen.getByTestId('status')).toHaveTextContent(status);
+
+test('a session is ready once the first cookie has been minted', async () => {
+  worker.use(aSessionLasting(900));
+
+  const screen = await render(<Probe />);
+
+  await expectStatus(screen, 'ready');
+  expect(renewals).toEqual([false]);
+  expect(posts).toEqual(['minted']);
+});
+
+test('a session the server refuses before any cookie exists is fatal', async () => {
+  worker.use(aRefusedSession(500));
+
+  const screen = await render(<Probe />);
+  await expectStatus(screen, 'error');
+
+  // Past the shortest retry delay (1 s): a first failure must schedule none.
+  await sleep(1_500);
+
+  await expectStatus(screen, 'error');
+  expect(posts).toEqual(['refused']);
+});
+
+test('a 401 the app cannot refresh past is fatal too', async () => {
+  // A refresh the server rejects ends the session app-wide, and the axios layer
+  // says so by navigating to /login — which would unload the test page. On that
+  // path the redirect is a no-op, leaving only the rejection the hook sees.
+  window.history.pushState(null, '', '/login');
+  worker.use(aRefusedSession(401));
+  worker.use(http.post(REFRESH_PATH, () => new HttpResponse(null, { status: 401 })));
+
+  const screen = await render(<Probe />);
+
+  await expectStatus(screen, 'error');
+});
+
+test('a failed renewal keeps the session and retries', async () => {
+  worker.use(aSessionLasting(1));
+
+  const screen = await render(<Probe />);
+  await expectStatus(screen, 'ready');
+
+  // Past the 1 s cookie but under the 5 s refresh floor, so nothing has renewed it.
+  await sleep(1_200);
+  worker.use(aSessionLasting(900));
+  worker.use(aRefusedSession(500, { once: true }));
+  window.dispatchEvent(new Event('focus'));
+
+  await expect.element(screen.getByTestId('renewing')).toHaveTextContent('true');
+  await expectStatus(screen, 'ready');
+
+  // The first retry lands a second later.
+  await expect
+    .element(screen.getByTestId('renewing'), { timeout: 2_000 })
+    .toHaveTextContent('false');
+  expect(posts).toEqual(['minted', 'refused', 'minted']);
+});
+
+test('renewing before the cookie lapses is invisible', async () => {
+  worker.use(aSessionLasting(5));
+
+  const screen = await render(<Probe />);
+  await expectStatus(screen, 'ready');
+
+  // A 5 s cookie is well inside the 30 s wake margin and nowhere near lapsing.
+  await sleep(300);
+  window.dispatchEvent(new Event('focus'));
+
+  await expect.poll(() => posts).toEqual(['minted', 'minted']);
+  expect(renewals).toEqual([false]);
+});
+
+test('an unmounted session mints nothing more', async () => {
+  worker.use(aSessionLasting(1));
+
+  const screen = await render(<Probe />);
+  await expectStatus(screen, 'ready');
+  screen.unmount();
+
+  // Past the 1 s cookie, so a session still mounted would renew on this focus.
+  await sleep(1_200);
+  window.dispatchEvent(new Event('focus'));
+  await sleep(100);
+
+  expect(posts).toEqual(['minted']);
+});

--- a/frontend/src/components/reader/useReaderSession.ts
+++ b/frontend/src/components/reader/useReaderSession.ts
@@ -1,0 +1,114 @@
+/**
+ * Keeps a publication cookie alive for one book while the reader is open.
+ *
+ * The navigator loads a book's resources into iframes, and an iframe load
+ * carries cookies and nothing else — never the in-memory access token, which
+ * is what this second credential buys. A 401 belongs to the axios interceptor,
+ * not here: it refreshes and replays, and only a dead session reaches us.
+ *
+ * Nothing here resets when `bookId` changes: the shell is keyed by book, so a
+ * different book is a different component with its own state.
+ */
+import { startPublicationSession } from '@/api/generated/readium/readium.ts';
+import { useEffect, useRef, useState } from 'react';
+
+// The cookie is httpOnly, so the page never sees it expire and can only go by
+// the `expires_in` it was told; four fifths of that leaves room for a slow post.
+const REFRESH_AT = 0.8;
+
+/** Never spin: a server that answered with a tiny expiry must not be hammered. */
+const MIN_REFRESH_MS = 5_000;
+
+/** How close to expiry counts as "renew now" when the tab comes back. */
+const WAKE_MARGIN_MS = 30_000;
+
+/** Backoff for a renewal that failed while the book is still open. */
+const RETRY_DELAYS_MS = [1_000, 2_000, 5_000, 15_000, 30_000];
+
+type ReaderSessionStatus = 'pending' | 'ready' | 'error';
+
+export interface ReaderSession {
+  status: ReaderSessionStatus;
+  /** True only while a cookie that has actually lapsed is being replaced. */
+  isRenewing: boolean;
+}
+
+const refreshDelayMs = (expiresIn: number) =>
+  Math.max(expiresIn * 1000 * REFRESH_AT, MIN_REFRESH_MS);
+
+/** One book's publication cookie, minted on open and re-minted before it lapses. */
+export const useReaderSession = (bookId: number): ReaderSession => {
+  const [status, setStatus] = useState<ReaderSessionStatus>('pending');
+  const [isRenewing, setIsRenewing] = useState(false);
+  // Null until a cookie has ever been issued, which is what separates "this
+  // reader never started" from "a renewal went wrong mid-book".
+  const expiresAtRef = useRef<number | null>(null);
+  const failuresRef = useRef(0);
+
+  useEffect(() => {
+    // Read through a call, never the flag itself: assignments from the cleanup
+    // are invisible to the compiler, which would prove the checks redundant.
+    const teardown = new AbortController();
+    const isStale = () => teardown.signal.aborted;
+    let inFlight = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    const schedule = (delay: number) => {
+      clearTimeout(timer);
+      timer = setTimeout(() => void mintCookie(), delay);
+    };
+
+    const mintCookie = async () => {
+      if (isStale() || inFlight) return;
+      inFlight = true;
+      try {
+        const session = await startPublicationSession(bookId);
+        if (isStale()) return;
+        failuresRef.current = 0;
+        expiresAtRef.current = Date.now() + session.expires_in * 1000;
+        setIsRenewing(false);
+        setStatus('ready');
+        schedule(refreshDelayMs(session.expires_in));
+      } catch {
+        if (isStale()) return;
+        // Never having held a cookie is fatal: nothing can load without one.
+        if (expiresAtRef.current === null) {
+          setStatus('error');
+          return;
+        }
+        // Losing a renewal is not: the cookie in the browser may still be good
+        // and the reader mid-page, so a blip must not cost them their place.
+        const delay = RETRY_DELAYS_MS[Math.min(failuresRef.current, RETRY_DELAYS_MS.length - 1)];
+        failuresRef.current += 1;
+        schedule(delay);
+      } finally {
+        inFlight = false;
+      }
+    };
+
+    // A backgrounded tab has its timers throttled to minutes and a sleeping
+    // machine runs none, so the renewal can land long after the cookie died.
+    const renewIfDue = () => {
+      if (isStale() || document.visibilityState !== 'visible') return;
+      const expiresAt = expiresAtRef.current;
+      if (expiresAt === null || Date.now() <= expiresAt - WAKE_MARGIN_MS) return;
+      // A cookie that has actually run out leaves the navigator loading against
+      // a dead credential; one renewed early needs no such ceremony.
+      if (Date.now() >= expiresAt) setIsRenewing(true);
+      void mintCookie();
+    };
+
+    void mintCookie();
+    document.addEventListener('visibilitychange', renewIfDue);
+    window.addEventListener('focus', renewIfDue);
+
+    return () => {
+      teardown.abort();
+      clearTimeout(timer);
+      document.removeEventListener('visibilitychange', renewIfDue);
+      window.removeEventListener('focus', renewIfDue);
+    };
+  }, [bookId]);
+
+  return { status, isRenewing };
+};

--- a/frontend/src/pages/BookPage/BookTitle/BookTitle.tsx
+++ b/frontend/src/pages/BookPage/BookTitle/BookTitle.tsx
@@ -1,6 +1,7 @@
 import type { BookDetails } from '@/api/generated/model';
 import { BookCover } from '@/components/BookCover.tsx';
 import { IconButtonWithTooltip } from '@/components/buttons/IconButtonWithTooltip.tsx';
+import { OpenInReaderButton } from '@/components/reader/OpenInReaderButton.tsx';
 import { ReadingStageChip } from '@/pages/BookPage/Reflection/ReadingStageChip.tsx';
 import { ManageIcon } from '@/theme/Icons.tsx';
 import { Box, LinearProgress, Tooltip, Typography } from '@mui/material';
@@ -12,6 +13,13 @@ import { BookStatsStrip } from './BookStatsStrip.tsx';
 export interface BookTitleProps {
   book: BookDetails;
 }
+
+const titleActionSx = {
+  color: 'text.primary',
+  ml: 0.5,
+  verticalAlign: 'middle',
+  '& svg': { fontSize: '1.75rem' },
+} as const;
 
 export const BookTitle = ({ book }: BookTitleProps) => {
   const [editDialogOpen, setEditDialogOpen] = useState(false);
@@ -97,13 +105,9 @@ export const BookTitle = ({ book }: BookTitleProps) => {
               onClick={handleEdit}
               icon={<ManageIcon />}
               size="small"
-              sx={{
-                color: 'text.primary',
-                ml: 0.5,
-                verticalAlign: 'middle',
-                '& svg': { fontSize: '1.75rem' },
-              }}
+              sx={titleActionSx}
             />
+            <OpenInReaderButton bookId={book.id} size="small" sx={titleActionSx} />
           </Typography>
 
           <Typography

--- a/frontend/src/pages/BookPage/navigation/bookPageRoutes.ts
+++ b/frontend/src/pages/BookPage/navigation/bookPageRoutes.ts
@@ -3,6 +3,7 @@ import {
   FlashcardsIcon,
   HighlightsIcon,
   NotesIcon,
+  ReaderIcon,
   ReflectionIcon,
   StatisticsIcon,
 } from '@/theme/Icons.tsx';
@@ -13,6 +14,7 @@ type BookPageRoute =
   | '/book/$bookId/highlights'
   | '/book/$bookId/flashcards'
   | '/book/$bookId/notes'
+  | '/book/$bookId/read'
   | '/book/$bookId/reflection'
   | '/book/$bookId/statistics';
 
@@ -26,6 +28,7 @@ export const BOOK_PAGE_LABELS = {
   highlights: 'Highlights',
   flashcards: 'Flashcards',
   notes: 'Notes',
+  read: 'Read',
   reflection: 'Reflection',
   statistics: 'Statistics',
 } as const;
@@ -65,6 +68,11 @@ export const BOOK_PAGE_ROUTES: BookPageRouteConfig[] = [
     to: '/book/$bookId/notes',
     segment: 'notes',
     icon: NotesIcon,
+  },
+  {
+    to: '/book/$bookId/read',
+    segment: 'read',
+    icon: ReaderIcon,
   },
   {
     to: '/book/$bookId/reflection',

--- a/frontend/src/pages/ReaderPage/ReaderPage.test.tsx
+++ b/frontend/src/pages/ReaderPage/ReaderPage.test.tsx
@@ -1,10 +1,15 @@
 import { aBookDetails } from '@tests/fixtures/book';
 import { renderApp } from '@tests/harness/renderApp';
 import { bookApi } from '@tests/msw/bookApi';
-import { readiumApi } from '@tests/msw/readiumApi';
+import { noPublication, readiumApi } from '@tests/msw/readiumApi';
 import { worker } from '@tests/msw/worker';
-import { http, HttpResponse } from 'msw';
+import { delay, http, HttpResponse } from 'msw';
 import { expect, test } from 'vitest';
+import { userEvent } from 'vitest/browser';
+
+const MANIFEST_PATH = '/api/v1/readium/books/:bookId/manifest.json';
+const SESSION_PATH = '/api/v1/readium/books/:bookId/session';
+const RESOURCE_PATH = '/api/v1/readium/books/:bookId/resources/*';
 
 const elementUnderTheAppBar = () => {
   const { left, top, width, height } = document.querySelector('header')!.getBoundingClientRect();
@@ -22,6 +27,16 @@ const aReadableBook = () =>
   bookApi({
     book: aBookDetails({ title: 'The Pragmatic Reader', author: 'Ada Lovelace' }),
   }).handlers;
+
+/** The book open at its first page, which is where every reading test starts. */
+const openTheBook = async () => {
+  const screen = await renderApp({ path: '/book/1/read' });
+  await expect.element(screen.getByText('Page 1 of 2')).toBeVisible();
+  return screen;
+};
+
+const expectPage = (screen: Screen, label: string) =>
+  expect.element(screen.getByText(label), { timeout: 5_000 }).toBeVisible();
 
 test('the book header offers to open the book in the reader', async () => {
   worker.use(...aReadableBook());
@@ -67,12 +82,7 @@ test('closing the reader leads to the book page', async () => {
 
 test('a session that cannot be started reports it and offers the way back', async () => {
   worker.use(...aReadableBook());
-  worker.use(
-    http.post(
-      '/api/v1/readium/books/:bookId/session',
-      () => new HttpResponse(null, { status: 500 })
-    )
-  );
+  worker.use(http.post(SESSION_PATH, () => new HttpResponse(null, { status: 500 })));
 
   const screen = await renderApp({ path: '/book/1/read' });
 
@@ -87,4 +97,121 @@ test('a session that cannot be started reports it and offers the way back', asyn
   await screen.getByRole('button', { name: 'Back to book' }).click();
 
   await expect.element(screen.getByRole('heading', { name: 'Ada Lovelace' })).toBeVisible();
+});
+
+test('the book opens at its first page', async () => {
+  worker.use(...aReadableBook());
+  worker.use(...readiumApi());
+
+  const screen = await openTheBook();
+
+  await expect.element(screen.getByRole('button', { name: 'Previous page' })).toBeEnabled();
+  await expect.element(screen.getByRole('button', { name: 'Next page' })).toBeEnabled();
+});
+
+test('the next button turns the page and the label follows', async () => {
+  worker.use(...aReadableBook());
+  worker.use(...readiumApi());
+
+  const screen = await openTheBook();
+
+  await screen.getByRole('button', { name: 'Next page' }).click();
+  await expectPage(screen, 'Page 2 of 2');
+
+  await screen.getByRole('button', { name: 'Previous page' }).click();
+  await expectPage(screen, 'Page 1 of 2');
+});
+
+test('the arrow keys turn the page', async () => {
+  worker.use(...aReadableBook());
+  worker.use(...readiumApi());
+
+  const screen = await openTheBook();
+
+  await userEvent.keyboard('{ArrowRight}');
+  await expectPage(screen, 'Page 2 of 2');
+
+  await userEvent.keyboard('{ArrowLeft}');
+  await expectPage(screen, 'Page 1 of 2');
+});
+
+test('an arrow key pressed before the book is on screen does not jam it', async () => {
+  worker.use(...aReadableBook());
+  worker.use(...readiumApi());
+  // The chapter alone is late; everything else is served as usual by falling
+  // through to the handler registered underneath this one.
+  worker.use(
+    http.get(RESOURCE_PATH, async ({ params }) => {
+      if (String(params[0]) !== 'OEBPS/chapter1.xhtml') return;
+      await delay(1_500);
+    })
+  );
+
+  const screen = await renderApp({ path: '/book/1/read' });
+  await expect.element(screen.getByLabelText('Loading the book')).toBeVisible();
+  await userEvent.keyboard('{ArrowRight}');
+
+  await expectPage(screen, 'Page 1 of 2');
+  await screen.getByRole('button', { name: 'Next page' }).click();
+  await expectPage(screen, 'Page 2 of 2');
+});
+
+test('a book with no EPUB explains there is nothing to read', async () => {
+  worker.use(...aReadableBook());
+  worker.use(...noPublication);
+
+  const screen = await renderApp({ path: '/book/1/read' });
+
+  await expect
+    .element(
+      screen.getByText(
+        'This book has no EPUB file, so there is nothing to read here yet. Upload one to read it in the browser.'
+      )
+    )
+    .toBeVisible();
+  await expect.element(screen.getByRole('button', { name: 'Back to book' })).toBeVisible();
+  await expect.element(screen.getByRole('button', { name: 'Try again' })).not.toBeInTheDocument();
+});
+
+test('a book whose manifest cannot be read says so and offers a retry', async () => {
+  worker.use(...aReadableBook());
+  worker.use(http.post(SESSION_PATH, () => HttpResponse.json({ expires_in: 900 })));
+  worker.use(http.get(MANIFEST_PATH, () => new HttpResponse(null, { status: 500 })));
+
+  const screen = await renderApp({ path: '/book/1/read' });
+
+  await expect
+    .element(screen.getByText('The book could not be opened. Please try again later.'))
+    .toBeVisible();
+
+  worker.use(...readiumApi());
+  await screen.getByRole('button', { name: 'Try again' }).click();
+
+  await expectPage(screen, 'Page 1 of 2');
+});
+
+test('a lapsed session holds the book until it has been renewed', async () => {
+  worker.use(...aReadableBook());
+  // One second of life, so the cookie has genuinely lapsed by the time the tab
+  // is brought back. The scheduled renewal cannot interfere: its floor is five.
+  worker.use(...readiumApi({ expiresIn: 1 }));
+
+  const screen = await openTheBook();
+
+  worker.use(
+    http.post(SESSION_PATH, async () => {
+      await delay(2_000);
+      return HttpResponse.json({ expires_in: 900 });
+    })
+  );
+  await new Promise((resolve) => setTimeout(resolve, 1_200));
+  window.dispatchEvent(new Event('focus'));
+
+  await expect.element(screen.getByText('Reconnecting…')).toBeVisible();
+  await expect.element(screen.getByRole('button', { name: 'Next page' })).toBeDisabled();
+
+  await expect
+    .element(screen.getByText('Reconnecting…'), { timeout: 5_000 })
+    .not.toBeInTheDocument();
+  await expect.element(screen.getByRole('button', { name: 'Next page' })).toBeEnabled();
 });

--- a/frontend/src/pages/ReaderPage/ReaderPage.test.tsx
+++ b/frontend/src/pages/ReaderPage/ReaderPage.test.tsx
@@ -1,0 +1,60 @@
+import { aBookDetails } from '@tests/fixtures/book';
+import { renderApp } from '@tests/harness/renderApp';
+import { bookApi } from '@tests/msw/bookApi';
+import { worker } from '@tests/msw/worker';
+import { expect, test } from 'vitest';
+
+const elementUnderTheAppBar = () => {
+  const { left, top, width, height } = document.querySelector('header')!.getBoundingClientRect();
+  return document.elementFromPoint(left + width / 2, top + height / 2);
+};
+
+type Screen = Awaited<ReturnType<typeof renderApp>>;
+
+const expectTheReaderOpen = async (screen: Screen) => {
+  await expect.element(screen.getByRole('button', { name: 'Close reader' })).toBeVisible();
+  expect(screen.router.state.location.pathname).toBe('/book/1/read');
+};
+
+const aReadableBook = () =>
+  bookApi({
+    book: aBookDetails({ title: 'The Pragmatic Reader', author: 'Ada Lovelace' }),
+  }).handlers;
+
+test('the book header offers to open the book in the reader', async () => {
+  worker.use(...aReadableBook());
+
+  const screen = await renderApp({ path: '/book/1' });
+  await screen.getByRole('link', { name: 'Open in reader' }).click();
+
+  await expectTheReaderOpen(screen);
+});
+
+test('the book navigation offers to read the book', async () => {
+  worker.use(...aReadableBook());
+
+  const screen = await renderApp({ path: '/book/1' });
+  await screen.getByRole('link', { name: 'Read', exact: true }).click();
+
+  await expectTheReaderOpen(screen);
+});
+
+test('the reader opens with the book title and a way out', async () => {
+  worker.use(...aReadableBook());
+
+  const screen = await renderApp({ path: '/book/1/read' });
+
+  await expect.element(screen.getByRole('heading', { name: 'The Pragmatic Reader' })).toBeVisible();
+  await expect.element(screen.getByRole('button', { name: 'Close reader' })).toBeVisible();
+  await expect.element(screen.getByRole('button', { name: 'Manage book' })).not.toBeInTheDocument();
+  expect(elementUnderTheAppBar()?.closest('header')).toBeNull();
+});
+
+test('closing the reader leads to the book page', async () => {
+  worker.use(...aReadableBook());
+
+  const screen = await renderApp({ path: '/book/1/read' });
+  await screen.getByRole('button', { name: 'Close reader' }).click();
+
+  await expect.element(screen.getByRole('heading', { name: 'Ada Lovelace' })).toBeVisible();
+});

--- a/frontend/src/pages/ReaderPage/ReaderPage.test.tsx
+++ b/frontend/src/pages/ReaderPage/ReaderPage.test.tsx
@@ -1,7 +1,9 @@
 import { aBookDetails } from '@tests/fixtures/book';
 import { renderApp } from '@tests/harness/renderApp';
 import { bookApi } from '@tests/msw/bookApi';
+import { readiumApi } from '@tests/msw/readiumApi';
 import { worker } from '@tests/msw/worker';
+import { http, HttpResponse } from 'msw';
 import { expect, test } from 'vitest';
 
 const elementUnderTheAppBar = () => {
@@ -23,6 +25,7 @@ const aReadableBook = () =>
 
 test('the book header offers to open the book in the reader', async () => {
   worker.use(...aReadableBook());
+  worker.use(...readiumApi());
 
   const screen = await renderApp({ path: '/book/1' });
   await screen.getByRole('link', { name: 'Open in reader' }).click();
@@ -32,6 +35,7 @@ test('the book header offers to open the book in the reader', async () => {
 
 test('the book navigation offers to read the book', async () => {
   worker.use(...aReadableBook());
+  worker.use(...readiumApi());
 
   const screen = await renderApp({ path: '/book/1' });
   await screen.getByRole('link', { name: 'Read', exact: true }).click();
@@ -41,6 +45,7 @@ test('the book navigation offers to read the book', async () => {
 
 test('the reader opens with the book title and a way out', async () => {
   worker.use(...aReadableBook());
+  worker.use(...readiumApi());
 
   const screen = await renderApp({ path: '/book/1/read' });
 
@@ -52,9 +57,34 @@ test('the reader opens with the book title and a way out', async () => {
 
 test('closing the reader leads to the book page', async () => {
   worker.use(...aReadableBook());
+  worker.use(...readiumApi());
 
   const screen = await renderApp({ path: '/book/1/read' });
   await screen.getByRole('button', { name: 'Close reader' }).click();
+
+  await expect.element(screen.getByRole('heading', { name: 'Ada Lovelace' })).toBeVisible();
+});
+
+test('a session that cannot be started reports it and offers the way back', async () => {
+  worker.use(...aReadableBook());
+  worker.use(
+    http.post(
+      '/api/v1/readium/books/:bookId/session',
+      () => new HttpResponse(null, { status: 500 })
+    )
+  );
+
+  const screen = await renderApp({ path: '/book/1/read' });
+
+  await expect
+    .element(
+      screen.getByText(
+        'The reader could not start a session for this book. Please try again later.'
+      )
+    )
+    .toBeVisible();
+
+  await screen.getByRole('button', { name: 'Back to book' }).click();
 
   await expect.element(screen.getByRole('heading', { name: 'Ada Lovelace' })).toBeVisible();
 });

--- a/frontend/src/pages/ReaderPage/ReaderPage.tsx
+++ b/frontend/src/pages/ReaderPage/ReaderPage.tsx
@@ -9,6 +9,8 @@ export const ReaderPage = () => {
 
   return (
     <ReaderShell
+      key={bookId}
+      bookId={Number(bookId)}
       title={book?.title ?? ''}
       onClose={() => void navigate({ to: '/book/$bookId', params: { bookId: String(bookId) } })}
     />

--- a/frontend/src/pages/ReaderPage/ReaderPage.tsx
+++ b/frontend/src/pages/ReaderPage/ReaderPage.tsx
@@ -1,0 +1,16 @@
+import { useGetBookDetails } from '@/api/generated/books/books.ts';
+import { ReaderShell } from '@/components/reader/ReaderShell.tsx';
+import { useNavigate, useParams } from '@tanstack/react-router';
+
+export const ReaderPage = () => {
+  const { bookId } = useParams({ strict: false });
+  const navigate = useNavigate();
+  const { data: book } = useGetBookDetails(Number(bookId));
+
+  return (
+    <ReaderShell
+      title={book?.title ?? ''}
+      onClose={() => void navigate({ to: '/book/$bookId', params: { bookId: String(bookId) } })}
+    />
+  );
+};

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -22,6 +22,7 @@ import { Route as BookBookIdNotesRouteImport } from './routes/book.$bookId/notes
 import { Route as BookBookIdReflectionRouteImport } from './routes/book.$bookId/reflection'
 import { Route as BookBookIdStatisticsRouteImport } from './routes/book.$bookId/statistics'
 import { Route as BookBookIdStructureRouteImport } from './routes/book.$bookId/structure'
+import { Route as BookBookIdReadRouteImport } from './routes/book_.$bookId/read'
 
 const IndexRoute = IndexRouteImport.update({
   id: '/',
@@ -88,6 +89,11 @@ const BookBookIdStructureRoute = BookBookIdStructureRouteImport.update({
   path: '/structure',
   getParentRoute: () => BookBookIdRoute,
 } as any)
+const BookBookIdReadRoute = BookBookIdReadRouteImport.update({
+  id: '/book_/$bookId/read',
+  path: '/book/$bookId/read',
+  getParentRoute: () => rootRouteImport,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
@@ -102,6 +108,7 @@ export interface FileRoutesByFullPath {
   '/book/$bookId/reflection': typeof BookBookIdReflectionRoute
   '/book/$bookId/statistics': typeof BookBookIdStatisticsRoute
   '/book/$bookId/structure': typeof BookBookIdStructureRoute
+  '/book/$bookId/read': typeof BookBookIdReadRoute
   '/book/$bookId/': typeof BookBookIdIndexRoute
 }
 export interface FileRoutesByTo {
@@ -116,6 +123,7 @@ export interface FileRoutesByTo {
   '/book/$bookId/reflection': typeof BookBookIdReflectionRoute
   '/book/$bookId/statistics': typeof BookBookIdStatisticsRoute
   '/book/$bookId/structure': typeof BookBookIdStructureRoute
+  '/book/$bookId/read': typeof BookBookIdReadRoute
   '/book/$bookId': typeof BookBookIdIndexRoute
 }
 export interface FileRoutesById {
@@ -132,6 +140,7 @@ export interface FileRoutesById {
   '/book/$bookId/reflection': typeof BookBookIdReflectionRoute
   '/book/$bookId/statistics': typeof BookBookIdStatisticsRoute
   '/book/$bookId/structure': typeof BookBookIdStructureRoute
+  '/book_/$bookId/read': typeof BookBookIdReadRoute
   '/book/$bookId/': typeof BookBookIdIndexRoute
 }
 export interface FileRouteTypes {
@@ -149,6 +158,7 @@ export interface FileRouteTypes {
     | '/book/$bookId/reflection'
     | '/book/$bookId/statistics'
     | '/book/$bookId/structure'
+    | '/book/$bookId/read'
     | '/book/$bookId/'
   fileRoutesByTo: FileRoutesByTo
   to:
@@ -163,6 +173,7 @@ export interface FileRouteTypes {
     | '/book/$bookId/reflection'
     | '/book/$bookId/statistics'
     | '/book/$bookId/structure'
+    | '/book/$bookId/read'
     | '/book/$bookId'
   id:
     | '__root__'
@@ -178,6 +189,7 @@ export interface FileRouteTypes {
     | '/book/$bookId/reflection'
     | '/book/$bookId/statistics'
     | '/book/$bookId/structure'
+    | '/book_/$bookId/read'
     | '/book/$bookId/'
   fileRoutesById: FileRoutesById
 }
@@ -188,6 +200,7 @@ export interface RootRouteChildren {
   RegisterRoute: typeof RegisterRoute
   SettingsRoute: typeof SettingsRoute
   BookBookIdRoute: typeof BookBookIdRouteWithChildren
+  BookBookIdReadRoute: typeof BookBookIdReadRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -283,6 +296,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof BookBookIdStructureRouteImport
       parentRoute: typeof BookBookIdRoute
     }
+    '/book_/$bookId/read': {
+      id: '/book_/$bookId/read'
+      path: '/book/$bookId/read'
+      fullPath: '/book/$bookId/read'
+      preLoaderRoute: typeof BookBookIdReadRouteImport
+      parentRoute: typeof rootRouteImport
+    }
   }
 }
 
@@ -317,6 +337,7 @@ const rootRouteChildren: RootRouteChildren = {
   RegisterRoute: RegisterRoute,
   SettingsRoute: SettingsRoute,
   BookBookIdRoute: BookBookIdRouteWithChildren,
+  BookBookIdReadRoute: BookBookIdReadRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/frontend/src/routes/book_.$bookId/read.tsx
+++ b/frontend/src/routes/book_.$bookId/read.tsx
@@ -1,0 +1,8 @@
+import { ReaderPage } from '@/pages/ReaderPage/ReaderPage.tsx';
+import { createFileRoute } from '@tanstack/react-router';
+
+// `book_` keeps this a sibling of `/book/$bookId` rather than a child, so the
+// reader gets the whole viewport instead of the book page's layout.
+export const Route = createFileRoute('/book_/$bookId/read')({
+  component: ReaderPage,
+});

--- a/frontend/src/theme/Icons.tsx
+++ b/frontend/src/theme/Icons.tsx
@@ -16,6 +16,10 @@ export {
   MoreVert as ManageIcon,
   Menu as MenuIcon,
   MoreHoriz as MoreIcon,
+  // Chevrons, not arrows: these turn a page inside the book, where the arrows
+  // above mean going somewhere else in the app.
+  ChevronRight as NextPageIcon,
+  ChevronLeft as PreviousPageIcon,
   KeyboardArrowUp as ScrollToTopIcon,
   Search as SearchIcon,
 } from '@mui/icons-material';

--- a/frontend/src/theme/Icons.tsx
+++ b/frontend/src/theme/Icons.tsx
@@ -32,6 +32,8 @@ export {
   FormatQuote as HighlightsIcon,
   Notes as NotesIcon,
   PaletteOutlined as PaletteIcon,
+  // Reading the book here in the browser, not a session read on a device.
+  ChromeReaderMode as ReaderIcon,
   AutoStories as ReadingSessionIcon,
   Psychology as ReflectionIcon,
   Equalizer as StatisticsIcon,

--- a/frontend/tests/fakes/FakeEbookReader.ts
+++ b/frontend/tests/fakes/FakeEbookReader.ts
@@ -1,0 +1,76 @@
+import type {
+  EbookLocation,
+  EbookReader,
+  OpenedEbook,
+  PageTurnDirection,
+} from '@/components/reader/EbookReader.ts';
+
+/** A place in the two-chapter book the other fixtures describe. */
+export const aFakeLocation = (position: number): EbookLocation => ({
+  href: `resources/OEBPS/chapter${position}.xhtml`,
+  type: 'application/xhtml+xml',
+  locations: { position },
+});
+
+/** An `EbookReader` whose open the test settles and whose events the test fires. */
+export class FakeEbookReader implements EbookReader {
+  readonly openedWith: string[] = [];
+  nextCalls = 0;
+  previousCalls = 0;
+  destroyed = false;
+
+  private readonly locationListeners = new Set<(location: EbookLocation) => void>();
+  private readonly pageTurnListeners = new Set<(direction: PageTurnDirection) => void>();
+  private settle: ((opened: OpenedEbook) => void) | undefined;
+  private isOpened = false;
+
+  async open(manifestUrl: string, signal?: AbortSignal): Promise<OpenedEbook> {
+    signal?.throwIfAborted();
+    if (this.isOpened) throw new Error('A reader opens one book; build another one.');
+    this.isOpened = true;
+    this.openedWith.push(manifestUrl);
+    return await new Promise<OpenedEbook>((resolve, reject) => {
+      this.settle = resolve;
+      // The interface's contract, and the only way a boot watchdog can reach an
+      // open that is going nowhere.
+      signal?.addEventListener('abort', () => reject(signal.reason), { once: true });
+    });
+  }
+
+  resolveOpen(opened: Partial<OpenedEbook> = {}): void {
+    this.settle?.({ pageCount: 2, toc: [], location: aFakeLocation(1), ...opened });
+  }
+
+  requestPageTurn(direction: PageTurnDirection): void {
+    for (const listener of [...this.pageTurnListeners]) listener(direction);
+  }
+
+  next(): Promise<void> {
+    this.nextCalls += 1;
+    return Promise.resolve();
+  }
+
+  previous(): Promise<void> {
+    this.previousCalls += 1;
+    return Promise.resolve();
+  }
+
+  goTo(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  onLocationChanged(listener: (location: EbookLocation) => void): () => void {
+    this.locationListeners.add(listener);
+    return () => this.locationListeners.delete(listener);
+  }
+
+  onPageTurnRequested(listener: (direction: PageTurnDirection) => void): () => void {
+    this.pageTurnListeners.add(listener);
+    return () => this.pageTurnListeners.delete(listener);
+  }
+
+  destroy(): Promise<void> {
+    this.destroyed = true;
+    return Promise.resolve();
+  }
+}

--- a/frontend/tests/fixtures/publication.ts
+++ b/frontend/tests/fixtures/publication.ts
@@ -1,0 +1,62 @@
+import type { PositionList, WebPublicationManifest } from '@/api/generated/model';
+
+const manifestHref = (bookId = 1) =>
+  `${window.location.origin}/api/v1/readium/books/${bookId}/manifest.json`;
+
+/**
+ * A small but genuine Readium Web Publication Manifest.
+ *
+ * Written the way the backend serves one: camelCase keys, hrefs relative to the
+ * manifest's own URL, and an unlinked `#` heading in the table of contents.
+ */
+export const aManifest = (
+  overrides: Partial<WebPublicationManifest> = {}
+): WebPublicationManifest => ({
+  metadata: {
+    title: 'The Pragmatic Reader',
+    author: 'Ada Lovelace',
+    language: 'en',
+    identifier: 'urn:uuid:pragmatic-reader',
+  },
+  links: [
+    { href: manifestHref(), rel: 'self', type: 'application/webpub+json' },
+    {
+      href: 'positions.json',
+      rel: 'http://readium.org/position-list',
+      type: 'application/vnd.readium.position-list+json',
+    },
+  ],
+  readingOrder: [
+    { href: 'resources/OEBPS/chapter1.xhtml', type: 'application/xhtml+xml' },
+    { href: 'resources/OEBPS/chapter2.xhtml', type: 'application/xhtml+xml' },
+  ],
+  resources: [{ href: 'resources/OEBPS/style.css', type: 'text/css' }],
+  toc: [
+    { href: 'resources/OEBPS/chapter1.xhtml', title: 'On Attention' },
+    {
+      // A part heading links nowhere; its chapters do.
+      href: '#',
+      title: 'Part two',
+      children: [{ href: 'resources/OEBPS/chapter2.xhtml', title: 'On Memory' }],
+    },
+  ],
+  ...overrides,
+});
+
+/** The position list the manifest's `position-list` link resolves to. */
+export const aPositionList = (overrides: Partial<PositionList> = {}): PositionList => ({
+  total: 2,
+  positions: [
+    {
+      href: 'resources/OEBPS/chapter1.xhtml',
+      type: 'application/xhtml+xml',
+      locations: { position: 1, progression: 0, totalProgression: 0 },
+    },
+    {
+      href: 'resources/OEBPS/chapter2.xhtml',
+      type: 'application/xhtml+xml',
+      locations: { position: 2, progression: 0, totalProgression: 0.5 },
+    },
+  ],
+  ...overrides,
+});

--- a/frontend/tests/msw/readiumApi.ts
+++ b/frontend/tests/msw/readiumApi.ts
@@ -1,0 +1,108 @@
+import type { PositionList, WebPublicationManifest } from '@/api/generated/model';
+import { http, HttpResponse } from 'msw';
+import { aManifest, aPositionList } from '../fixtures/publication';
+
+const MANIFEST_PATH = '/api/v1/readium/books/:bookId/manifest.json';
+const POSITIONS_PATH = '/api/v1/readium/books/:bookId/positions.json';
+const SESSION_PATH = '/api/v1/readium/books/:bookId/session';
+const RESOURCE_PATH = '/api/v1/readium/books/:bookId/resources/*';
+
+/** A chapter as an EPUB actually ships one: XHTML, with its own namespace. */
+const chapterDocument = (title: string) =>
+  `<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head><title>${title}</title></head>
+  <body><h1>${title}</h1><p>Attention is the rarest and purest form of generosity.</p></body>
+</html>`;
+
+/**
+ * A chapter that tries to break out of its frame, by every route a document has.
+ *
+ * The `onerror` image is a `data:` URL because a missing file's request outlives
+ * the test that provoked it.
+ */
+const hostileChapter = () =>
+  `<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <title>On Attention</title>
+    <script>parent.document.body.setAttribute('data-pwned', 'inline-script')</script>
+    <script src="evil.js"></script>
+    <meta http-equiv="REFRESH" content="0; url=escape-hatch.xhtml" />
+  </head>
+  <body onload="parent.document.body.setAttribute('data-pwned', 'onload')">
+    <h1>On Attention</h1>
+    <p><a href="javascript:parent.document.body.setAttribute('data-pwned','href')">A link.</a></p>
+    <img src="data:image/png;base64,bm90LWFuLWltYWdl" onerror="parent.document.body.setAttribute('data-pwned', 'onerror')" />
+  </body>
+</html>`;
+
+/** The files `aManifest` names, keyed by the path the resource route receives. */
+const RESOURCES: Record<string, { body: string; type: string } | undefined> = {
+  'OEBPS/chapter1.xhtml': { body: chapterDocument('On Attention'), type: 'application/xhtml+xml' },
+  'OEBPS/chapter2.xhtml': { body: chapterDocument('On Memory'), type: 'application/xhtml+xml' },
+  'OEBPS/style.css': { body: 'body { margin: 0; }', type: 'text/css' },
+  'OEBPS/evil.js': {
+    body: "parent.document.body.setAttribute('data-pwned', 'external-script')",
+    type: 'text/javascript',
+  },
+};
+
+interface ReadiumApiOptions {
+  manifest?: WebPublicationManifest;
+  positions?: PositionList;
+  /** Seconds of life the session endpoint claims for the publication cookie. */
+  expiresIn?: number;
+  /** Serve the first chapter as a book that attacks the page that opened it. */
+  hostile?: boolean;
+  /** Told about every request these handlers answer, for tests about what was sent. */
+  onRequest?: (request: Request) => void;
+}
+
+/**
+ * The web reader's endpoints for a book that has an EPUB — resources included.
+ *
+ * The navigator fetches the reading order itself, so serving the chapters here
+ * is what lets a test drive the real thing rather than a mock of it.
+ */
+export const readiumApi = ({
+  manifest,
+  positions,
+  expiresIn = 900,
+  hostile = false,
+  onRequest = () => {},
+}: ReadiumApiOptions = {}) => [
+  http.post(SESSION_PATH, ({ request }) => {
+    onRequest(request);
+    return HttpResponse.json({ expires_in: expiresIn });
+  }),
+  http.get(MANIFEST_PATH, ({ request }) => {
+    onRequest(request);
+    return HttpResponse.json(manifest ?? aManifest());
+  }),
+  http.get(POSITIONS_PATH, ({ request }) => {
+    onRequest(request);
+    return HttpResponse.json(positions ?? aPositionList());
+  }),
+  http.get(RESOURCE_PATH, ({ request, params }) => {
+    onRequest(request);
+    const path = String(params[0]);
+    const rewritten =
+      hostile && path === 'OEBPS/chapter1.xhtml'
+        ? { body: hostileChapter(), type: 'application/xhtml+xml' }
+        : undefined;
+    const resource = rewritten ?? RESOURCES[path];
+    if (!resource) return new HttpResponse(null, { status: 404 });
+    return new HttpResponse(resource.body, {
+      headers: { 'Content-Type': resource.type, ETag: `"${path}"` },
+    });
+  }),
+];
+
+/** A book with no EPUB: the manifest 404s, which is how the app learns there is none. */
+export const noPublication = [
+  http.post(SESSION_PATH, () => HttpResponse.json({ expires_in: 900 })),
+  http.get(MANIFEST_PATH, () => new HttpResponse(null, { status: 404 })),
+];

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -27,7 +27,12 @@ export default mergeConfig(
     // Pre-bundled up front: discovering these mid-run makes Vite reload the page
     // and Vitest reports the reload as a failed test.
     optimizeDeps: {
-      include: ['react/jsx-dev-runtime', 'react-dom/client'],
+      include: [
+        'react/jsx-dev-runtime',
+        'react-dom/client',
+        '@readium/navigator',
+        '@readium/shared',
+      ],
     },
     test: {
       include: ['src/**/*.test.tsx'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,8 @@
         "@mui/icons-material": "^9.3.1",
         "@mui/material": "^9.4.0",
         "@mui/x-date-pickers": "^9.12.0",
+        "@readium/navigator": "2.10.0",
+        "@readium/shared": "2.5.0",
         "@tanstack/react-query": "^5.101.4",
         "@tanstack/react-router": "^1.170.32",
         "axios": "^1.20.0",
@@ -298,6 +300,7 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -579,6 +582,7 @@
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
       "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -622,6 +626,7 @@
       "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.1.tgz",
       "integrity": "sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -1521,6 +1526,7 @@
       "resolved": "https://registry.npmjs.org/@mui/material/-/material-9.4.0.tgz",
       "integrity": "sha512-6KKUIvkQ2r/s48s9VZV9JEZ1W2dRa7RndVsF+Ipx4CYxDOQeozeRsS5r9NiheFf8A5hpbqJJIGoX7hjg5X4XUw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.29.7",
         "@mui/core-downloads-tracker": "^9.4.0",
@@ -1631,6 +1637,7 @@
       "resolved": "https://registry.npmjs.org/@mui/system/-/system-9.4.0.tgz",
       "integrity": "sha512-AZz9z13oGS1J0BYeAFHTbV7PegCtPiE/uMEIi7TJ1kTx3Vkt+jUpLyXF/2uV8B6Y79iTh98kVeOH9fX3x3zXXg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.29.7",
         "@mui/private-theming": "^9.4.0",
@@ -2626,6 +2633,71 @@
         "url": "https://opencollective.com/popperjs"
       }
     },
+    "node_modules/@readium/decorator": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@readium/decorator/-/decorator-1.2.0.tgz",
+      "integrity": "sha512-bhQ4Z4muzxdKioYbo9GpnsuWROS/VAuD3eSdPZau4Kbn7dW3wA8QMLMCQVwvx2pSW/NSMb+VP9vZ1xkmxPOVKg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@readium/navigator-html-injectables": "2.8.0",
+        "@readium/shared": "2.5.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@readium/helpers": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@readium/helpers/-/helpers-1.1.0.tgz",
+      "integrity": "sha512-jerMfJn0ZXmJ1HwARzZybfJm+mFxDTYvKOV+HEuPBvj1OMNB46FW4pB5TC6hY61xla440hAAxnKxBJF2bFY51Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "user-agent-data-types": "^0.4.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@readium/navigator": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@readium/navigator/-/navigator-2.10.0.tgz",
+      "integrity": "sha512-UvAtzE3hef5v4WKawLEQC6MZbjR1Iea+FKKjqSVz8XR6Nya/GzK+sojE058kL3vKawRqk1zISTtOTf4+A7CQiQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@readium/decorator": "1.2.0",
+        "@readium/helpers": "1.1.0",
+        "@readium/navigator-html-injectables": "2.8.0",
+        "@readium/shared": "2.5.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@readium/navigator-html-injectables": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@readium/navigator-html-injectables/-/navigator-html-injectables-2.8.0.tgz",
+      "integrity": "sha512-xf5jROqh8TaKQ/iCkZ39IOGsqoEa/Ntre+U1+QYRnSSMq4GtpeP5cNV877ucsbkiCgxzx2bWmUbcm8qo1o5X2w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@readium/helpers": "1.1.0",
+        "@readium/shared": "2.5.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@readium/shared": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@readium/shared/-/shared-2.5.0.tgz",
+      "integrity": "sha512-1fkvtcYhXuSjX9vtabGxvoomadEnaLuE48f9fZ1GBiFng/g11gdAFhh7vZLjx18x130lX7r72HR/wb+o56KbAw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@readium/helpers": "1.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@rolldown/binding-android-arm-eabi": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm-eabi/-/binding-android-arm-eabi-1.2.5.tgz",
@@ -2951,6 +3023,7 @@
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -3431,6 +3504,7 @@
       "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~8.3.0"
       }
@@ -3452,6 +3526,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
       "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3462,6 +3537,7 @@
       "integrity": "sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3533,6 +3609,7 @@
       "integrity": "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.65.0",
         "@typescript-eslint/types": "8.65.0",
@@ -4119,6 +4196,7 @@
       "integrity": "sha512-nMoXGEiRpT7m3W7NsbvrM2aKNwiNHZf+zEpUCvMteGjZFvfT96Q9fh7QyB98dvDWXiKvrLxA7bJ1mCOOv+JQPw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/browser": "4.1.10",
         "@vitest/mocker": "4.1.10",
@@ -4263,6 +4341,7 @@
       "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4497,6 +4576,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.42",
         "caniuse-lite": "^1.0.30001803",
@@ -4883,6 +4963,7 @@
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
       "integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
@@ -5151,6 +5232,7 @@
       "integrity": "sha512-9VaAkDURekixUQJy0oJYl2DcN6oKMfxay7XzaGYAWQwsb6qfKf+x76R2k1L8kb1boc+FyCAaTA9GmiKaaiaF+A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "workspaces": [
         "packages/*"
       ],
@@ -6606,6 +6688,7 @@
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7030,6 +7113,7 @@
       "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
       "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -7780,6 +7864,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@inquirer/confirm": "^6.0.11",
         "@mswjs/interceptors": "^0.41.3",
@@ -8003,6 +8088,7 @@
       "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=22.12.0"
       }
@@ -8442,6 +8528,7 @@
       "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -8546,6 +8633,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
       "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8578,6 +8666,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
       "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -8870,6 +8959,7 @@
       "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.6.3.tgz",
       "integrity": "sha512-5PwLbVPpT4DEki1hYVSSsoxWY6xCNMVucAVLK/CH0mXSDfp/I4KaAex72q80GNt5hpn7CCMGdSpIg4YGqH/wXQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9187,6 +9277,7 @@
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9321,6 +9412,7 @@
       "integrity": "sha512-uSKqkh8Cr48vllnEy+jdaAgOeR6Y+QCBW7usgUsKj7gJEfR7stw9U/fE49LBnj2tPRKPY0c0EBJSWe9Appmplg==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@gerrit0/mini-shiki": "^3.23.0",
         "lunr": "^2.3.9",
@@ -9371,6 +9463,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9597,6 +9690,12 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/user-agent-data-types": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/user-agent-data-types/-/user-agent-data-types-0.4.3.tgz",
+      "integrity": "sha512-Dn3fjwVgeM363mx1sEgOpOp9NNqHBj6Gn68dFbV1WoTr3s05CijKdxfH6A3Q5uzXnYNB6vdAfs/1HWFpObc7EQ==",
+      "license": "MIT"
+    },
     "node_modules/vfile": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
@@ -9645,6 +9744,7 @@
       "integrity": "sha512-cFKLV/PRgAUlIRm5WjMjJ86jrftzpqcgH+Us+DS8mI3CDNiH30Whrz8uHL3+MOLPAgqbMBAqWdAHAphOAM+z/Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.33.0",
         "picomatch": "^4.0.5",
@@ -9736,6 +9836,7 @@
       "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.10",
         "@vitest/mocker": "4.1.10",
@@ -10092,6 +10193,7 @@
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }


### PR DESCRIPTION
Closes #804. Part of #807 (left open; see the comment there for what remains).

## What this is

The web reader, rebuilt as a minimal shell over a small engine interface instead of a port of the spike's 900-line `ReaderShell`. A book opens at `/book/:id/read` from a "Read" entry in the book navigation or the link in the book header, and the reader turns pages with the arrow keys or two buttons. Table of contents, appearance settings, tap zones, highlights on the page and resume come back in their own PRs, each extending the same interface.

Read the commits in order; each ends green and adds one layer:

1. **Route, page, ways in.** `/book_/$bookId/read` (a sibling of the book page, so the reader owns the viewport), an empty shell, the nav entry after Notes and the header link. Body scroll is locked so pull-to-refresh cannot arm under the fixed overlay.
2. **The engine behind `EbookReader`.** The interface (`open`, `next`, `previous`, `goTo`, `onLocationChanged`, `onPageTurnRequested`, `destroy`; JSON only, so a remote implementation is possible later, #807), `ReadiumReader` on `@readium/navigator` 2.10.0, and `sanitizeResponse`, which strips a book's own scripts before Readium frames a chapter. Arrow keys come through Readium's own key handling; nothing outside the engine touches a frame window.
3. **The publication cookie.** `useReaderSession` mints it on open through the Bearer client, renews at 80 % of `expires_in`, re-checks on focus, backs off on failed renewals, and reports `isRenewing` only when the cookie has actually lapsed.
4. **The book on screen.** `useEbookReader` builds one single-use reader per attempt behind the cookie with a 15 s watchdog; the shell shows the page label, holds page turns while a lapsed cookie is renewed, and offers a retry where one could work.

## Departures from the reference worth knowing

- Names: `EbookReader` / `ReadiumReader` / `sanitizeResponse`, not bridge / direct bridge / hardening.
- The engine fetches the manifest itself with plain `fetch`; the manifest no longer goes through the generated axios client (#804's ask), and `credentials: 'include'` was dropped as a same-origin no-op.
- A reader is single-use with its own throwaway wrapper element. That replaces the spike's boot-promise chaining for StrictMode, and works around `EpubNavigator.destroy()` never disconnecting its own `ResizeObserver`.
- `goTo` rejects a location the book does not contain instead of resolving as if it had jumped.
- No `has_ebook` gating on the entry points: every book in the app has an EPUB.

## Tests

Browser-mode Vitest against MSW and a fixture publication, with the real navigator in Chromium: a hostile chapter cannot mark the parent document, no Authorization header reaches the cookie-only routes, real key presses inside and outside the frame turn pages, a lapsed cookie holds the book until renewal, a missing or unreadable manifest and a boot that never finishes each get their message. `FakeEbookReader` drives the shell without a navigator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DZ2vdUGgLAsfUzU1S46PVU
