### PR TITLE
R3.1 Frontend: table of contents drawer (#824)

### DIFF
--- a/frontend/src/components/reader/EbookReader.ts
+++ b/frontend/src/components/reader/EbookReader.ts
@@ -25,6 +25,8 @@ export interface EbookLocation {
 /** One heading of the book's table of contents. */
 export interface EbookTocEntry {
   href: string;
+  /** Empty for the many manifests whose contents links declare no media type. */
+  type: string;
   title: string;
   children: EbookTocEntry[];
 }
@@ -33,6 +35,8 @@ export interface EbookTocEntry {
 export interface OpenedEbook {
   pageCount: number;
   toc: EbookTocEntry[];
+  /** The contents entry the book opened at, or null where none covers it. */
+  tocHref: string | null;
   location: EbookLocation;
 }
 
@@ -64,5 +68,7 @@ export interface EbookReader {
   goTo(location: EbookLocation): Promise<void>;
   onLocationChanged(listener: (location: EbookLocation) => void): () => void;
   onPageTurnRequested(listener: (direction: PageTurnDirection) => void): () => void;
+  /** The reader has moved into a different contents entry; `OpenedEbook.tocHref` is the first. */
+  onTocEntryChanged(listener: (href: string | null) => void): () => void;
   destroy(): Promise<void>;
 }

--- a/frontend/src/components/reader/ReaderShell.test.tsx
+++ b/frontend/src/components/reader/ReaderShell.test.tsx
@@ -1,3 +1,4 @@
+import type { EbookTocEntry, OpenedEbook } from '@/components/reader/EbookReader.ts';
 import { ReaderShell, type ReaderShellProps } from '@/components/reader/ReaderShell.tsx';
 import { FakeEbookReader, aFakeLocation } from '@tests/fakes/FakeEbookReader';
 import { readiumApi } from '@tests/msw/readiumApi';
@@ -43,11 +44,24 @@ const renderShell = async (props: Partial<ReaderShellProps> = {}) =>
 
 type Screen = Awaited<ReturnType<typeof renderShell>>;
 
+/** Two chapters, the second without a media type, as many manifests publish them. */
+const A_TOC: EbookTocEntry[] = [
+  {
+    href: 'resources/OEBPS/chapter1.xhtml',
+    type: 'application/xhtml+xml',
+    title: 'On Attention',
+    children: [],
+  },
+  { href: 'resources/OEBPS/chapter2.xhtml', type: '', title: 'On Memory', children: [] },
+];
+
+const aBookWithContents = (): Partial<OpenedEbook> => ({ toc: A_TOC, tocHref: A_TOC[0].href });
+
 /** The shell with the book on screen at its first page. */
-const anOpenBook = async () => {
+const anOpenBook = async (opened: Partial<OpenedEbook> = {}) => {
   const screen = await renderShell();
   await expect.poll(() => readers.length).toBe(1);
-  readers[0].resolveOpen();
+  readers[0].resolveOpen(opened);
   await expect.element(screen.getByText('Page 1 of 2')).toBeVisible();
   return screen;
 };
@@ -136,6 +150,40 @@ test('a book whose chapters never arrive times out and can be retried', async ()
   await screen.getByRole('button', { name: 'Try again' }).click();
 
   await expect.element(screen.getByText('Page 1 of 2'), { timeout: 5_000 }).toBeVisible();
+});
+
+test('the contents are not offered until the book is on screen', async () => {
+  worker.use(...readiumApi());
+
+  const screen = await renderShell();
+
+  await expect.element(screen.getByRole('button', { name: 'Contents' })).toBeDisabled();
+
+  await expect.poll(() => readers.length).toBe(1);
+  readers[0].resolveOpen(aBookWithContents());
+
+  await expect.element(screen.getByRole('button', { name: 'Contents' })).toBeEnabled();
+});
+
+test('picking a contents entry goes there and closes the drawer', async () => {
+  worker.use(...readiumApi());
+
+  const screen = await anOpenBook(aBookWithContents());
+
+  await screen.getByRole('button', { name: 'Contents' }).click();
+  // The entry the book opened at, which the seam reports through `tocHref` alone.
+  await expect
+    .element(screen.getByRole('button', { name: 'On Attention' }))
+    .toHaveAttribute('aria-current', 'location');
+
+  await screen.getByRole('button', { name: 'On Memory' }).click();
+
+  expect(readers[0].goToCalls).toEqual([
+    { href: 'resources/OEBPS/chapter2.xhtml', type: '', locations: {} },
+  ]);
+  await expect
+    .element(screen.getByRole('navigation', { name: 'Table of contents' }))
+    .not.toBeInTheDocument();
 });
 
 test('closing the shell destroys the reader', async () => {

--- a/frontend/src/components/reader/ReaderShell.test.tsx
+++ b/frontend/src/components/reader/ReaderShell.test.tsx
@@ -80,6 +80,14 @@ test('the shell waits for the cookie before opening the book', async () => {
   await expect.element(screen.getByLabelText('Loading the book')).toBeVisible();
 });
 
+test('a book whose positions say nothing about progress still numbers its pages', async () => {
+  worker.use(...readiumApi());
+
+  const screen = await anOpenBook();
+
+  await expect.element(screen.getByText('Page 1 of 2', { exact: true })).toBeVisible();
+});
+
 test('a page turn asked for by the book is forwarded', async () => {
   worker.use(...readiumApi());
 

--- a/frontend/src/components/reader/ReaderShell.tsx
+++ b/frontend/src/components/reader/ReaderShell.tsx
@@ -32,6 +32,13 @@ export interface ReaderShellProps {
 /** The width the page-turn buttons need beside the text on anything but a phone. */
 const PAGE_TURN_GUTTER = '48px';
 
+/** Readium's own page gutter is horizontal only, so the air above and below is ours to add. */
+const READING_SURFACE_INSET = 2;
+
+const pageLabel = (page: number, pageCount: number, progression: number | undefined) =>
+  `Page ${page} of ${pageCount}` +
+  (progression === undefined ? '' : ` · ${Math.round(progression * 100)}%`);
+
 const overlaySx: SxProps<Theme> = {
   position: 'fixed',
   inset: 0,
@@ -182,7 +189,7 @@ export const ReaderShell = ({
             </Typography>
             {book.pageCount > 0 && position !== undefined && (
               <Typography variant="body2" noWrap sx={{ color: 'text.secondary' }}>
-                Page {position} of {book.pageCount}
+                {pageLabel(position, book.pageCount, book.location?.locations.totalProgression)}
               </Typography>
             )}
           </Stack>
@@ -206,6 +213,7 @@ export const ReaderShell = ({
           sx={{
             height: '100%',
             px: { xs: 0, sm: PAGE_TURN_GUTTER },
+            py: READING_SURFACE_INSET,
             visibility: isOpen ? 'visible' : 'hidden',
           }}
         />

--- a/frontend/src/components/reader/ReaderShell.tsx
+++ b/frontend/src/components/reader/ReaderShell.tsx
@@ -1,9 +1,11 @@
 import { API_BASE_URL } from '@/api/base-url.ts';
 import { IconButtonWithTooltip } from '@/components/buttons/IconButtonWithTooltip.tsx';
+import type { EbookTocEntry } from '@/components/reader/EbookReader.ts';
+import { TocDrawer } from '@/components/reader/TocDrawer.tsx';
 import { useEbookReader, type UseEbookReaderOptions } from '@/components/reader/useEbookReader.ts';
 import { useReaderSession } from '@/components/reader/useReaderSession.ts';
 import { useBodyScrollLock } from '@/hooks/useBodyScrollLock.ts';
-import { CloseIcon, NextPageIcon, PreviousPageIcon } from '@/theme/Icons.tsx';
+import { ChapterListIcon, CloseIcon, NextPageIcon, PreviousPageIcon } from '@/theme/Icons.tsx';
 import { ICON_SIZE } from '@/theme/iconSizes.ts';
 import {
   Box,
@@ -16,7 +18,7 @@ import {
   type SxProps,
   type Theme,
 } from '@mui/material';
-import { useRef } from 'react';
+import { useRef, useState } from 'react';
 
 export interface ReaderShellProps {
   bookId: number;
@@ -114,6 +116,7 @@ export const ReaderShell = ({
   useBodyScrollLock(true);
   const { status: sessionStatus, isRenewing } = useReaderSession(bookId);
   const host = useRef<HTMLDivElement | null>(null);
+  const [isTocOpen, setIsTocOpen] = useState(false);
   const book = useEbookReader({
     host,
     manifestUrl: manifestUrlFor(bookId),
@@ -157,10 +160,22 @@ export const ReaderShell = ({
   const pageTurnsDisabled = isRenewing || !isOpen;
   const position = book.location?.locations.position;
 
+  const goToTocEntry = (entry: EbookTocEntry) => {
+    setIsTocOpen(false);
+    book.goTo({ href: entry.href, type: entry.type, locations: {} });
+  };
+
   return (
     <Box sx={overlaySx}>
       <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
         <Toolbar variant="dense" sx={{ gap: 1 }}>
+          <IconButtonWithTooltip
+            label="Contents"
+            onClick={() => setIsTocOpen(true)}
+            disabled={!isOpen}
+            edge="start"
+            icon={<ChapterListIcon sx={{ fontSize: ICON_SIZE.ui }} />}
+          />
           <Stack sx={{ flex: 1, minWidth: 0 }}>
             <Typography variant="h6" component="h1" noWrap>
               {title}
@@ -227,6 +242,14 @@ export const ReaderShell = ({
           </Stack>
         )}
       </Box>
+
+      <TocDrawer
+        open={isTocOpen}
+        onClose={() => setIsTocOpen(false)}
+        toc={book.toc}
+        onSelect={goToTocEntry}
+        currentHref={book.currentTocHref}
+      />
     </Box>
   );
 };

--- a/frontend/src/components/reader/ReadiumReader.test.tsx
+++ b/frontend/src/components/reader/ReadiumReader.test.tsx
@@ -19,14 +19,18 @@ let reader: ReadiumReader;
 const recordEvents = () => {
   const positions: (number | undefined)[] = [];
   const turns: PageTurnDirection[] = [];
+  const tocHrefs: (string | null)[] = [];
   reader.onLocationChanged((location) => positions.push(location.locations.position));
   reader.onPageTurnRequested((direction) => turns.push(direction));
+  reader.onTocEntryChanged((href) => tocHrefs.push(href));
   return {
     positions,
     turns,
+    tocHrefs,
     clear: () => {
       positions.length = 0;
       turns.length = 0;
+      tocHrefs.length = 0;
     },
   };
 };
@@ -71,6 +75,38 @@ test('next and previous turn the page and report where the reader is', async () 
   recorded.clear();
   await reader.previous();
   await expect.poll(() => recorded.positions).toContain(1);
+});
+
+test('the book names the contents entry it opened at', async () => {
+  worker.use(...readiumApi());
+
+  const opened = await reader.open(MANIFEST_URL);
+
+  expect(opened.tocHref).toBe('resources/OEBPS/chapter1.xhtml');
+  expect(opened.toc[0].href).toBe('resources/OEBPS/chapter1.xhtml');
+});
+
+test('the reported contents entry follows the reader into the next chapter', async () => {
+  worker.use(...readiumApi());
+  const opened = await reader.open(MANIFEST_URL);
+  const recorded = recordEvents();
+  const onMemory = opened.toc[1].children[0];
+
+  await reader.next();
+
+  await expect.poll(() => recorded.tocHrefs).toEqual([onMemory.href]);
+});
+
+test('a contents entry that declares no media type can be navigated to', async () => {
+  worker.use(...readiumApi());
+  const opened = await reader.open(MANIFEST_URL);
+  const recorded = recordEvents();
+  const onMemory = opened.toc[1].children[0];
+  expect(onMemory.type).toBe('');
+
+  await reader.goTo({ href: onMemory.href, type: onMemory.type, locations: {} });
+
+  await expect.poll(() => recorded.positions).toContain(2);
 });
 
 test('goTo lands on the location it is given', async () => {

--- a/frontend/src/components/reader/ReadiumReader.ts
+++ b/frontend/src/components/reader/ReadiumReader.ts
@@ -12,7 +12,15 @@ import {
   type EpubNavigatorListeners,
   type IKeyboardPeripheralsConfig,
 } from '@readium/navigator';
-import { HttpFetcher, Locator, Manifest, Publication, type Link } from '@readium/shared';
+import {
+  HttpFetcher,
+  Locator,
+  LocatorLocations,
+  Manifest,
+  Publication,
+  type Link,
+  type TimelineItem,
+} from '@readium/shared';
 
 const DESTROY_TIMEOUT_MS = 2000;
 
@@ -47,15 +55,20 @@ const toLocation = (locator: Locator): EbookLocation => ({
   },
 });
 
-const fromLocation = (location: EbookLocation): Locator => {
-  const locator = Locator.deserialize(location);
-  if (!locator) throw new Error('That location does not name a place in a publication.');
-  return locator;
-};
+// Built rather than deserialized: `Locator.deserialize` refuses a location
+// whose media type is empty, which is what a contents entry usually carries.
+const fromLocation = (location: EbookLocation): Locator =>
+  new Locator({
+    href: location.href,
+    type: location.type,
+    title: location.title,
+    locations: new LocatorLocations(location.locations),
+  });
 
 const tocEntriesFrom = (links: Link[]): EbookTocEntry[] =>
   links.map((link) => ({
     href: link.href,
+    type: link.type ?? '',
     title: link.title ?? '',
     children: tocEntriesFrom(link.children?.items ?? []),
   }));
@@ -93,6 +106,7 @@ const whenSized = (element: HTMLElement, signal: AbortSignal) =>
 export class ReadiumReader implements EbookReader {
   private readonly locationListeners = new Set<(location: EbookLocation) => void>();
   private readonly pageTurnListeners = new Set<(direction: PageTurnDirection) => void>();
+  private readonly tocEntryListeners = new Set<(href: string | null) => void>();
   private readonly destruction = new AbortController();
   private navigator: EpubNavigator | undefined;
   private wrapper: HTMLDivElement | undefined;
@@ -138,6 +152,7 @@ export class ReadiumReader implements EbookReader {
     return {
       pageCount: positions.length,
       toc: tocEntriesFrom(publication.toc?.items ?? []),
+      tocHref: this.tocEntryHrefFor(navigator.timeline.locate(navigator.currentLocator)),
       location: toLocation(navigator.currentLocator),
     };
   }
@@ -166,6 +181,10 @@ export class ReadiumReader implements EbookReader {
     return this.subscribe(this.pageTurnListeners, listener);
   }
 
+  onTocEntryChanged(listener: (href: string | null) => void): () => void {
+    return this.subscribe(this.tocEntryListeners, listener);
+  }
+
   async destroy(): Promise<void> {
     if (this.isDestroyed) return;
     this.isDestroyed = true;
@@ -189,6 +208,7 @@ export class ReadiumReader implements EbookReader {
     this.wrapper = undefined;
     this.locationListeners.clear();
     this.pageTurnListeners.clear();
+    this.tocEntryListeners.clear();
   }
 
   /** The wrapper Readium's ResizeObserver may keep, and the container it draws into. */
@@ -240,7 +260,8 @@ export class ReadiumReader implements EbookReader {
     return {
       frameLoaded: () => {},
       positionChanged: (locator) => this.notify(this.locationListeners, toLocation(locator)),
-      timelineItemChanged: () => {},
+      timelineItemChanged: (item) =>
+        this.notify(this.tocEntryListeners, this.tocEntryHrefFor(item)),
       // Claimed so Readium's own quarter-screen pager does not turn pages
       // behind the UI's back.
       tap: () => true,
@@ -258,6 +279,14 @@ export class ReadiumReader implements EbookReader {
         if (event.type === 'previous_page') this.notify(this.pageTurnListeners, 'previous');
       },
     };
+  }
+
+  /** Most places in a book have no contents entry of their own; `tocEntryFor`
+   * walks back to the nearest one that covers them. */
+  private tocEntryHrefFor(item: TimelineItem | undefined): string | null {
+    const navigator = this.navigator;
+    if (!navigator || !item) return null;
+    return navigator.timeline.tocEntryFor(item)?.link.href ?? null;
   }
 
   private move(

--- a/frontend/src/components/reader/TocDrawer.tsx
+++ b/frontend/src/components/reader/TocDrawer.tsx
@@ -1,0 +1,118 @@
+import type { EbookTocEntry } from '@/components/reader/EbookReader.ts';
+import { SectionTitle } from '@/components/typography/SectionTitle.tsx';
+import { CloseIcon } from '@/theme/Icons.tsx';
+import { ICON_SIZE } from '@/theme/iconSizes.ts';
+import {
+  Box,
+  Drawer,
+  IconButton,
+  List,
+  ListItemButton,
+  ListItemText,
+  Stack,
+  Typography,
+} from '@mui/material';
+import { Fragment, useCallback } from 'react';
+
+/** The href a manifest gives a heading that links nowhere — a part title, say. */
+const UNLINKED_HREF = '#';
+
+/** How far one level of nesting indents a chapter under its parent. */
+const INDENT_PER_LEVEL = 2;
+
+interface TocDrawerProps {
+  open: boolean;
+  onClose: () => void;
+  toc: EbookTocEntry[];
+  onSelect: (entry: EbookTocEntry) => void;
+  /** The entry the reader is in, as the engine resolved it. */
+  currentHref: string | null;
+}
+
+interface TocEntriesProps {
+  entries: EbookTocEntry[];
+  depth: number;
+  onSelect: (entry: EbookTocEntry) => void;
+  currentHref: string | null;
+  /** Attached to the marked entry, which scrolls it into view as it mounts. */
+  currentRef: (node: HTMLDivElement | null) => void;
+}
+
+const TocEntries = ({ entries, depth, onSelect, currentHref, currentRef }: TocEntriesProps) => (
+  <>
+    {entries.map((entry, index) => {
+      const isNavigable = entry.href !== UNLINKED_HREF;
+      const isCurrent = entry.href === currentHref;
+      return (
+        <Fragment key={`${entry.href}-${index}`}>
+          <ListItemButton
+            ref={isCurrent ? currentRef : undefined}
+            disabled={!isNavigable}
+            selected={isCurrent}
+            aria-current={isCurrent ? 'location' : undefined}
+            onClick={() => onSelect(entry)}
+            sx={{ pl: 2 + depth * INDENT_PER_LEVEL, borderRadius: 1 }}
+          >
+            <ListItemText
+              primary={entry.title || 'Untitled'}
+              slotProps={{ primary: { variant: 'body2' } }}
+            />
+          </ListItemButton>
+          <TocEntries
+            entries={entry.children}
+            depth={depth + 1}
+            onSelect={onSelect}
+            currentHref={currentHref}
+            currentRef={currentRef}
+          />
+        </Fragment>
+      );
+    })}
+  </>
+);
+
+/** The book's contents as the manifest publishes them, with the chapter being read marked. */
+export const TocDrawer = ({ open, onClose, toc, onSelect, currentHref }: TocDrawerProps) => {
+  // A callback ref rather than an effect keyed on `open`: a temporary `Drawer`
+  // renders nothing while closed and MUI's `Portal` returns null on its first
+  // render, so such an effect fires in a commit where the list does not exist.
+  const currentRef = useCallback((node: HTMLDivElement | null) => {
+    node?.scrollIntoView({ block: 'center' });
+  }, []);
+
+  return (
+    <Drawer
+      anchor="left"
+      open={open}
+      onClose={onClose}
+      slotProps={{ paper: { 'aria-label': 'Contents' } }}
+    >
+      <Box sx={{ width: { xs: 280, sm: 340 } }} role="navigation" aria-label="Table of contents">
+        <Stack
+          direction="row"
+          sx={{ alignItems: 'center', justifyContent: 'space-between', p: 2, pb: 1 }}
+        >
+          <SectionTitle gutterBottom={false}>Contents</SectionTitle>
+          <IconButton onClick={onClose} aria-label="Close contents" size="small">
+            <CloseIcon sx={{ fontSize: ICON_SIZE.ui }} />
+          </IconButton>
+        </Stack>
+        {toc.length === 0 ? (
+          <Typography variant="body2" sx={{ color: 'text.secondary', px: 2, pb: 2 }}>
+            This book has no table of contents.
+          </Typography>
+        ) : (
+          <List sx={{ pb: 2 }}>
+            <TocEntries
+              entries={toc}
+              depth={0}
+              onSelect={onSelect}
+              currentHref={currentHref}
+              currentRef={currentRef}
+            />
+          </List>
+        )}
+      </Box>
+    </Drawer>
+  );
+};

--- a/frontend/src/components/reader/useEbookReader.ts
+++ b/frontend/src/components/reader/useEbookReader.ts
@@ -2,6 +2,7 @@ import {
   PublicationUnavailableError,
   type EbookLocation,
   type EbookReader,
+  type EbookTocEntry,
   type OpenedEbook,
 } from '@/components/reader/EbookReader.ts';
 import { ReadiumReader } from '@/components/reader/ReadiumReader.ts';
@@ -33,8 +34,12 @@ export interface EbookReaderState {
   status: EbookReaderStatus;
   pageCount: number;
   location: EbookLocation | null;
+  toc: EbookTocEntry[];
+  /** The contents entry covering where the reader is, or null where none does. */
+  currentTocHref: string | null;
   next: () => void;
   previous: () => void;
+  goTo: (location: EbookLocation) => void;
   retry: () => void;
 }
 
@@ -45,6 +50,8 @@ const outcomeOfFailure = (error: unknown): EbookReaderOutcome => {
   if (error instanceof DOMException && error.name === 'TimeoutError') return 'timeout';
   return 'error';
 };
+
+const NO_TOC: EbookTocEntry[] = [];
 
 /** One book opened into a host element, and where the reader is in it. */
 export const useEbookReader = ({
@@ -58,6 +65,8 @@ export const useEbookReader = ({
   const [outcome, setOutcome] = useState<EbookReaderOutcome | null>(null);
   const [pageCount, setPageCount] = useState(0);
   const [location, setLocation] = useState<EbookLocation | null>(null);
+  const [toc, setToc] = useState<EbookTocEntry[]>(NO_TOC);
+  const [currentTocHref, setCurrentTocHref] = useState<string | null>(null);
   const [attempt, setAttempt] = useState(0);
   const readerRef = useRef<EbookReader | null>(null);
   // Through a ref, so a hold that starts mid-book never rebuilds the reader.
@@ -77,6 +86,7 @@ export const useEbookReader = ({
     let isOpen = false;
     const unsubscribes = [
       reader.onLocationChanged(setLocation),
+      reader.onTocEntryChanged(setCurrentTocHref),
       reader.onPageTurnRequested((direction) => {
         // Readium's pager sets a navigating flag it never clears when it has no
         // frames yet, so one key before the book is up kills every later turn.
@@ -90,6 +100,8 @@ export const useEbookReader = ({
       isOpen = true;
       setPageCount(opened.pageCount);
       setLocation(opened.location);
+      setToc(opened.toc);
+      setCurrentTocHref(opened.tocHref);
       setOutcome('open');
     };
     const onFailed = (error: unknown) => {
@@ -117,12 +129,18 @@ export const useEbookReader = ({
 
   const next = useCallback(() => void readerRef.current?.next(), []);
   const previous = useCallback(() => void readerRef.current?.previous(), []);
+  const goTo = useCallback(
+    (destination: EbookLocation) => void readerRef.current?.goTo(destination),
+    []
+  );
   // Both, and in one go: the host is unmounted behind the message this is
   // offered on, and has to be back in the tree before the new attempt looks for it.
   const retry = useCallback(() => {
     setOutcome(null);
-    // Otherwise the last attempt's page label sits over the new attempt's skeleton.
+    // Nothing from the last attempt survives into the new one.
     setPageCount(0);
+    setToc(NO_TOC);
+    setCurrentTocHref(null);
     setAttempt((count) => count + 1);
   }, []);
 
@@ -130,5 +148,5 @@ export const useEbookReader = ({
   // render: an effect that set the status would cascade one on every open.
   const status: EbookReaderStatus = enabled ? (outcome ?? 'opening') : 'idle';
 
-  return { status, pageCount, location, next, previous, retry };
+  return { status, pageCount, location, toc, currentTocHref, next, previous, goTo, retry };
 };

--- a/frontend/src/pages/ReaderPage/ReaderPage.test.tsx
+++ b/frontend/src/pages/ReaderPage/ReaderPage.test.tsx
@@ -33,7 +33,7 @@ const aReadableBook = () =>
 /** The book open at its first page, which is where every reading test starts. */
 const openTheBook = async () => {
   const screen = await renderApp({ path: '/book/1/read' });
-  await expect.element(screen.getByText('Page 1 of 2')).toBeVisible();
+  await expect.element(screen.getByText('Page 1 of 2 · 0%')).toBeVisible();
   return screen;
 };
 
@@ -118,10 +118,10 @@ test('the next button turns the page and the label follows', async () => {
   const screen = await openTheBook();
 
   await screen.getByRole('button', { name: 'Next page' }).click();
-  await expectPage(screen, 'Page 2 of 2');
+  await expectPage(screen, 'Page 2 of 2 · 50%');
 
   await screen.getByRole('button', { name: 'Previous page' }).click();
-  await expectPage(screen, 'Page 1 of 2');
+  await expectPage(screen, 'Page 1 of 2 · 0%');
 });
 
 test('the arrow keys turn the page', async () => {
@@ -131,10 +131,10 @@ test('the arrow keys turn the page', async () => {
   const screen = await openTheBook();
 
   await userEvent.keyboard('{ArrowRight}');
-  await expectPage(screen, 'Page 2 of 2');
+  await expectPage(screen, 'Page 2 of 2 · 50%');
 
   await userEvent.keyboard('{ArrowLeft}');
-  await expectPage(screen, 'Page 1 of 2');
+  await expectPage(screen, 'Page 1 of 2 · 0%');
 });
 
 test('an arrow key pressed before the book is on screen does not jam it', async () => {
@@ -153,9 +153,9 @@ test('an arrow key pressed before the book is on screen does not jam it', async 
   await expect.element(screen.getByLabelText('Loading the book')).toBeVisible();
   await userEvent.keyboard('{ArrowRight}');
 
-  await expectPage(screen, 'Page 1 of 2');
+  await expectPage(screen, 'Page 1 of 2 · 0%');
   await screen.getByRole('button', { name: 'Next page' }).click();
-  await expectPage(screen, 'Page 2 of 2');
+  await expectPage(screen, 'Page 2 of 2 · 50%');
 });
 
 test('a book with no EPUB explains there is nothing to read', async () => {
@@ -189,7 +189,7 @@ test('a book whose manifest cannot be read says so and offers a retry', async ()
   worker.use(...readiumApi());
   await screen.getByRole('button', { name: 'Try again' }).click();
 
-  await expectPage(screen, 'Page 1 of 2');
+  await expectPage(screen, 'Page 1 of 2 · 0%');
 });
 
 test('a lapsed session holds the book until it has been renewed', async () => {
@@ -265,7 +265,7 @@ test('the contents mark the chapter being read, and follow the reader out of it'
   await closeTheContents(screen);
 
   await screen.getByRole('button', { name: 'Next page' }).click();
-  await expectPage(screen, 'Page 2 of 2');
+  await expectPage(screen, 'Page 2 of 2 · 50%');
 
   const reopened = await openTheContents(screen);
   await expect
@@ -347,5 +347,5 @@ test('an arrow key with the contents open does not turn the page behind them', a
   // Settled rather than polled: a turn that got through would land a frame or
   // two later, and an immediate assertion would pass while it was in flight.
   await new Promise((resolve) => setTimeout(resolve, 1_200));
-  await expect.element(screen.getByText('Page 1 of 2')).toBeVisible();
+  await expect.element(screen.getByText('Page 1 of 2 · 0%')).toBeVisible();
 });

--- a/frontend/src/pages/ReaderPage/ReaderPage.test.tsx
+++ b/frontend/src/pages/ReaderPage/ReaderPage.test.tsx
@@ -1,4 +1,6 @@
+import type { WebPublicationManifest } from '@/api/generated/model';
 import { aBookDetails } from '@tests/fixtures/book';
+import { aManifest } from '@tests/fixtures/publication';
 import { renderApp } from '@tests/harness/renderApp';
 import { bookApi } from '@tests/msw/bookApi';
 import { noPublication, readiumApi } from '@tests/msw/readiumApi';
@@ -214,4 +216,136 @@ test('a lapsed session holds the book until it has been renewed', async () => {
     .element(screen.getByText('Reconnecting…'), { timeout: 5_000 })
     .not.toBeInTheDocument();
   await expect.element(screen.getByRole('button', { name: 'Next page' })).toBeEnabled();
+});
+
+const openTheContents = async (screen: Screen) => {
+  await screen.getByRole('button', { name: 'Contents' }).click();
+  return screen.getByRole('navigation', { name: 'Table of contents' });
+};
+
+const closeTheContents = async (screen: Screen) => {
+  await screen.getByRole('button', { name: 'Close contents' }).click();
+  await expect
+    .element(screen.getByRole('navigation', { name: 'Table of contents' }))
+    .not.toBeInTheDocument();
+};
+
+/** A book on screen at its first page, with its contents drawer open. */
+const aBookWithItsContentsOpen = async (manifest?: WebPublicationManifest) => {
+  worker.use(...aReadableBook());
+  worker.use(...readiumApi({ manifest }));
+  const screen = await openTheBook();
+  return { screen, contents: await openTheContents(screen) };
+};
+
+test('the contents drawer lists the chapters the manifest publishes', async () => {
+  const { screen, contents } = await aBookWithItsContentsOpen();
+
+  await expect.element(screen.getByRole('dialog', { name: 'Contents' })).toBeVisible();
+  await expect.element(contents.getByText('On Attention')).toBeVisible();
+  await expect.element(contents.getByText('Part two')).toBeVisible();
+  await expect.element(contents.getByText('On Memory')).toBeVisible();
+
+  // The tree is kept rather than flattened: a chapter sits in from its part.
+  const indentOf = (title: string) =>
+    (contents.getByText(title).element() as HTMLElement).getBoundingClientRect().left;
+  expect(indentOf('On Memory')).toBeGreaterThan(indentOf('Part two'));
+  expect(indentOf('Part two')).toBe(indentOf('On Attention'));
+});
+
+test('the contents mark the chapter being read, and follow the reader out of it', async () => {
+  const { screen, contents } = await aBookWithItsContentsOpen();
+
+  await expect
+    .element(contents.getByRole('button', { name: 'On Attention' }))
+    .toHaveAttribute('aria-current', 'location');
+  await expect
+    .element(contents.getByRole('button', { name: 'On Memory' }))
+    .not.toHaveAttribute('aria-current');
+  await closeTheContents(screen);
+
+  await screen.getByRole('button', { name: 'Next page' }).click();
+  await expectPage(screen, 'Page 2 of 2');
+
+  const reopened = await openTheContents(screen);
+  await expect
+    .element(reopened.getByRole('button', { name: 'On Memory' }))
+    .toHaveAttribute('aria-current', 'location');
+  await expect
+    .element(reopened.getByRole('button', { name: 'On Attention' }))
+    .not.toHaveAttribute('aria-current');
+});
+
+/** The nearest ancestor that actually scrolls, whatever MUI happens to call it. */
+const scrollerAbove = (node: HTMLElement): HTMLElement | null => {
+  for (let el = node.parentElement; el; el = el.parentElement) {
+    if (el.scrollHeight > el.clientHeight + 1) return el;
+  }
+  return null;
+};
+
+/** A book whose contents are long enough to push the chapter being read off screen. */
+const aLongToc = () =>
+  aManifest({
+    toc: [
+      ...Array.from({ length: 40 }, (_, index) => ({
+        href: `resources/OEBPS/front-matter-${index}.xhtml`,
+        title: `Front matter ${index}`,
+      })),
+      { href: 'resources/OEBPS/chapter1.xhtml', title: 'On Attention' },
+      { href: 'resources/OEBPS/chapter2.xhtml', title: 'On Memory' },
+    ],
+  });
+
+test('the contents open scrolled to the chapter being read', async () => {
+  const { contents } = await aBookWithItsContentsOpen(aLongToc());
+
+  const marked = contents.getByRole('button', { name: 'On Attention' });
+  await expect.element(marked).toHaveAttribute('aria-current', 'location');
+
+  const node = marked.element() as HTMLElement;
+  await expect.poll(() => scrollerAbove(node)?.scrollTop ?? 0).toBeGreaterThan(0);
+
+  // And it is genuinely on screen, which is the thing the reader gets.
+  const box = node.getBoundingClientRect();
+  expect(box.top).toBeGreaterThanOrEqual(0);
+  expect(box.bottom).toBeLessThanOrEqual(window.innerHeight);
+});
+
+test('a heading that links nowhere cannot be picked', async () => {
+  const { contents } = await aBookWithItsContentsOpen();
+
+  await expect
+    .element(contents.getByRole('button', { name: 'Part two' }))
+    .toHaveAttribute('aria-disabled', 'true');
+  await expect
+    .element(contents.getByRole('button', { name: 'On Memory' }))
+    .not.toHaveAttribute('aria-disabled');
+});
+
+test('an entry the manifest leaves untitled is still named', async () => {
+  const { contents } = await aBookWithItsContentsOpen(
+    aManifest({ toc: [{ href: 'resources/OEBPS/chapter1.xhtml', title: '' }] })
+  );
+
+  await expect
+    .element(contents.getByRole('button', { name: 'Untitled' }))
+    .toHaveAttribute('aria-current', 'location');
+});
+
+test('a book with no contents says so', async () => {
+  const { contents } = await aBookWithItsContentsOpen(aManifest({ toc: [] }));
+
+  await expect.element(contents.getByText('This book has no table of contents.')).toBeVisible();
+});
+
+test('an arrow key with the contents open does not turn the page behind them', async () => {
+  const { screen } = await aBookWithItsContentsOpen();
+
+  await userEvent.keyboard('{ArrowRight}');
+
+  // Settled rather than polled: a turn that got through would land a frame or
+  // two later, and an immediate assertion would pass while it was in flight.
+  await new Promise((resolve) => setTimeout(resolve, 1_200));
+  await expect.element(screen.getByText('Page 1 of 2')).toBeVisible();
 });

--- a/frontend/tests/fakes/FakeEbookReader.ts
+++ b/frontend/tests/fakes/FakeEbookReader.ts
@@ -15,12 +15,14 @@ export const aFakeLocation = (position: number): EbookLocation => ({
 /** An `EbookReader` whose open the test settles and whose events the test fires. */
 export class FakeEbookReader implements EbookReader {
   readonly openedWith: string[] = [];
+  readonly goToCalls: EbookLocation[] = [];
   nextCalls = 0;
   previousCalls = 0;
   destroyed = false;
 
   private readonly locationListeners = new Set<(location: EbookLocation) => void>();
   private readonly pageTurnListeners = new Set<(direction: PageTurnDirection) => void>();
+  private readonly tocEntryListeners = new Set<(href: string | null) => void>();
   private settle: ((opened: OpenedEbook) => void) | undefined;
   private isOpened = false;
 
@@ -38,11 +40,15 @@ export class FakeEbookReader implements EbookReader {
   }
 
   resolveOpen(opened: Partial<OpenedEbook> = {}): void {
-    this.settle?.({ pageCount: 2, toc: [], location: aFakeLocation(1), ...opened });
+    this.settle?.({ pageCount: 2, toc: [], tocHref: null, location: aFakeLocation(1), ...opened });
   }
 
   requestPageTurn(direction: PageTurnDirection): void {
     for (const listener of [...this.pageTurnListeners]) listener(direction);
+  }
+
+  reportTocEntry(href: string | null): void {
+    for (const listener of [...this.tocEntryListeners]) listener(href);
   }
 
   next(): Promise<void> {
@@ -55,7 +61,8 @@ export class FakeEbookReader implements EbookReader {
     return Promise.resolve();
   }
 
-  goTo(): Promise<void> {
+  goTo(location: EbookLocation): Promise<void> {
+    this.goToCalls.push(location);
     return Promise.resolve();
   }
 
@@ -67,6 +74,11 @@ export class FakeEbookReader implements EbookReader {
   onPageTurnRequested(listener: (direction: PageTurnDirection) => void): () => void {
     this.pageTurnListeners.add(listener);
     return () => this.pageTurnListeners.delete(listener);
+  }
+
+  onTocEntryChanged(listener: (href: string | null) => void): () => void {
+    this.tocEntryListeners.add(listener);
+    return () => this.tocEntryListeners.delete(listener);
   }
 
   destroy(): Promise<void> {


### PR DESCRIPTION
Closes #824. Part of #823 (R3 — Reader UI, second pass), after #822.

A book of ninety chapters had no way to reach chapter forty. The manifest's
table of contents already crossed the `EbookReader` seam; now it is on screen.

## Three commits

1. **The seam reports which contents entry is being read.** `EbookReader` gains
   `onTocEntryChanged`, `OpenedEbook` gains `tocHref`, and `EbookTocEntry`
   carries the media type needed to navigate to it. The entry is resolved by
   Readium's `timeline.tocEntryFor`, which answers in three tiers — the entry
   for this resource, else the nearest preceding heading inside it, else the
   nearest preceding resource's entry. Matching hrefs by hand gets single-file
   books and covers between chapters wrong.
2. **The contents drawer.** Nested as the author shaped the book rather than
   flattened, the chapter being read marked, the drawer opening scrolled to it,
   unlinked part headings disabled, and an empty contents list saying so.
3. **The page label's progress and the reading inset.** `Page 12 of 340 · 4%`,
   and air above the first line so it does not sit against the header's border.

## Two departures from the ticket, both deliberate

**The opening contents entry is a return value, not an event.** #824 specified
an emit "once after open ... (Readium reports only changes)". That premise does
not hold: `EpubNavigator.eventListener`'s `_pong` branch calls
`_notifyTimelineChange` when the first frame reports in, inside
`navigator.load()`. The hand-written emit survived its own deletion with every
test green. `OpenedEbook.tocHref` mirrors `OpenedEbook.location` instead — the
opening value returned, the changes subscribed to.

**Arrow keys do not move focus inside the drawer, and will not.** #824 asked
for "arrow keys inside the drawer move focus in the list and must not turn
pages". The second half works and is tested. The first describes something the
spike never did either — MUI's `List` has no roving tabindex — and Tab is the
expected way to browse the contents. Closing #824 without it.

## A bug fixed on the way

`ReadiumReader.goTo` ran locations through `Locator.deserialize`, which returns
`undefined` unless `href` *and* `type` are truthy. Manifest contents links
usually declare no media type, so navigating to a contents entry would have
thrown. `fromLocation` now builds the `Locator` directly, as Readium's own
`goLink` does.

**Tripwire for R4 (#827/#828):** that change no longer collects
`otherLocations`, which is where `cssSelector` and `partialCfi` live. Widening
`EbookLocation.locations` for highlight anchors means widening `fromLocation`
in the same change.

## For R3.2 (#825)

The arrow-key suppression here comes from MUI stamping `role="dialog"` on the
drawer paper, which is in Readium's `interactiveRoles` and is checked before
the tabIndex test that a `tabIndex=-1` paper would fail. An appearance popover
on `Popover` or `Menu` may not inherit that, so #825 needs its own arrow-key
test rather than leaning on this one.

## Known and accepted

- A manifest naming the same href twice marks both rows. Both entries genuinely
  cover that resource, and a JSON seam reporting a bare href cannot do better.
- An entry the manifest leaves untitled reads as "Untitled" — our own EPUB
  parser emits an empty title for a nav `<li>` with a sublist but no `<a>`, and
  for any NCX navPoint without a label.
- A short book's last page reads below 100% (two pages ends at 50%); a long
  book reaches 100% on its last page or few. Readium reports progression at the
  start of a position.

## Verification

260 tests across 32 files, up from 250. `tsc`, `eslint`, `prettier`, `knip`
clean; jscpd unchanged at 20 clones / 0.9%. Every new behaviour was
mutation-checked — broken in the smallest way that should fail a test, with a
test confirmed to fail, then reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DZ2vdUGgLAsfUzU1S46PVU
