### PR TITLE
R3.2 Appearance popover: font size, spacing, page colour, alignment, columns (#825)

### DIFF
--- a/frontend/src/components/inputs/ChoiceSection.tsx
+++ b/frontend/src/components/inputs/ChoiceSection.tsx
@@ -1,0 +1,42 @@
+import { SectionTitle } from '@/components/typography/SectionTitle.tsx';
+import { Box, ToggleButton, ToggleButtonGroup } from '@mui/material';
+
+interface ChoiceSectionProps<Option extends string> {
+  /** The heading above the control, and the group's accessible name. */
+  heading: string;
+  options: readonly Option[];
+  labels: Record<Option, string>;
+  value: Option;
+  onSelect: (option: Option) => void;
+}
+
+/** A headed row of choices, one of which is always the chosen one. */
+export const ChoiceSection = <Option extends string>({
+  heading,
+  options,
+  labels,
+  value,
+  onSelect,
+}: ChoiceSectionProps<Option>) => (
+  <Box>
+    <SectionTitle>{heading}</SectionTitle>
+    <ToggleButtonGroup
+      exclusive
+      fullWidth
+      size="small"
+      value={value}
+      aria-label={heading}
+      onChange={(_event, chosen: Option | null) => {
+        // Null when the button pressed was the active one already, and every
+        // one of these settings always has a value.
+        if (chosen !== null) onSelect(chosen);
+      }}
+    >
+      {options.map((option) => (
+        <ToggleButton key={option} value={option}>
+          {labels[option]}
+        </ToggleButton>
+      ))}
+    </ToggleButtonGroup>
+  </Box>
+);

--- a/frontend/src/components/reader/EbookReader.ts
+++ b/frontend/src/components/reader/EbookReader.ts
@@ -46,6 +46,8 @@ export interface OpenedEbook {
 export interface EbookAppearance {
   /** A multiplier on the publication's own font size; 1 is the book as its publisher set it. */
   fontSize: number;
+  /** A multiplier on the font size; `null` leaves the book's own spacing alone. */
+  lineHeight: number | null;
   /** `null` says nothing at all, leaving the book's own stylesheet in charge. */
   textAlign: 'start' | 'justify' | null;
   /** `null` fits as many columns as the width allows. */

--- a/frontend/src/components/reader/EbookReader.ts
+++ b/frontend/src/components/reader/EbookReader.ts
@@ -38,6 +38,8 @@ export interface OpenedEbook {
   /** The contents entry the book opened at, or null where none covers it. */
   tocHref: string | null;
   location: EbookLocation;
+  /** The range the engine honours for `EbookAppearance.fontSize`; any value inside it is legal. */
+  fontSizeRange: [number, number];
 }
 
 /** How the page should look, in terms any engine can honour. */

--- a/frontend/src/components/reader/EbookReader.ts
+++ b/frontend/src/components/reader/EbookReader.ts
@@ -40,6 +40,18 @@ export interface OpenedEbook {
   location: EbookLocation;
 }
 
+/** How the page should look, in terms any engine can honour. */
+export interface EbookAppearance {
+  /** A multiplier on the publication's own font size; 1 is the book as its publisher set it. */
+  fontSize: number;
+  /** `null` says nothing at all, leaving the book's own stylesheet in charge. */
+  textAlign: 'start' | 'justify' | null;
+  /** `null` fits as many columns as the width allows. */
+  columnCount: number | null;
+  pageBackgroundColor: string;
+  pageTextColor: string;
+}
+
 /** Which way a page turn was asked to go. */
 export type PageTurnDirection = 'next' | 'previous';
 
@@ -54,15 +66,21 @@ export class PublicationUnavailableError extends Error {
   }
 }
 
+export interface OpenEbookOptions {
+  /** Handed to the engine at construction, so the book opens at the right size
+   * rather than reflowing a tick after it appears. */
+  appearance: EbookAppearance;
+  /** The caller's cancellation — an unmount, a remount, a boot watchdog — which
+   * every await inside observes, composed with the reader's own destruction. */
+  signal?: AbortSignal;
+}
+
 /** A book on screen, and the ways the UI moves through it. */
 export interface EbookReader {
-  /**
-   * Loads the book named by a Readium manifest URL into the host element. Call once.
-   *
-   * `signal` is the caller's cancellation (an unmount, a remount, a boot watchdog via
-   * `AbortSignal.timeout`); every await inside observes it, composed with the reader's destruction.
-   */
-  open(manifestUrl: string, signal?: AbortSignal): Promise<OpenedEbook>;
+  /** Loads the book named by a Readium manifest URL into the host element. Call once. */
+  open(manifestUrl: string, options: OpenEbookOptions): Promise<OpenedEbook>;
+  /** Applies an appearance to a book already on screen. */
+  setAppearance(appearance: EbookAppearance): Promise<void>;
   next(): Promise<void>;
   previous(): Promise<void>;
   goTo(location: EbookLocation): Promise<void>;

--- a/frontend/src/components/reader/EbookReader.ts
+++ b/frontend/src/components/reader/EbookReader.ts
@@ -48,6 +48,10 @@ export interface EbookAppearance {
   fontSize: number;
   /** A multiplier on the font size; `null` leaves the book's own spacing alone. */
   lineHeight: number | null;
+  /** The gap between paragraphs in rem; `null` leaves the book's own alone. */
+  paragraphSpacing: number | null;
+  /** The indent of a paragraph's first line in rem; `null` leaves the book's own alone. */
+  paragraphIndent: number | null;
   /** `null` says nothing at all, leaving the book's own stylesheet in charge. */
   textAlign: 'start' | 'justify' | null;
   /** `null` fits as many columns as the width allows. */

--- a/frontend/src/components/reader/ReaderLoading.tsx
+++ b/frontend/src/components/reader/ReaderLoading.tsx
@@ -1,0 +1,13 @@
+import { Spinner } from '@/components/animations/Spinner.tsx';
+import { Stack } from '@mui/material';
+
+/** What stands in for the page while the book is on its way to the screen. */
+export const ReaderLoading = () => (
+  <Stack
+    aria-label="Loading the book"
+    aria-busy="true"
+    sx={{ position: 'absolute', inset: 0, justifyContent: 'center' }}
+  >
+    <Spinner />
+  </Stack>
+);

--- a/frontend/src/components/reader/ReaderSettings.tsx
+++ b/frontend/src/components/reader/ReaderSettings.tsx
@@ -4,6 +4,8 @@ import {
   READER_ALIGNMENTS,
   READER_COLUMN_LABELS,
   READER_COLUMNS,
+  READER_LINE_HEIGHT_LABELS,
+  READER_LINE_HEIGHTS,
   READER_PAGE_COLOR_LABELS,
   READER_PAGE_COLORS,
   type ReaderPreferences,
@@ -121,6 +123,13 @@ export const ReaderSettings = ({
         range={fontSizeRange}
         value={preferences.fontSize}
         onChange={(fontSize) => onChange({ ...preferences, fontSize })}
+      />
+      <ChoiceSection
+        heading="Line height"
+        options={READER_LINE_HEIGHTS}
+        labels={READER_LINE_HEIGHT_LABELS}
+        value={preferences.lineHeight}
+        onSelect={(lineHeight) => onChange({ ...preferences, lineHeight })}
       />
       <ChoiceSection
         heading="Page colour"

--- a/frontend/src/components/reader/ReaderSettings.tsx
+++ b/frontend/src/components/reader/ReaderSettings.tsx
@@ -4,10 +4,10 @@ import {
   READER_ALIGNMENTS,
   READER_COLUMN_LABELS,
   READER_COLUMNS,
-  READER_LINE_HEIGHT_LABELS,
-  READER_LINE_HEIGHTS,
   READER_PAGE_COLOR_LABELS,
   READER_PAGE_COLORS,
+  READER_SPACING_LABELS,
+  READER_SPACINGS,
   type ReaderPreferences,
 } from '@/components/reader/readerPreferences.ts';
 import { SectionTitle } from '@/components/typography/SectionTitle.tsx';
@@ -125,11 +125,11 @@ export const ReaderSettings = ({
         onChange={(fontSize) => onChange({ ...preferences, fontSize })}
       />
       <ChoiceSection
-        heading="Line height"
-        options={READER_LINE_HEIGHTS}
-        labels={READER_LINE_HEIGHT_LABELS}
-        value={preferences.lineHeight}
-        onSelect={(lineHeight) => onChange({ ...preferences, lineHeight })}
+        heading="Spacing"
+        options={READER_SPACINGS}
+        labels={READER_SPACING_LABELS}
+        value={preferences.spacing}
+        onSelect={(spacing) => onChange({ ...preferences, spacing })}
       />
       <ChoiceSection
         heading="Page colour"

--- a/frontend/src/components/reader/ReaderSettings.tsx
+++ b/frontend/src/components/reader/ReaderSettings.tsx
@@ -125,20 +125,6 @@ export const ReaderSettings = ({
         onChange={(fontSize) => onChange({ ...preferences, fontSize })}
       />
       <ChoiceSection
-        heading="Spacing"
-        options={READER_SPACINGS}
-        labels={READER_SPACING_LABELS}
-        value={preferences.spacing}
-        onSelect={(spacing) => onChange({ ...preferences, spacing })}
-      />
-      <ChoiceSection
-        heading="Page colour"
-        options={READER_PAGE_COLORS}
-        labels={READER_PAGE_COLOR_LABELS}
-        value={preferences.pageColor}
-        onSelect={(pageColor) => onChange({ ...preferences, pageColor })}
-      />
-      <ChoiceSection
         heading="Text alignment"
         options={READER_ALIGNMENTS}
         labels={READER_ALIGNMENT_LABELS}
@@ -146,11 +132,25 @@ export const ReaderSettings = ({
         onSelect={(alignment) => onChange({ ...preferences, alignment })}
       />
       <ChoiceSection
+        heading="Spacing"
+        options={READER_SPACINGS}
+        labels={READER_SPACING_LABELS}
+        value={preferences.spacing}
+        onSelect={(spacing) => onChange({ ...preferences, spacing })}
+      />
+      <ChoiceSection
         heading="Columns"
         options={READER_COLUMNS}
         labels={READER_COLUMN_LABELS}
         value={preferences.columns}
         onSelect={(columns) => onChange({ ...preferences, columns })}
+      />
+      <ChoiceSection
+        heading="Page colour"
+        options={READER_PAGE_COLORS}
+        labels={READER_PAGE_COLOR_LABELS}
+        value={preferences.pageColor}
+        onSelect={(pageColor) => onChange({ ...preferences, pageColor })}
       />
     </Stack>
   </Popover>

--- a/frontend/src/components/reader/ReaderSettings.tsx
+++ b/frontend/src/components/reader/ReaderSettings.tsx
@@ -1,0 +1,63 @@
+import { ChoiceSection } from '@/components/inputs/ChoiceSection.tsx';
+import {
+  READER_ALIGNMENT_LABELS,
+  READER_ALIGNMENTS,
+  READER_COLUMN_LABELS,
+  READER_COLUMNS,
+  READER_PAGE_COLOR_LABELS,
+  READER_PAGE_COLORS,
+  type ReaderPreferences,
+} from '@/components/reader/readerPreferences.ts';
+import { Popover, Stack } from '@mui/material';
+
+interface ReaderSettingsProps {
+  anchorEl: Element | null;
+  onClose: () => void;
+  preferences: ReaderPreferences;
+  onChange: (preferences: ReaderPreferences) => void;
+}
+
+/** What the page looks like: its colour, how its lines are set, and in how many columns. */
+export const ReaderSettings = ({
+  anchorEl,
+  onClose,
+  preferences,
+  onChange,
+}: ReaderSettingsProps) => (
+  <Popover
+    open={anchorEl !== null}
+    anchorEl={anchorEl}
+    onClose={onClose}
+    anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+    transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+    // Readium suppresses a page turn while an interactive element has focus, and
+    // `role=dialog` is what makes this paper — which holds it — count as one.
+    slotProps={{
+      paper: { role: 'dialog', 'aria-label': 'Appearance', sx: { p: 2.5, width: 320 } },
+    }}
+  >
+    <Stack spacing={2}>
+      <ChoiceSection
+        heading="Page colour"
+        options={READER_PAGE_COLORS}
+        labels={READER_PAGE_COLOR_LABELS}
+        value={preferences.pageColor}
+        onSelect={(pageColor) => onChange({ ...preferences, pageColor })}
+      />
+      <ChoiceSection
+        heading="Text alignment"
+        options={READER_ALIGNMENTS}
+        labels={READER_ALIGNMENT_LABELS}
+        value={preferences.alignment}
+        onSelect={(alignment) => onChange({ ...preferences, alignment })}
+      />
+      <ChoiceSection
+        heading="Columns"
+        options={READER_COLUMNS}
+        labels={READER_COLUMN_LABELS}
+        value={preferences.columns}
+        onSelect={(columns) => onChange({ ...preferences, columns })}
+      />
+    </Stack>
+  </Popover>
+);

--- a/frontend/src/components/reader/ReaderSettings.tsx
+++ b/frontend/src/components/reader/ReaderSettings.tsx
@@ -8,21 +8,101 @@ import {
   READER_PAGE_COLORS,
   type ReaderPreferences,
 } from '@/components/reader/readerPreferences.ts';
-import { Popover, Stack } from '@mui/material';
+import { SectionTitle } from '@/components/typography/SectionTitle.tsx';
+import { LargerTextIcon, SmallerTextIcon } from '@/theme/Icons.tsx';
+import { ICON_SIZE } from '@/theme/iconSizes.ts';
+import { Box, IconButton, InputAdornment, Popover, Stack, TextField } from '@mui/material';
+import { useState } from 'react';
+
+const FONT_SIZE_STEP = 0.25;
+
+const asPercent = (fontSize: number) => String(Math.round(fontSize * 100));
+
+// A size clamped to the range, or typed, need not sit on a step. Carrying that
+// offset forward would put the size the book opened at out of the buttons' reach.
+const steppedFrom = (fontSize: number, direction: 1 | -1) => {
+  const steps = fontSize / FONT_SIZE_STEP;
+  return (direction === 1 ? Math.floor(steps) + 1 : Math.ceil(steps) - 1) * FONT_SIZE_STEP;
+};
+
+const clamped = (fontSize: number, [min, max]: [number, number]) =>
+  Math.min(Math.max(fontSize, min), max);
+
+interface FontSizeSectionProps {
+  range: [number, number];
+  value: number;
+  onChange: (fontSize: number) => void;
+}
+
+const FontSizeSection = ({ range, value, onChange }: FontSizeSectionProps) => {
+  const [typed, setTyped] = useState(asPercent(value));
+  const apply = (fontSize: number) => {
+    setTyped(asPercent(fontSize));
+    // Enter and then a blur commit the same size twice, and the engine reflows
+    // the book on every appearance it is handed.
+    if (asPercent(fontSize) !== asPercent(value)) onChange(fontSize);
+  };
+  // On blur and Enter rather than per keystroke: "1" on the way to "150" is a
+  // size of its own, and each one would reach the engine.
+  const commit = () => {
+    const percent = Number(typed);
+    if (typed.trim() === '' || !Number.isFinite(percent)) {
+      setTyped(asPercent(value));
+      return;
+    }
+    apply(clamped(Math.round(percent) / 100, range));
+  };
+
+  const step = (direction: 1 | -1) => apply(clamped(steppedFrom(value, direction), range));
+
+  return (
+    <Box>
+      <SectionTitle>Font size</SectionTitle>
+      <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
+        <IconButton aria-label="Smaller text" disabled={value <= range[0]} onClick={() => step(-1)}>
+          <SmallerTextIcon sx={{ fontSize: ICON_SIZE.ui }} />
+        </IconButton>
+        <TextField
+          size="small"
+          value={typed}
+          onChange={(event) => setTyped(event.target.value)}
+          onBlur={commit}
+          // The arrows a reader reaches for in a number field. They cannot turn
+          // the page: Readium suppresses its page turns while an input has focus.
+          onKeyDown={(event) => {
+            if (event.key === 'Enter') commit();
+            if (event.key === 'ArrowUp') step(1);
+            if (event.key === 'ArrowDown') step(-1);
+          }}
+          slotProps={{
+            htmlInput: { 'aria-label': 'Font size in percent', inputMode: 'numeric' },
+            input: { endAdornment: <InputAdornment position="end">%</InputAdornment> },
+          }}
+          sx={{ flex: 1 }}
+        />
+        <IconButton aria-label="Larger text" disabled={value >= range[1]} onClick={() => step(1)}>
+          <LargerTextIcon sx={{ fontSize: ICON_SIZE.ui }} />
+        </IconButton>
+      </Stack>
+    </Box>
+  );
+};
 
 interface ReaderSettingsProps {
   anchorEl: Element | null;
   onClose: () => void;
   preferences: ReaderPreferences;
   onChange: (preferences: ReaderPreferences) => void;
+  fontSizeRange: [number, number];
 }
 
-/** What the page looks like: its colour, how its lines are set, and in how many columns. */
+/** What the page looks like: text size, colour, how the lines are set, and in how many columns. */
 export const ReaderSettings = ({
   anchorEl,
   onClose,
   preferences,
   onChange,
+  fontSizeRange,
 }: ReaderSettingsProps) => (
   <Popover
     open={anchorEl !== null}
@@ -37,6 +117,11 @@ export const ReaderSettings = ({
     }}
   >
     <Stack spacing={2}>
+      <FontSizeSection
+        range={fontSizeRange}
+        value={preferences.fontSize}
+        onChange={(fontSize) => onChange({ ...preferences, fontSize })}
+      />
       <ChoiceSection
         heading="Page colour"
         options={READER_PAGE_COLORS}

--- a/frontend/src/components/reader/ReaderShell.test.tsx
+++ b/frontend/src/components/reader/ReaderShell.test.tsx
@@ -93,6 +93,7 @@ test("the book is opened with the reader's appearance", async () => {
   await expect.poll(() => readers.length).toBe(1);
   expect(readers[0].openedWith[0].appearance).toEqual({
     fontSize: 1,
+    lineHeight: null,
     textAlign: null,
     columnCount: 1,
     // The light page is the app's own off-white rather than publisher white.
@@ -353,6 +354,14 @@ test('a size being typed reaches the book only once it is committed', async () =
   await userEvent.keyboard('{Enter}');
 
   expect(fontSizes()).toEqual([1.5]);
+});
+
+test('a line height chosen in the popover reaches the engine', async () => {
+  const screen = await anOpenAppearance();
+
+  await screen.getByRole('button', { name: 'Tight' }).click();
+
+  expect(readers[0].appearances.map((appearance) => appearance.lineHeight)).toEqual([1.2]);
 });
 
 test('a page colour chosen in the popover reaches the engine', async () => {

--- a/frontend/src/components/reader/ReaderShell.test.tsx
+++ b/frontend/src/components/reader/ReaderShell.test.tsx
@@ -8,6 +8,7 @@ import { worker } from '@tests/msw/worker';
 import { HttpResponse, delay, http } from 'msw';
 import { beforeEach, expect, test } from 'vitest';
 import { render } from 'vitest-browser-react';
+import { userEvent } from 'vitest/browser';
 
 const SESSION_PATH = '/api/v1/readium/books/:bookId/session';
 const RESOURCE_PATH = '/api/v1/readium/books/:bookId/resources/*';
@@ -212,6 +213,38 @@ test('picking a contents entry goes there and closes the drawer', async () => {
   await expect
     .element(screen.getByRole('navigation', { name: 'Table of contents' }))
     .not.toBeInTheDocument();
+});
+
+const openTheAppearance = async (screen: Screen) => {
+  await screen.getByRole('button', { name: 'Appearance' }).click();
+  await expect.element(screen.getByRole('dialog', { name: 'Appearance' })).toBeVisible();
+};
+
+test('a page colour chosen in the popover reaches the engine', async () => {
+  worker.use(...readiumApi());
+
+  const screen = await anOpenBook();
+  await openTheAppearance(screen);
+
+  await screen.getByRole('button', { name: 'Dark' }).click();
+
+  expect(readers[0].appearances).toHaveLength(1);
+  expect(readers[0].appearances[0]).toMatchObject({
+    pageBackgroundColor: theme.customColors.readerPage.dark.background,
+    pageTextColor: theme.customColors.readerPage.dark.text,
+  });
+});
+
+test('opening the appearance and closing it again leaves the book alone', async () => {
+  worker.use(...readiumApi());
+
+  const screen = await anOpenBook();
+  await openTheAppearance(screen);
+
+  await userEvent.keyboard('{Escape}');
+
+  await expect.element(screen.getByRole('dialog', { name: 'Appearance' })).not.toBeInTheDocument();
+  expect(readers[0].appearances).toEqual([]);
 });
 
 test('closing the shell destroys the reader', async () => {

--- a/frontend/src/components/reader/ReaderShell.test.tsx
+++ b/frontend/src/components/reader/ReaderShell.test.tsx
@@ -94,6 +94,8 @@ test("the book is opened with the reader's appearance", async () => {
   expect(readers[0].openedWith[0].appearance).toEqual({
     fontSize: 1,
     lineHeight: null,
+    paragraphSpacing: null,
+    paragraphIndent: null,
     textAlign: null,
     columnCount: 1,
     // The light page is the app's own off-white rather than publisher white.
@@ -356,12 +358,18 @@ test('a size being typed reaches the book only once it is committed', async () =
   expect(fontSizes()).toEqual([1.5]);
 });
 
-test('a line height chosen in the popover reaches the engine', async () => {
+test('a spacing chosen in the popover reaches the engine', async () => {
   const screen = await anOpenAppearance();
 
   await screen.getByRole('button', { name: 'Tight' }).click();
 
-  expect(readers[0].appearances.map((appearance) => appearance.lineHeight)).toEqual([1.2]);
+  expect(readers[0].appearances).toHaveLength(1);
+  expect(readers[0].appearances[0]).toMatchObject({
+    lineHeight: 1.2,
+    // Tight squeezes the lines and leaves the paragraph breaks as the book set them.
+    paragraphSpacing: null,
+    paragraphIndent: null,
+  });
 });
 
 test('a page colour chosen in the popover reaches the engine', async () => {

--- a/frontend/src/components/reader/ReaderShell.test.tsx
+++ b/frontend/src/components/reader/ReaderShell.test.tsx
@@ -1,5 +1,7 @@
 import type { EbookTocEntry, OpenedEbook } from '@/components/reader/EbookReader.ts';
 import { ReaderShell, type ReaderShellProps } from '@/components/reader/ReaderShell.tsx';
+import { theme } from '@/theme/theme.ts';
+import { ThemeProvider } from '@mui/material/styles';
 import { FakeEbookReader, aFakeLocation } from '@tests/fakes/FakeEbookReader';
 import { readiumApi } from '@tests/msw/readiumApi';
 import { worker } from '@tests/msw/worker';
@@ -33,13 +35,15 @@ const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 const renderShell = async (props: Partial<ReaderShellProps> = {}) =>
   await render(
-    <ReaderShell
-      bookId={1}
-      title="The Pragmatic Reader"
-      onClose={() => {}}
-      createReader={createReader}
-      {...props}
-    />
+    <ThemeProvider theme={theme}>
+      <ReaderShell
+        bookId={1}
+        title="The Pragmatic Reader"
+        onClose={() => {}}
+        createReader={createReader}
+        {...props}
+      />
+    </ThemeProvider>
   );
 
 type Screen = Awaited<ReturnType<typeof renderShell>>;
@@ -76,8 +80,24 @@ test('the shell waits for the cookie before opening the book', async () => {
 
   expect(readers).toHaveLength(0);
   await expect.poll(() => readers.length).toBe(1);
-  expect(readers[0].openedWith).toEqual([MANIFEST_URL]);
+  expect(readers[0].openedWith.map((opened) => opened.manifestUrl)).toEqual([MANIFEST_URL]);
   await expect.element(screen.getByLabelText('Loading the book')).toBeVisible();
+});
+
+test("the book is opened with the reader's appearance", async () => {
+  worker.use(...readiumApi());
+
+  await renderShell();
+
+  await expect.poll(() => readers.length).toBe(1);
+  expect(readers[0].openedWith[0].appearance).toEqual({
+    fontSize: 1,
+    textAlign: null,
+    columnCount: 1,
+    // The light page is the app's own off-white rather than publisher white.
+    pageBackgroundColor: theme.palette.background.default,
+    pageTextColor: theme.palette.text.primary,
+  });
 });
 
 test('a book whose positions say nothing about progress still numbers its pages', async () => {

--- a/frontend/src/components/reader/ReaderShell.test.tsx
+++ b/frontend/src/components/reader/ReaderShell.test.tsx
@@ -220,6 +220,141 @@ const openTheAppearance = async (screen: Screen) => {
   await expect.element(screen.getByRole('dialog', { name: 'Appearance' })).toBeVisible();
 };
 
+const theFontSize = (screen: Screen) =>
+  screen.getByRole('textbox', { name: 'Font size in percent' });
+
+/** The popover open over a book whose engine reports the fake's own font-size range. */
+const anOpenAppearance = async () => {
+  worker.use(...readiumApi());
+  const screen = await anOpenBook();
+  await openTheAppearance(screen);
+  return screen;
+};
+
+const fontSizes = () => readers[0].appearances.map((appearance) => appearance.fontSize);
+
+test('the font size opens on what the book is showing, and steps by a quarter', async () => {
+  const screen = await anOpenAppearance();
+
+  await expect.element(theFontSize(screen)).toHaveValue('100');
+
+  await screen.getByRole('button', { name: 'Larger text' }).click();
+
+  await expect.element(theFontSize(screen)).toHaveValue('125');
+  expect(fontSizes()).toEqual([1.25]);
+});
+
+test("the larger button stops the size at the top of the engine's range", async () => {
+  const screen = await anOpenAppearance();
+  const larger = screen.getByRole('button', { name: 'Larger text' });
+  // Not a whole number of steps below the fake's ceiling of 2, so the press
+  // that follows has something to clamp.
+  await userEvent.fill(theFontSize(screen), '190');
+  await userEvent.keyboard('{Enter}');
+
+  await larger.click();
+
+  await expect.element(theFontSize(screen)).toHaveValue('200');
+  await expect.element(larger).toBeDisabled();
+  expect(fontSizes()).toEqual([1.9, 2]);
+});
+
+test("the smaller button stops the size at the bottom of the engine's range", async () => {
+  const screen = await anOpenAppearance();
+  const smaller = screen.getByRole('button', { name: 'Smaller text' });
+
+  // A second quarter down from where the book opened is past the fake's floor.
+  await smaller.click();
+  await smaller.click();
+
+  await expect.element(theFontSize(screen)).toHaveValue('60');
+  await expect.element(smaller).toBeDisabled();
+  expect(fontSizes()).toEqual([0.75, 0.6]);
+});
+
+test('the size the book opened at is still within reach of the buttons', async () => {
+  const screen = await anOpenAppearance();
+  const smaller = screen.getByRole('button', { name: 'Smaller text' });
+  const larger = screen.getByRole('button', { name: 'Larger text' });
+  await smaller.click();
+  await smaller.click();
+  await expect.element(theFontSize(screen)).toHaveValue('60');
+
+  await larger.click();
+  await larger.click();
+
+  // The floor does not sit on a quarter, and a reader who pokes at the buttons
+  // and changes their mind has to be able to get back to where they started.
+  await expect.element(theFontSize(screen)).toHaveValue('100');
+  expect(fontSizes()).toEqual([0.75, 0.6, 0.75, 1]);
+});
+
+test('a size typed between two steps steps to the nearer one', async () => {
+  const screen = await anOpenAppearance();
+  await userEvent.fill(theFontSize(screen), '103');
+  await userEvent.keyboard('{Enter}');
+
+  await screen.getByRole('button', { name: 'Larger text' }).click();
+
+  await expect.element(theFontSize(screen)).toHaveValue('125');
+  expect(fontSizes()).toEqual([1.03, 1.25]);
+});
+
+test('the arrow keys step the size the field is showing', async () => {
+  const screen = await anOpenAppearance();
+  await theFontSize(screen).click();
+
+  await userEvent.keyboard('{ArrowUp}');
+  await expect.element(theFontSize(screen)).toHaveValue('125');
+
+  await userEvent.keyboard('{ArrowDown}');
+  await expect.element(theFontSize(screen)).toHaveValue('100');
+  expect(fontSizes()).toEqual([1.25, 1]);
+});
+
+test('a size typed into the field reaches the book', async () => {
+  const screen = await anOpenAppearance();
+
+  await userEvent.fill(theFontSize(screen), '140');
+  await userEvent.keyboard('{Enter}');
+
+  expect(fontSizes()).toEqual([1.4]);
+});
+
+test("a size typed past the engine's range is brought inside it", async () => {
+  const screen = await anOpenAppearance();
+
+  await userEvent.fill(theFontSize(screen), '900');
+  await userEvent.keyboard('{Enter}');
+
+  await expect.element(theFontSize(screen)).toHaveValue('200');
+  expect(fontSizes()).toEqual([2]);
+});
+
+test('a field cleared and left alone leaves the size as it was', async () => {
+  const screen = await anOpenAppearance();
+
+  await userEvent.fill(theFontSize(screen), '');
+  await userEvent.tab();
+
+  await expect.element(theFontSize(screen)).toHaveValue('100');
+  expect(fontSizes()).toEqual([]);
+});
+
+test('a size being typed reaches the book only once it is committed', async () => {
+  const screen = await anOpenAppearance();
+
+  await userEvent.fill(theFontSize(screen), '1');
+  await userEvent.fill(theFontSize(screen), '15');
+  await userEvent.fill(theFontSize(screen), '150');
+
+  expect(fontSizes()).toEqual([]);
+
+  await userEvent.keyboard('{Enter}');
+
+  expect(fontSizes()).toEqual([1.5]);
+});
+
 test('a page colour chosen in the popover reaches the engine', async () => {
   worker.use(...readiumApi());
 

--- a/frontend/src/components/reader/ReaderShell.test.tsx
+++ b/frontend/src/components/reader/ReaderShell.test.tsx
@@ -1,7 +1,9 @@
 import type { EbookTocEntry, OpenedEbook } from '@/components/reader/EbookReader.ts';
+import { READER_PREFERENCES_KEY } from '@/components/reader/readerPreferenceStorage.ts';
 import { ReaderShell, type ReaderShellProps } from '@/components/reader/ReaderShell.tsx';
 import { theme } from '@/theme/theme.ts';
 import { ThemeProvider } from '@mui/material/styles';
+import { fontSizeRangeConfig } from '@readium/navigator';
 import { FakeEbookReader, aFakeLocation } from '@tests/fakes/FakeEbookReader';
 import { readiumApi } from '@tests/msw/readiumApi';
 import { worker } from '@tests/msw/worker';
@@ -385,6 +387,72 @@ test('a page colour chosen in the popover reaches the engine', async () => {
     pageBackgroundColor: theme.customColors.readerPage.dark.background,
     pageTextColor: theme.customColors.readerPage.dark.text,
   });
+});
+
+/** A whole appearance, none of it the default, as the storage holds it. */
+const A_STORED_APPEARANCE = {
+  version: 1,
+  pageColor: 'dark',
+  fontSize: 1.5,
+  spacing: 'tight',
+  alignment: 'justified',
+  columns: 'auto',
+};
+
+const seedPreferences = (record: object) =>
+  window.localStorage.setItem(READER_PREFERENCES_KEY, JSON.stringify(record));
+
+const storedPreferences = () =>
+  JSON.parse(window.localStorage.getItem(READER_PREFERENCES_KEY) ?? 'null') as {
+    pageColor?: string;
+  } | null;
+
+test('the book is opened with the appearance left in storage', async () => {
+  worker.use(...readiumApi());
+  seedPreferences(A_STORED_APPEARANCE);
+
+  await renderShell();
+
+  await expect.poll(() => readers.length).toBe(1);
+  expect(readers[0].openedWith[0].appearance).toMatchObject({
+    fontSize: 1.5,
+    lineHeight: 1.2,
+    textAlign: 'justify',
+    columnCount: null,
+    pageBackgroundColor: theme.customColors.readerPage.dark.background,
+  });
+});
+
+test("a stored font size past the engine's range opens inside it", async () => {
+  worker.use(...readiumApi());
+  seedPreferences({ ...A_STORED_APPEARANCE, fontSize: 12 });
+
+  await renderShell();
+
+  await expect.poll(() => readers.length).toBe(1);
+  expect(readers[0].openedWith[0].appearance.fontSize).toBe(fontSizeRangeConfig.range[1]);
+});
+
+test('a setting chosen in the popover is written down', async () => {
+  const screen = await anOpenAppearance();
+
+  await screen.getByRole('button', { name: 'Dark' }).click();
+
+  expect(storedPreferences()?.pageColor).toBe('dark');
+});
+
+test('an appearance from a newer version is read past and left alone', async () => {
+  const fromANewerReader = JSON.stringify({ ...A_STORED_APPEARANCE, version: 2 });
+  window.localStorage.setItem(READER_PREFERENCES_KEY, fromANewerReader);
+  const screen = await anOpenAppearance();
+  expect(readers[0].openedWith[0].appearance.pageBackgroundColor).toBe(
+    theme.palette.background.default
+  );
+
+  await screen.getByRole('button', { name: 'Justified' }).click();
+
+  expect(readers[0].appearances).toHaveLength(1);
+  expect(window.localStorage.getItem(READER_PREFERENCES_KEY)).toBe(fromANewerReader);
 });
 
 test('opening the appearance and closing it again leaves the book alone', async () => {

--- a/frontend/src/components/reader/ReaderShell.tsx
+++ b/frontend/src/components/reader/ReaderShell.tsx
@@ -2,15 +2,11 @@ import { API_BASE_URL } from '@/api/base-url.ts';
 import { IconButtonWithTooltip } from '@/components/buttons/IconButtonWithTooltip.tsx';
 import type { EbookTocEntry } from '@/components/reader/EbookReader.ts';
 import { ReaderLoading } from '@/components/reader/ReaderLoading.tsx';
-import {
-  DEFAULT_READER_PREFERENCES,
-  readerPageColors,
-  toEbookAppearance,
-  type ReaderPreferences,
-} from '@/components/reader/readerPreferences.ts';
+import { readerPageColors, toEbookAppearance } from '@/components/reader/readerPreferences.ts';
 import { ReaderSettings } from '@/components/reader/ReaderSettings.tsx';
 import { TocDrawer } from '@/components/reader/TocDrawer.tsx';
 import { useEbookReader, type UseEbookReaderOptions } from '@/components/reader/useEbookReader.ts';
+import { useReaderPreferences } from '@/components/reader/useReaderPreferences.ts';
 import { useReaderSession } from '@/components/reader/useReaderSession.ts';
 import { useBodyScrollLock } from '@/hooks/useBodyScrollLock.ts';
 import {
@@ -137,7 +133,7 @@ export const ReaderShell = ({
   const { status: sessionStatus, isRenewing } = useReaderSession(bookId);
   const host = useRef<HTMLDivElement | null>(null);
   const [isTocOpen, setIsTocOpen] = useState(false);
-  const [preferences, setPreferences] = useState<ReaderPreferences>(DEFAULT_READER_PREFERENCES);
+  const [preferences, setPreferences] = useReaderPreferences();
   const [appearanceAnchor, setAppearanceAnchor] = useState<Element | null>(null);
   const theme = useTheme();
   const pageColors = readerPageColors(theme, preferences.pageColor);

--- a/frontend/src/components/reader/ReaderShell.tsx
+++ b/frontend/src/components/reader/ReaderShell.tsx
@@ -283,12 +283,15 @@ export const ReaderShell = ({
         currentHref={book.currentTocHref}
       />
 
-      <ReaderSettings
-        anchorEl={appearanceAnchor}
-        onClose={() => setAppearanceAnchor(null)}
-        preferences={preferences}
-        onChange={setPreferences}
-      />
+      {book.fontSizeRange && (
+        <ReaderSettings
+          anchorEl={appearanceAnchor}
+          onClose={() => setAppearanceAnchor(null)}
+          preferences={preferences}
+          onChange={setPreferences}
+          fontSizeRange={book.fontSizeRange}
+        />
+      )}
     </Box>
   );
 };

--- a/frontend/src/components/reader/ReaderShell.tsx
+++ b/frontend/src/components/reader/ReaderShell.tsx
@@ -1,6 +1,11 @@
 import { API_BASE_URL } from '@/api/base-url.ts';
 import { IconButtonWithTooltip } from '@/components/buttons/IconButtonWithTooltip.tsx';
 import type { EbookTocEntry } from '@/components/reader/EbookReader.ts';
+import {
+  DEFAULT_READER_PREFERENCES,
+  readerPageColors,
+  toEbookAppearance,
+} from '@/components/reader/readerPreferences.ts';
 import { TocDrawer } from '@/components/reader/TocDrawer.tsx';
 import { useEbookReader, type UseEbookReaderOptions } from '@/components/reader/useEbookReader.ts';
 import { useReaderSession } from '@/components/reader/useReaderSession.ts';
@@ -15,10 +20,11 @@ import {
   Stack,
   Toolbar,
   Typography,
+  useTheme,
   type SxProps,
   type Theme,
 } from '@mui/material';
-import { useRef, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 
 export interface ReaderShellProps {
   bookId: number;
@@ -45,8 +51,6 @@ const overlaySx: SxProps<Theme> = {
   zIndex: (t) => t.zIndex.appBar + 1,
   display: 'flex',
   flexDirection: 'column',
-  backgroundColor: 'background.default',
-  color: 'text.primary',
 };
 
 const manifestUrlFor = (bookId: number) =>
@@ -83,7 +87,7 @@ interface ReaderMessageProps {
 }
 
 const ReaderMessage = ({ children, onClose, onRetry }: ReaderMessageProps) => (
-  <Box sx={overlaySx}>
+  <Box sx={{ ...overlaySx, backgroundColor: 'background.default', color: 'text.primary' }}>
     <Box
       sx={{
         flex: 1,
@@ -124,11 +128,16 @@ export const ReaderShell = ({
   const { status: sessionStatus, isRenewing } = useReaderSession(bookId);
   const host = useRef<HTMLDivElement | null>(null);
   const [isTocOpen, setIsTocOpen] = useState(false);
+  const theme = useTheme();
+  const pageColors = readerPageColors(theme, DEFAULT_READER_PREFERENCES.pageColor);
+  // An object rebuilt every render would reopen the book on every render.
+  const appearance = useMemo(() => toEbookAppearance(theme, DEFAULT_READER_PREFERENCES), [theme]);
   const book = useEbookReader({
     host,
     manifestUrl: manifestUrlFor(bookId),
     enabled: sessionStatus === 'ready',
     holdPageTurns: isRenewing,
+    appearance,
     createReader,
     bootTimeoutMs,
   });
@@ -173,7 +182,14 @@ export const ReaderShell = ({
   };
 
   return (
-    <Box sx={overlaySx}>
+    <Box
+      sx={{
+        ...overlaySx,
+        backgroundColor: pageColors.background,
+        color: pageColors.text,
+        transition: (t) => t.transitions.create(['background-color', 'color']),
+      }}
+    >
       <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
         <Toolbar variant="dense" sx={{ gap: 1 }}>
           <IconButtonWithTooltip
@@ -243,7 +259,7 @@ export const ReaderShell = ({
               alignItems: 'center',
               justifyContent: 'center',
               pointerEvents: isRenewing ? 'auto' : 'none',
-              ...(isRenewing && { backgroundColor: 'background.default', opacity: 0.9 }),
+              ...(isRenewing && { backgroundColor: pageColors.background, opacity: 0.9 }),
             }}
           >
             {isRenewing && <Typography variant="body2">Reconnecting…</Typography>}

--- a/frontend/src/components/reader/ReaderShell.tsx
+++ b/frontend/src/components/reader/ReaderShell.tsx
@@ -1,22 +1,31 @@
 import { API_BASE_URL } from '@/api/base-url.ts';
 import { IconButtonWithTooltip } from '@/components/buttons/IconButtonWithTooltip.tsx';
 import type { EbookTocEntry } from '@/components/reader/EbookReader.ts';
+import { ReaderLoading } from '@/components/reader/ReaderLoading.tsx';
 import {
   DEFAULT_READER_PREFERENCES,
   readerPageColors,
   toEbookAppearance,
+  type ReaderPreferences,
 } from '@/components/reader/readerPreferences.ts';
+import { ReaderSettings } from '@/components/reader/ReaderSettings.tsx';
 import { TocDrawer } from '@/components/reader/TocDrawer.tsx';
 import { useEbookReader, type UseEbookReaderOptions } from '@/components/reader/useEbookReader.ts';
 import { useReaderSession } from '@/components/reader/useReaderSession.ts';
 import { useBodyScrollLock } from '@/hooks/useBodyScrollLock.ts';
-import { ChapterListIcon, CloseIcon, NextPageIcon, PreviousPageIcon } from '@/theme/Icons.tsx';
+import {
+  ChapterListIcon,
+  CloseIcon,
+  NextPageIcon,
+  PaletteIcon,
+  PreviousPageIcon,
+} from '@/theme/Icons.tsx';
 import { ICON_SIZE } from '@/theme/iconSizes.ts';
 import {
+  alpha,
   Box,
   Button,
   IconButton,
-  Skeleton,
   Stack,
   Toolbar,
   Typography,
@@ -128,10 +137,13 @@ export const ReaderShell = ({
   const { status: sessionStatus, isRenewing } = useReaderSession(bookId);
   const host = useRef<HTMLDivElement | null>(null);
   const [isTocOpen, setIsTocOpen] = useState(false);
+  const [preferences, setPreferences] = useState<ReaderPreferences>(DEFAULT_READER_PREFERENCES);
+  const [appearanceAnchor, setAppearanceAnchor] = useState<Element | null>(null);
   const theme = useTheme();
-  const pageColors = readerPageColors(theme, DEFAULT_READER_PREFERENCES.pageColor);
-  // An object rebuilt every render would reopen the book on every render.
-  const appearance = useMemo(() => toEbookAppearance(theme, DEFAULT_READER_PREFERENCES), [theme]);
+  const pageColors = readerPageColors(theme, preferences.pageColor);
+  // A new object every render would submit the same appearance to the engine
+  // again on every render, which is not a cost the engine skips.
+  const appearance = useMemo(() => toEbookAppearance(theme, preferences), [theme, preferences]);
   const book = useEbookReader({
     host,
     manifestUrl: manifestUrlFor(bookId),
@@ -190,7 +202,7 @@ export const ReaderShell = ({
         transition: (t) => t.transitions.create(['background-color', 'color']),
       }}
     >
-      <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
+      <Box sx={{ borderBottom: 1, borderColor: alpha(pageColors.text, 0.12) }}>
         <Toolbar variant="dense" sx={{ gap: 1 }}>
           <IconButtonWithTooltip
             label="Contents"
@@ -204,11 +216,19 @@ export const ReaderShell = ({
               {title}
             </Typography>
             {book.pageCount > 0 && position !== undefined && (
-              <Typography variant="body2" noWrap sx={{ color: 'text.secondary' }}>
+              // 0.7 of the page's own text, which is 6.3:1 on the light page
+              // and 8.4:1 on the dark one; body text needs 4.5:1.
+              <Typography variant="body2" noWrap sx={{ color: alpha(pageColors.text, 0.7) }}>
                 {pageLabel(position, book.pageCount, book.location?.locations.totalProgression)}
               </Typography>
             )}
           </Stack>
+          <IconButtonWithTooltip
+            label="Appearance"
+            onClick={(event) => setAppearanceAnchor(event.currentTarget)}
+            disabled={!isOpen}
+            icon={<PaletteIcon sx={{ fontSize: ICON_SIZE.ui }} />}
+          />
           <IconButtonWithTooltip
             label="Close reader"
             onClick={onClose}
@@ -234,19 +254,7 @@ export const ReaderShell = ({
           }}
         />
 
-        {!isOpen && (
-          <Stack
-            aria-label="Loading the book"
-            aria-busy="true"
-            sx={{ position: 'absolute', inset: 0, p: 4, alignItems: 'center' }}
-          >
-            <Box sx={{ width: '100%', maxWidth: 640 }}>
-              {Array.from({ length: 12 }, (_, index) => (
-                <Skeleton key={index} height={28} width={index % 5 === 4 ? '55%' : '100%'} />
-              ))}
-            </Box>
-          </Stack>
-        )}
+        {!isOpen && <ReaderLoading />}
 
         {/* Mounted for as long as the book is: a live region that appears
             together with its text announces nothing. */}
@@ -273,6 +281,13 @@ export const ReaderShell = ({
         toc={book.toc}
         onSelect={goToTocEntry}
         currentHref={book.currentTocHref}
+      />
+
+      <ReaderSettings
+        anchorEl={appearanceAnchor}
+        onClose={() => setAppearanceAnchor(null)}
+        preferences={preferences}
+        onChange={setPreferences}
       />
     </Box>
   );

--- a/frontend/src/components/reader/ReadiumReader.test.tsx
+++ b/frontend/src/components/reader/ReadiumReader.test.tsx
@@ -4,6 +4,7 @@ import {
   type PageTurnDirection,
 } from '@/components/reader/EbookReader.ts';
 import { ReadiumReader } from '@/components/reader/ReadiumReader.ts';
+import { fontSizeRangeConfig } from '@readium/navigator';
 import { aManifest, aPositionList } from '@tests/fixtures/publication';
 import { noPublication, readiumApi } from '@tests/msw/readiumApi';
 import { worker } from '@tests/msw/worker';
@@ -80,6 +81,14 @@ test('opens the book at its first page and names its chapters', async () => {
   expect(opened.toc.map((entry) => entry.title)).toEqual(['On Attention', 'Part two']);
   expect(opened.toc[1].children.map((entry) => entry.title)).toEqual(['On Memory']);
   expect(frame()).not.toBeNull();
+});
+
+test("the book reports the font-size range the engine's own editor honours", async () => {
+  worker.use(...readiumApi());
+
+  const opened = await openTheBook();
+
+  expect(opened.fontSizeRange).toEqual(fontSizeRangeConfig.range);
 });
 
 test('opening with an appearance paints it into the book', async () => {

--- a/frontend/src/components/reader/ReadiumReader.test.tsx
+++ b/frontend/src/components/reader/ReadiumReader.test.tsx
@@ -1,5 +1,6 @@
 import {
   PublicationUnavailableError,
+  type EbookAppearance,
   type PageTurnDirection,
 } from '@/components/reader/EbookReader.ts';
 import { ReadiumReader } from '@/components/reader/ReadiumReader.ts';
@@ -12,6 +13,15 @@ import { userEvent } from 'vitest/browser';
 
 const MANIFEST_PATH = '/api/v1/readium/books/:bookId/manifest.json';
 const MANIFEST_URL = `${window.location.origin}/api/v1/readium/books/1/manifest.json`;
+
+/** The reader's defaults as the seam carries them: the light page, at the book's own size. */
+const AN_APPEARANCE: EbookAppearance = {
+  fontSize: 1,
+  textAlign: null,
+  columnCount: 1,
+  pageBackgroundColor: '#fafaf9',
+  pageTextColor: '#1c1917',
+};
 
 let host: HTMLDivElement;
 let reader: ReadiumReader;
@@ -35,9 +45,17 @@ const recordEvents = () => {
   };
 };
 
+/** The book on the reader's own defaults, which is what every test but the appearance ones needs. */
+const openTheBook = (signal?: AbortSignal) =>
+  reader.open(MANIFEST_URL, { appearance: AN_APPEARANCE, signal });
+
 const frame = () => host.querySelector('iframe');
 
 const frameText = () => frame()?.contentDocument?.body.textContent ?? '';
+
+/** What ReadiumCSS has written into the chapter for one of its user settings. */
+const userProperty = (name: string) =>
+  frame()?.contentDocument?.documentElement.style.getPropertyValue(`--USER__${name}`) ?? '';
 
 beforeEach(() => {
   host = document.createElement('div');
@@ -55,7 +73,7 @@ afterEach(async () => {
 test('opens the book at its first page and names its chapters', async () => {
   worker.use(...readiumApi());
 
-  const opened = await reader.open(MANIFEST_URL);
+  const opened = await openTheBook();
 
   expect(opened.pageCount).toBe(2);
   expect(opened.location.locations.position).toBe(1);
@@ -64,9 +82,40 @@ test('opens the book at its first page and names its chapters', async () => {
   expect(frame()).not.toBeNull();
 });
 
+test('opening with an appearance paints it into the book', async () => {
+  worker.use(...readiumApi());
+
+  await reader.open(MANIFEST_URL, { appearance: AN_APPEARANCE });
+
+  await expect.poll(() => userProperty('fontSize')).toBe('100%');
+  expect(userProperty('backgroundColor')).toBe(AN_APPEARANCE.pageBackgroundColor);
+  expect(userProperty('textColor')).toBe(AN_APPEARANCE.pageTextColor);
+  // The book's own stylesheet is still the one setting lines.
+  expect(userProperty('textAlign')).toBe('');
+});
+
+test('setAppearance reaches a book already on screen', async () => {
+  worker.use(...readiumApi());
+  await reader.open(MANIFEST_URL, { appearance: AN_APPEARANCE });
+  await expect.poll(() => userProperty('fontSize')).toBe('100%');
+
+  await reader.setAppearance({
+    fontSize: 1.5,
+    textAlign: 'justify',
+    columnCount: null,
+    pageBackgroundColor: '#1c1917',
+    pageTextColor: '#f5f5f4',
+  });
+
+  await expect.poll(() => userProperty('textAlign')).toBe('justify');
+  await expect.poll(() => userProperty('backgroundColor')).toBe('#1c1917');
+  await expect.poll(() => userProperty('textColor')).toBe('#f5f5f4');
+  await expect.poll(() => userProperty('fontSize')).toBe('150%');
+});
+
 test('next and previous turn the page and report where the reader is', async () => {
   worker.use(...readiumApi());
-  await reader.open(MANIFEST_URL);
+  await openTheBook();
   const recorded = recordEvents();
 
   await reader.next();
@@ -80,7 +129,7 @@ test('next and previous turn the page and report where the reader is', async () 
 test('the book names the contents entry it opened at', async () => {
   worker.use(...readiumApi());
 
-  const opened = await reader.open(MANIFEST_URL);
+  const opened = await openTheBook();
 
   expect(opened.tocHref).toBe('resources/OEBPS/chapter1.xhtml');
   expect(opened.toc[0].href).toBe('resources/OEBPS/chapter1.xhtml');
@@ -88,7 +137,7 @@ test('the book names the contents entry it opened at', async () => {
 
 test('the reported contents entry follows the reader into the next chapter', async () => {
   worker.use(...readiumApi());
-  const opened = await reader.open(MANIFEST_URL);
+  const opened = await openTheBook();
   const recorded = recordEvents();
   const onMemory = opened.toc[1].children[0];
 
@@ -99,7 +148,7 @@ test('the reported contents entry follows the reader into the next chapter', asy
 
 test('a contents entry that declares no media type can be navigated to', async () => {
   worker.use(...readiumApi());
-  const opened = await reader.open(MANIFEST_URL);
+  const opened = await openTheBook();
   const recorded = recordEvents();
   const onMemory = opened.toc[1].children[0];
   expect(onMemory.type).toBe('');
@@ -111,7 +160,7 @@ test('a contents entry that declares no media type can be navigated to', async (
 
 test('goTo lands on the location it is given', async () => {
   worker.use(...readiumApi());
-  await reader.open(MANIFEST_URL);
+  await openTheBook();
   const recorded = recordEvents();
 
   await reader.goTo(aPositionList().positions[1]);
@@ -121,7 +170,7 @@ test('goTo lands on the location it is given', async () => {
 
 test('goTo rejects a location the book does not contain', async () => {
   worker.use(...readiumApi());
-  await reader.open(MANIFEST_URL);
+  await openTheBook();
 
   await expect(
     reader.goTo({
@@ -152,7 +201,7 @@ test('a manifest that claims another origin still has its chapters resolve again
     })
   );
 
-  await reader.open(MANIFEST_URL);
+  await openTheBook();
   await expect.poll(frameText).toContain('On Attention');
 
   const base = frame()!.contentDocument!.querySelector('base')!.href;
@@ -163,7 +212,7 @@ test('the manifest and the resources are asked for without a bearer token', asyn
   const requests: Request[] = [];
   worker.use(...readiumApi({ onRequest: (request) => requests.push(request) }));
 
-  await reader.open(MANIFEST_URL);
+  await openTheBook();
 
   const paths = requests.map((request) => new URL(request.url).pathname);
   expect(paths.some((path) => path.includes('/readium/books/1/resources/'))).toBe(true);
@@ -173,7 +222,7 @@ test('the manifest and the resources are asked for without a bearer token', asyn
 test('a book with no publication is reported as missing, an unreadable one as an error', async () => {
   worker.use(...noPublication);
 
-  const missing = await reader.open(MANIFEST_URL).catch((error: unknown) => error);
+  const missing = await openTheBook().catch((error: unknown) => error);
 
   expect(missing).toBeInstanceOf(PublicationUnavailableError);
   expect((missing as PublicationUnavailableError).reason).toBe('missing');
@@ -181,7 +230,9 @@ test('a book with no publication is reported as missing, an unreadable one as an
 
   worker.use(http.get(MANIFEST_PATH, () => new HttpResponse(null, { status: 500 })));
   const broken = new ReadiumReader(host);
-  const failed = await broken.open(MANIFEST_URL).catch((error: unknown) => error);
+  const failed = await broken
+    .open(MANIFEST_URL, { appearance: AN_APPEARANCE })
+    .catch((error: unknown) => error);
 
   expect(failed).toBeInstanceOf(PublicationUnavailableError);
   expect((failed as PublicationUnavailableError).reason).toBe('error');
@@ -189,7 +240,9 @@ test('a book with no publication is reported as missing, an unreadable one as an
 
   worker.use(http.get(MANIFEST_PATH, () => HttpResponse.html('<!doctype html>')));
   const notAManifest = new ReadiumReader(host);
-  const garbled = await notAManifest.open(MANIFEST_URL).catch((error: unknown) => error);
+  const garbled = await notAManifest
+    .open(MANIFEST_URL, { appearance: AN_APPEARANCE })
+    .catch((error: unknown) => error);
 
   expect(garbled).toBeInstanceOf(PublicationUnavailableError);
   expect((garbled as PublicationUnavailableError).reason).toBe('error');
@@ -198,7 +251,7 @@ test('a book with no publication is reported as missing, an unreadable one as an
 
 test('an arrow key pressed inside the book asks for a page turn', async () => {
   worker.use(...readiumApi());
-  await reader.open(MANIFEST_URL);
+  await openTheBook();
   await expect.poll(frameText).toContain('On Attention');
   const recorded = recordEvents();
 
@@ -222,7 +275,7 @@ test('a book cannot run its own scripts against the page that opened it', async 
 
   // Unsanitised, the chapter's meta refresh navigates the frame away and the
   // open never settles; the assertions below are what has to report that.
-  void reader.open(MANIFEST_URL).catch(() => undefined);
+  void openTheBook().catch(() => undefined);
   await expect.poll(frameText, { timeout: 5_000 }).toContain('On Attention');
 
   expect(document.body.getAttribute('data-pwned')).toBeNull();
@@ -231,7 +284,7 @@ test('a book cannot run its own scripts against the page that opened it', async 
 
 test('destroy removes the book from the page and can be called twice', async () => {
   worker.use(...readiumApi());
-  await reader.open(MANIFEST_URL);
+  await openTheBook();
 
   await reader.destroy();
 
@@ -250,7 +303,7 @@ test('aborting an open leaves nothing behind', async () => {
     })
   );
 
-  await expect(reader.open(MANIFEST_URL, controller.signal)).rejects.toThrow();
+  await expect(openTheBook(controller.signal)).rejects.toThrow();
 
   expect(frame()).toBeNull();
   expect(host.children).toHaveLength(0);
@@ -265,7 +318,7 @@ test(
     host.style.height = '0';
     const controller = new AbortController();
 
-    const opening = reader.open(MANIFEST_URL, controller.signal);
+    const opening = openTheBook(controller.signal);
     setTimeout(() => controller.abort(), 100);
 
     await expect(opening).rejects.toThrow();
@@ -278,7 +331,7 @@ test('destroying while the host has no size settles the open', { timeout: 3_000 
   host.style.width = '0';
   host.style.height = '0';
 
-  const opening = reader.open(MANIFEST_URL);
+  const opening = openTheBook();
   setTimeout(() => void reader.destroy(), 100);
 
   await expect(opening).rejects.toThrow();

--- a/frontend/src/components/reader/ReadiumReader.test.tsx
+++ b/frontend/src/components/reader/ReadiumReader.test.tsx
@@ -19,6 +19,8 @@ const MANIFEST_URL = `${window.location.origin}/api/v1/readium/books/1/manifest.
 const AN_APPEARANCE: EbookAppearance = {
   fontSize: 1,
   lineHeight: null,
+  paragraphSpacing: null,
+  paragraphIndent: null,
   textAlign: null,
   columnCount: 1,
   pageBackgroundColor: '#fafaf9',
@@ -113,6 +115,8 @@ test('setAppearance reaches a book already on screen', async () => {
   await reader.setAppearance({
     fontSize: 1.5,
     lineHeight: 1.8,
+    paragraphSpacing: 1,
+    paragraphIndent: 1.5,
     textAlign: 'justify',
     columnCount: null,
     pageBackgroundColor: '#1c1917',
@@ -121,6 +125,8 @@ test('setAppearance reaches a book already on screen', async () => {
 
   await expect.poll(() => userProperty('textAlign')).toBe('justify');
   await expect.poll(() => userProperty('lineHeight')).toBe('1.8');
+  await expect.poll(() => userProperty('paraSpacing')).toBe('1rem');
+  await expect.poll(() => userProperty('paraIndent')).toBe('1.5rem');
   await expect.poll(() => userProperty('backgroundColor')).toBe('#1c1917');
   await expect.poll(() => userProperty('textColor')).toBe('#f5f5f4');
   await expect.poll(() => userProperty('fontSize')).toBe('150%');

--- a/frontend/src/components/reader/ReadiumReader.test.tsx
+++ b/frontend/src/components/reader/ReadiumReader.test.tsx
@@ -18,6 +18,7 @@ const MANIFEST_URL = `${window.location.origin}/api/v1/readium/books/1/manifest.
 /** The reader's defaults as the seam carries them: the light page, at the book's own size. */
 const AN_APPEARANCE: EbookAppearance = {
   fontSize: 1,
+  lineHeight: null,
   textAlign: null,
   columnCount: 1,
   pageBackgroundColor: '#fafaf9',
@@ -101,6 +102,7 @@ test('opening with an appearance paints it into the book', async () => {
   expect(userProperty('textColor')).toBe(AN_APPEARANCE.pageTextColor);
   // The book's own stylesheet is still the one setting lines.
   expect(userProperty('textAlign')).toBe('');
+  expect(userProperty('lineHeight')).toBe('');
 });
 
 test('setAppearance reaches a book already on screen', async () => {
@@ -110,6 +112,7 @@ test('setAppearance reaches a book already on screen', async () => {
 
   await reader.setAppearance({
     fontSize: 1.5,
+    lineHeight: 1.8,
     textAlign: 'justify',
     columnCount: null,
     pageBackgroundColor: '#1c1917',
@@ -117,6 +120,7 @@ test('setAppearance reaches a book already on screen', async () => {
   });
 
   await expect.poll(() => userProperty('textAlign')).toBe('justify');
+  await expect.poll(() => userProperty('lineHeight')).toBe('1.8');
   await expect.poll(() => userProperty('backgroundColor')).toBe('#1c1917');
   await expect.poll(() => userProperty('textColor')).toBe('#f5f5f4');
   await expect.poll(() => userProperty('fontSize')).toBe('150%');

--- a/frontend/src/components/reader/ReadiumReader.ts
+++ b/frontend/src/components/reader/ReadiumReader.ts
@@ -52,13 +52,15 @@ const TEXT_ALIGNMENTS: Record<NonNullable<EbookAppearance['textAlign']>, TextAli
   justify: TextAlignment.justify,
 };
 
-// Six of `EpubPreferences`' forty-odd fields: every one set here is one the
+// Eight of `EpubPreferences`' forty-odd fields: every one set here is one the
 // reader can no longer inherit from the book. `null` rather than omitted,
 // because the navigator merges and skips `undefined`, so an omission is no reset.
 const toEpubPreferences = (appearance: EbookAppearance): EpubPreferences =>
   new EpubPreferences({
     fontSize: appearance.fontSize,
     lineHeight: appearance.lineHeight,
+    paragraphSpacing: appearance.paragraphSpacing,
+    paragraphIndent: appearance.paragraphIndent,
     textAlign: appearance.textAlign === null ? null : TEXT_ALIGNMENTS[appearance.textAlign],
     columnCount: appearance.columnCount,
     backgroundColor: appearance.pageBackgroundColor,

--- a/frontend/src/components/reader/ReadiumReader.ts
+++ b/frontend/src/components/reader/ReadiumReader.ts
@@ -52,12 +52,13 @@ const TEXT_ALIGNMENTS: Record<NonNullable<EbookAppearance['textAlign']>, TextAli
   justify: TextAlignment.justify,
 };
 
-// Five of `EpubPreferences`' forty-odd fields: every one set here is one the
+// Six of `EpubPreferences`' forty-odd fields: every one set here is one the
 // reader can no longer inherit from the book. `null` rather than omitted,
 // because the navigator merges and skips `undefined`, so an omission is no reset.
 const toEpubPreferences = (appearance: EbookAppearance): EpubPreferences =>
   new EpubPreferences({
     fontSize: appearance.fontSize,
+    lineHeight: appearance.lineHeight,
     textAlign: appearance.textAlign === null ? null : TEXT_ALIGNMENTS[appearance.textAlign],
     columnCount: appearance.columnCount,
     backgroundColor: appearance.pageBackgroundColor,

--- a/frontend/src/components/reader/ReadiumReader.ts
+++ b/frontend/src/components/reader/ReadiumReader.ts
@@ -1,14 +1,18 @@
 import {
   PublicationUnavailableError,
+  type EbookAppearance,
   type EbookLocation,
   type EbookReader,
   type EbookTocEntry,
+  type OpenEbookOptions,
   type OpenedEbook,
   type PageTurnDirection,
 } from '@/components/reader/EbookReader.ts';
 import { sanitizeResponse } from '@/components/reader/sanitizeResponse.ts';
 import {
   EpubNavigator,
+  EpubPreferences,
+  TextAlignment,
   type EpubNavigatorListeners,
   type IKeyboardPeripheralsConfig,
 } from '@readium/navigator';
@@ -42,6 +46,23 @@ const PAGE_TURN_KEYS: IKeyboardPeripheralsConfig = [
   { type: 'next_page', keyCombos: [{ keyCode: 39, suppressOnInteractiveElement: true }] },
   { type: 'previous_page', keyCombos: [{ keyCode: 37, suppressOnInteractiveElement: true }] },
 ];
+
+const TEXT_ALIGNMENTS: Record<NonNullable<EbookAppearance['textAlign']>, TextAlignment> = {
+  start: TextAlignment.start,
+  justify: TextAlignment.justify,
+};
+
+// Five of `EpubPreferences`' forty-odd fields: every one set here is one the
+// reader can no longer inherit from the book. `null` rather than omitted,
+// because the navigator merges and skips `undefined`, so an omission is no reset.
+const toEpubPreferences = (appearance: EbookAppearance): EpubPreferences =>
+  new EpubPreferences({
+    fontSize: appearance.fontSize,
+    textAlign: appearance.textAlign === null ? null : TEXT_ALIGNMENTS[appearance.textAlign],
+    columnCount: appearance.columnCount,
+    backgroundColor: appearance.pageBackgroundColor,
+    textColor: appearance.pageTextColor,
+  });
 
 const toLocation = (locator: Locator): EbookLocation => ({
   href: locator.href,
@@ -115,7 +136,7 @@ export class ReadiumReader implements EbookReader {
 
   constructor(private readonly host: HTMLElement) {}
 
-  async open(manifestUrl: string, signal?: AbortSignal): Promise<OpenedEbook> {
+  async open(manifestUrl: string, { appearance, signal }: OpenEbookOptions): Promise<OpenedEbook> {
     signal?.throwIfAborted();
     if (this.isOpened) throw new Error('A reader opens one book; build another one.');
     this.isOpened = true;
@@ -138,7 +159,11 @@ export class ReadiumReader implements EbookReader {
       this.navigatorListeners(),
       positions,
       undefined,
-      { preferences: {}, defaults: {}, keyboardPeripherals: PAGE_TURN_KEYS }
+      {
+        preferences: toEpubPreferences(appearance),
+        defaults: {},
+        keyboardPeripherals: PAGE_TURN_KEYS,
+      }
     );
     this.navigator = navigator;
 
@@ -155,6 +180,10 @@ export class ReadiumReader implements EbookReader {
       tocHref: this.tocEntryHrefFor(navigator.timeline.locate(navigator.currentLocator)),
       location: toLocation(navigator.currentLocator),
     };
+  }
+
+  async setAppearance(appearance: EbookAppearance): Promise<void> {
+    await this.navigator?.submitPreferences(toEpubPreferences(appearance));
   }
 
   async next(): Promise<void> {

--- a/frontend/src/components/reader/ReadiumReader.ts
+++ b/frontend/src/components/reader/ReadiumReader.ts
@@ -179,6 +179,9 @@ export class ReadiumReader implements EbookReader {
       toc: tocEntriesFrom(publication.toc?.items ?? []),
       tocHref: this.tocEntryHrefFor(navigator.timeline.locate(navigator.currentLocator)),
       location: toLocation(navigator.currentLocator),
+      // Asked of the navigator's own editor rather than copied from the library's
+      // `fontSizeRangeConfig`: a second copy of those numbers drifts on an upgrade.
+      fontSizeRange: navigator.preferencesEditor.fontSize.supportedRange,
     };
   }
 

--- a/frontend/src/components/reader/readerPreferenceStorage.ts
+++ b/frontend/src/components/reader/readerPreferenceStorage.ts
@@ -1,0 +1,75 @@
+import {
+  DEFAULT_READER_PREFERENCES,
+  READER_ALIGNMENTS,
+  READER_COLUMNS,
+  READER_PAGE_COLORS,
+  READER_SPACINGS,
+  type ReaderPreferences,
+} from '@/components/reader/readerPreferences.ts';
+import { fontSizeRangeConfig } from '@readium/navigator';
+
+/** Where the reader's appearance is remembered: one key for the whole library. */
+export const READER_PREFERENCES_KEY = 'crossbill.reader.preferences';
+
+// Bumped whenever what the popover controls stops being expressible in what is
+// already written down, so a record of another shape is recognised, not half-read.
+const STORAGE_VERSION = 1;
+
+interface StoredPreferences extends ReaderPreferences {
+  version: number;
+}
+
+const storedRecord = (): Partial<StoredPreferences> | null => {
+  try {
+    const raw = window.localStorage.getItem(READER_PREFERENCES_KEY);
+    if (raw === null) return null;
+    return JSON.parse(raw) as Partial<StoredPreferences> | null;
+  } catch {
+    // Storage the browser refuses to hand over, or text that is not JSON.
+    return null;
+  }
+};
+
+const offered = <T extends string>(options: readonly T[], value: unknown, fallback: T): T =>
+  options.find((option) => option === value) ?? fallback;
+
+const storedFontSize = (value: unknown): number => {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return DEFAULT_READER_PREFERENCES.fontSize;
+  }
+  const [min, max] = fontSizeRangeConfig.range;
+  return Math.min(Math.max(value, min), max);
+};
+
+/**
+ * The reader's remembered appearance, or the defaults wherever it cannot be read.
+ *
+ * Silently: none of the ways this goes wrong is worth a word to somebody who
+ * came here to read a book, and each one leaves a perfectly usable reader.
+ */
+export const loadReaderPreferences = (): ReaderPreferences => {
+  const stored = storedRecord();
+  if (stored?.version !== STORAGE_VERSION) return DEFAULT_READER_PREFERENCES;
+  return {
+    pageColor: offered(READER_PAGE_COLORS, stored.pageColor, DEFAULT_READER_PREFERENCES.pageColor),
+    fontSize: storedFontSize(stored.fontSize),
+    spacing: offered(READER_SPACINGS, stored.spacing, DEFAULT_READER_PREFERENCES.spacing),
+    alignment: offered(READER_ALIGNMENTS, stored.alignment, DEFAULT_READER_PREFERENCES.alignment),
+    columns: offered(READER_COLUMNS, stored.columns, DEFAULT_READER_PREFERENCES.columns),
+  };
+};
+
+/** Writes the appearance down, where the browser allows it. */
+export const saveReaderPreferences = (preferences: ReaderPreferences): void => {
+  try {
+    // A record from a newer build reads as the defaults above, so overwriting
+    // one would make the version field cause the very loss it exists to prevent.
+    const existing = storedRecord()?.version;
+    if (typeof existing === 'number' && existing > STORAGE_VERSION) return;
+
+    const stored: StoredPreferences = { version: STORAGE_VERSION, ...preferences };
+    window.localStorage.setItem(READER_PREFERENCES_KEY, JSON.stringify(stored));
+  } catch {
+    // Storage turned off, or full.
+  }
+};

--- a/frontend/src/components/reader/readerPreferences.test.tsx
+++ b/frontend/src/components/reader/readerPreferences.test.tsx
@@ -1,24 +1,31 @@
 import {
   DEFAULT_READER_PREFERENCES,
-  READER_LINE_HEIGHTS,
+  READER_SPACINGS,
   toEbookAppearance,
 } from '@/components/reader/readerPreferences.ts';
 import { theme } from '@/theme/theme.ts';
-import { lineHeightRangeConfig } from '@readium/navigator';
+import {
+  lineHeightRangeConfig,
+  paragraphIndentRangeConfig,
+  paragraphSpacingRangeConfig,
+} from '@readium/navigator';
 import { expect, test } from 'vitest';
 
-// The line heights are ours rather than the engine's, so nothing but this
-// notices an upgrade that narrows the range out from under them.
-test('every line height the reader is offered is one the engine honours', () => {
-  const [min, max] = lineHeightRangeConfig.range;
+// The spacings are ours rather than the engine's, so nothing but this notices
+// an upgrade that narrows a range out from under them.
+test('every spacing the reader is offered is one the engine honours', () => {
+  for (const spacing of READER_SPACINGS) {
+    const appearance = toEbookAppearance(theme, { ...DEFAULT_READER_PREFERENCES, spacing });
+    const sent: [number | null, [number, number]][] = [
+      [appearance.lineHeight, lineHeightRangeConfig.range],
+      [appearance.paragraphSpacing, paragraphSpacingRangeConfig.range],
+      [appearance.paragraphIndent, paragraphIndentRangeConfig.range],
+    ];
 
-  for (const lineHeight of READER_LINE_HEIGHTS) {
-    const { lineHeight: sent } = toEbookAppearance(theme, {
-      ...DEFAULT_READER_PREFERENCES,
-      lineHeight,
-    });
-    if (sent === null) continue;
-    expect(sent).toBeGreaterThanOrEqual(min);
-    expect(sent).toBeLessThanOrEqual(max);
+    for (const [value, [min, max]] of sent) {
+      if (value === null) continue;
+      expect(value).toBeGreaterThanOrEqual(min);
+      expect(value).toBeLessThanOrEqual(max);
+    }
   }
 });

--- a/frontend/src/components/reader/readerPreferences.test.tsx
+++ b/frontend/src/components/reader/readerPreferences.test.tsx
@@ -1,0 +1,24 @@
+import {
+  DEFAULT_READER_PREFERENCES,
+  READER_LINE_HEIGHTS,
+  toEbookAppearance,
+} from '@/components/reader/readerPreferences.ts';
+import { theme } from '@/theme/theme.ts';
+import { lineHeightRangeConfig } from '@readium/navigator';
+import { expect, test } from 'vitest';
+
+// The line heights are ours rather than the engine's, so nothing but this
+// notices an upgrade that narrows the range out from under them.
+test('every line height the reader is offered is one the engine honours', () => {
+  const [min, max] = lineHeightRangeConfig.range;
+
+  for (const lineHeight of READER_LINE_HEIGHTS) {
+    const { lineHeight: sent } = toEbookAppearance(theme, {
+      ...DEFAULT_READER_PREFERENCES,
+      lineHeight,
+    });
+    if (sent === null) continue;
+    expect(sent).toBeGreaterThanOrEqual(min);
+    expect(sent).toBeLessThanOrEqual(max);
+  }
+});

--- a/frontend/src/components/reader/readerPreferences.ts
+++ b/frontend/src/components/reader/readerPreferences.ts
@@ -1,0 +1,52 @@
+import type { EbookAppearance } from '@/components/reader/EbookReader.ts';
+import type { Theme } from '@mui/material/styles';
+
+/** The page colours the reader can choose between. */
+export type ReaderPageColor = 'light' | 'dark';
+
+/** How lines are set, `default` leaving the book's own stylesheet in charge. */
+type ReaderAlignment = 'default' | 'left' | 'justified';
+
+/** How many columns the page is set in. */
+type ReaderColumns = 'single' | 'auto';
+
+export interface ReaderPreferences {
+  pageColor: ReaderPageColor;
+  fontSize: number;
+  alignment: ReaderAlignment;
+  columns: ReaderColumns;
+}
+
+export const DEFAULT_READER_PREFERENCES: ReaderPreferences = {
+  pageColor: 'light',
+  fontSize: 1,
+  alignment: 'default',
+  columns: 'single',
+};
+
+// `left` is `start`: in a right-to-left book the ragged edge belongs on the
+// right, and only `start` follows the publication's own reading progression.
+const TEXT_ALIGNMENTS: Record<ReaderAlignment, EbookAppearance['textAlign']> = {
+  default: null,
+  left: 'start',
+  justified: 'justify',
+};
+
+/** The page colours of one reading colour, for the reader's chrome and its content alike. */
+export const readerPageColors = (theme: Theme, name: ReaderPageColor) =>
+  theme.customColors.readerPage[name];
+
+/** What the reader chose, in the terms the seam carries. */
+export const toEbookAppearance = (
+  theme: Theme,
+  preferences: ReaderPreferences
+): EbookAppearance => {
+  const colors = readerPageColors(theme, preferences.pageColor);
+  return {
+    fontSize: preferences.fontSize,
+    textAlign: TEXT_ALIGNMENTS[preferences.alignment],
+    columnCount: preferences.columns === 'single' ? 1 : null,
+    pageBackgroundColor: colors.background,
+    pageTextColor: colors.text,
+  };
+};

--- a/frontend/src/components/reader/readerPreferences.ts
+++ b/frontend/src/components/reader/readerPreferences.ts
@@ -2,13 +2,29 @@ import type { EbookAppearance } from '@/components/reader/EbookReader.ts';
 import type { Theme } from '@mui/material/styles';
 
 /** The page colours the reader can choose between. */
-export type ReaderPageColor = 'light' | 'dark';
+export const READER_PAGE_COLORS = ['light', 'dark'] as const;
+export type ReaderPageColor = (typeof READER_PAGE_COLORS)[number];
+export const READER_PAGE_COLOR_LABELS: Record<ReaderPageColor, string> = {
+  light: 'Light',
+  dark: 'Dark',
+};
 
 /** How lines are set, `default` leaving the book's own stylesheet in charge. */
-type ReaderAlignment = 'default' | 'left' | 'justified';
+export const READER_ALIGNMENTS = ['default', 'left', 'justified'] as const;
+type ReaderAlignment = (typeof READER_ALIGNMENTS)[number];
+export const READER_ALIGNMENT_LABELS: Record<ReaderAlignment, string> = {
+  default: 'Default',
+  left: 'Left',
+  justified: 'Justified',
+};
 
 /** How many columns the page is set in. */
-type ReaderColumns = 'single' | 'auto';
+export const READER_COLUMNS = ['single', 'auto'] as const;
+type ReaderColumns = (typeof READER_COLUMNS)[number];
+export const READER_COLUMN_LABELS: Record<ReaderColumns, string> = {
+  single: '1 column',
+  auto: 'Auto',
+};
 
 export interface ReaderPreferences {
   pageColor: ReaderPageColor;

--- a/frontend/src/components/reader/readerPreferences.ts
+++ b/frontend/src/components/reader/readerPreferences.ts
@@ -9,6 +9,15 @@ export const READER_PAGE_COLOR_LABELS: Record<ReaderPageColor, string> = {
   dark: 'Dark',
 };
 
+/** How far apart the lines are set, `default` leaving the book's own spacing alone. */
+export const READER_LINE_HEIGHTS = ['tight', 'default', 'loose'] as const;
+type ReaderLineHeight = (typeof READER_LINE_HEIGHTS)[number];
+export const READER_LINE_HEIGHT_LABELS: Record<ReaderLineHeight, string> = {
+  tight: 'Tight',
+  default: 'Default',
+  loose: 'Loose',
+};
+
 /** How lines are set, `default` leaving the book's own stylesheet in charge. */
 export const READER_ALIGNMENTS = ['default', 'left', 'justified'] as const;
 type ReaderAlignment = (typeof READER_ALIGNMENTS)[number];
@@ -29,6 +38,7 @@ export const READER_COLUMN_LABELS: Record<ReaderColumns, string> = {
 export interface ReaderPreferences {
   pageColor: ReaderPageColor;
   fontSize: number;
+  lineHeight: ReaderLineHeight;
   alignment: ReaderAlignment;
   columns: ReaderColumns;
 }
@@ -36,8 +46,15 @@ export interface ReaderPreferences {
 export const DEFAULT_READER_PREFERENCES: ReaderPreferences = {
   pageColor: 'light',
   fontSize: 1,
+  lineHeight: 'default',
   alignment: 'default',
   columns: 'single',
+};
+
+const LINE_HEIGHTS: Record<ReaderLineHeight, EbookAppearance['lineHeight']> = {
+  tight: 1.2,
+  default: null,
+  loose: 1.8,
 };
 
 // `left` is `start`: in a right-to-left book the ragged edge belongs on the
@@ -60,6 +77,7 @@ export const toEbookAppearance = (
   const colors = readerPageColors(theme, preferences.pageColor);
   return {
     fontSize: preferences.fontSize,
+    lineHeight: LINE_HEIGHTS[preferences.lineHeight],
     textAlign: TEXT_ALIGNMENTS[preferences.alignment],
     columnCount: preferences.columns === 'single' ? 1 : null,
     pageBackgroundColor: colors.background,

--- a/frontend/src/components/reader/readerPreferences.ts
+++ b/frontend/src/components/reader/readerPreferences.ts
@@ -59,7 +59,7 @@ const SPACINGS: Record<
 > = {
   tight: { lineHeight: 1.2, paragraphSpacing: null, paragraphIndent: null },
   default: { lineHeight: null, paragraphSpacing: null, paragraphIndent: null },
-  loose: { lineHeight: 1.8, paragraphSpacing: 1, paragraphIndent: 1.5 },
+  loose: { lineHeight: 1.8, paragraphSpacing: 1, paragraphIndent: 1 },
 };
 
 // `left` is `start`: in a right-to-left book the ragged edge belongs on the

--- a/frontend/src/components/reader/readerPreferences.ts
+++ b/frontend/src/components/reader/readerPreferences.ts
@@ -9,10 +9,10 @@ export const READER_PAGE_COLOR_LABELS: Record<ReaderPageColor, string> = {
   dark: 'Dark',
 };
 
-/** How far apart the lines are set, `default` leaving the book's own spacing alone. */
-export const READER_LINE_HEIGHTS = ['tight', 'default', 'loose'] as const;
-type ReaderLineHeight = (typeof READER_LINE_HEIGHTS)[number];
-export const READER_LINE_HEIGHT_LABELS: Record<ReaderLineHeight, string> = {
+/** How far apart the text is set, `default` leaving the book's own spacing alone. */
+export const READER_SPACINGS = ['tight', 'default', 'loose'] as const;
+type ReaderSpacing = (typeof READER_SPACINGS)[number];
+export const READER_SPACING_LABELS: Record<ReaderSpacing, string> = {
   tight: 'Tight',
   default: 'Default',
   loose: 'Loose',
@@ -38,7 +38,7 @@ export const READER_COLUMN_LABELS: Record<ReaderColumns, string> = {
 export interface ReaderPreferences {
   pageColor: ReaderPageColor;
   fontSize: number;
-  lineHeight: ReaderLineHeight;
+  spacing: ReaderSpacing;
   alignment: ReaderAlignment;
   columns: ReaderColumns;
 }
@@ -46,15 +46,20 @@ export interface ReaderPreferences {
 export const DEFAULT_READER_PREFERENCES: ReaderPreferences = {
   pageColor: 'light',
   fontSize: 1,
-  lineHeight: 'default',
+  spacing: 'default',
   alignment: 'default',
   columns: 'single',
 };
 
-const LINE_HEIGHTS: Record<ReaderLineHeight, EbookAppearance['lineHeight']> = {
-  tight: 1.2,
-  default: null,
-  loose: 1.8,
+// Tight leaves the paragraph breaks alone rather than closing them to 0: a book
+// that separates its paragraphs by spacing alone would run them together.
+const SPACINGS: Record<
+  ReaderSpacing,
+  Pick<EbookAppearance, 'lineHeight' | 'paragraphSpacing' | 'paragraphIndent'>
+> = {
+  tight: { lineHeight: 1.2, paragraphSpacing: null, paragraphIndent: null },
+  default: { lineHeight: null, paragraphSpacing: null, paragraphIndent: null },
+  loose: { lineHeight: 1.8, paragraphSpacing: 1, paragraphIndent: 1.5 },
 };
 
 // `left` is `start`: in a right-to-left book the ragged edge belongs on the
@@ -77,7 +82,7 @@ export const toEbookAppearance = (
   const colors = readerPageColors(theme, preferences.pageColor);
   return {
     fontSize: preferences.fontSize,
-    lineHeight: LINE_HEIGHTS[preferences.lineHeight],
+    ...SPACINGS[preferences.spacing],
     textAlign: TEXT_ALIGNMENTS[preferences.alignment],
     columnCount: preferences.columns === 'single' ? 1 : null,
     pageBackgroundColor: colors.background,

--- a/frontend/src/components/reader/useEbookReader.ts
+++ b/frontend/src/components/reader/useEbookReader.ts
@@ -84,6 +84,7 @@ export const useEbookReader = ({
   useEffect(() => {
     appearanceRef.current = appearance;
   }, [appearance]);
+  const appliedRef = useRef<EbookAppearance | null>(null);
 
   useEffect(() => {
     const element = host.current;
@@ -125,6 +126,7 @@ export const useEbookReader = ({
     const abortedFirst = new Promise<never>((_, reject) => {
       signal.addEventListener('abort', () => reject(signal.reason as Error), { once: true });
     });
+    appliedRef.current = appearanceRef.current;
     const opening = reader.open(manifestUrl, { appearance: appearanceRef.current, signal });
     Promise.race([opening, abortedFirst]).then(onOpened, onFailed);
 
@@ -158,6 +160,14 @@ export const useEbookReader = ({
   // Derived rather than stored, so that starting an attempt is not itself a
   // render: an effect that set the status would cascade one on every open.
   const status: EbookReaderStatus = enabled ? (outcome ?? 'opening') : 'idle';
+
+  // Guarded, because nothing in the engine's own chain compares anything: an
+  // appearance submitted again re-pushes CSS and reflows a book already right.
+  useEffect(() => {
+    if (status !== 'open' || appliedRef.current === appearance) return;
+    appliedRef.current = appearance;
+    void readerRef.current?.setAppearance(appearance);
+  }, [appearance, status]);
 
   return { status, pageCount, location, toc, currentTocHref, next, previous, goTo, retry };
 };

--- a/frontend/src/components/reader/useEbookReader.ts
+++ b/frontend/src/components/reader/useEbookReader.ts
@@ -40,6 +40,8 @@ export interface EbookReaderState {
   toc: EbookTocEntry[];
   /** The contents entry covering where the reader is, or null where none does. */
   currentTocHref: string | null;
+  /** Null until a book is on screen: only an engine with one can report it. */
+  fontSizeRange: [number, number] | null;
   next: () => void;
   previous: () => void;
   goTo: (location: EbookLocation) => void;
@@ -71,6 +73,7 @@ export const useEbookReader = ({
   const [location, setLocation] = useState<EbookLocation | null>(null);
   const [toc, setToc] = useState<EbookTocEntry[]>(NO_TOC);
   const [currentTocHref, setCurrentTocHref] = useState<string | null>(null);
+  const [fontSizeRange, setFontSizeRange] = useState<[number, number] | null>(null);
   const [attempt, setAttempt] = useState(0);
   const readerRef = useRef<EbookReader | null>(null);
   // Through a ref, so a hold that starts mid-book never rebuilds the reader.
@@ -113,6 +116,7 @@ export const useEbookReader = ({
       setLocation(opened.location);
       setToc(opened.toc);
       setCurrentTocHref(opened.tocHref);
+      setFontSizeRange(opened.fontSizeRange);
       setOutcome('open');
     };
     const onFailed = (error: unknown) => {
@@ -154,6 +158,7 @@ export const useEbookReader = ({
     setPageCount(0);
     setToc(NO_TOC);
     setCurrentTocHref(null);
+    setFontSizeRange(null);
     setAttempt((count) => count + 1);
   }, []);
 
@@ -169,5 +174,16 @@ export const useEbookReader = ({
     void readerRef.current?.setAppearance(appearance);
   }, [appearance, status]);
 
-  return { status, pageCount, location, toc, currentTocHref, next, previous, goTo, retry };
+  return {
+    status,
+    pageCount,
+    location,
+    toc,
+    currentTocHref,
+    fontSizeRange,
+    next,
+    previous,
+    goTo,
+    retry,
+  };
 };

--- a/frontend/src/components/reader/useEbookReader.ts
+++ b/frontend/src/components/reader/useEbookReader.ts
@@ -1,5 +1,6 @@
 import {
   PublicationUnavailableError,
+  type EbookAppearance,
   type EbookLocation,
   type EbookReader,
   type EbookTocEntry,
@@ -25,6 +26,8 @@ export interface UseEbookReaderOptions {
   /** True while a lapsed cookie is being replaced: a page fetched with a dead
    * credential comes back blank. */
   holdPageTurns: boolean;
+  /** How the page should look; the book opens on it. */
+  appearance: EbookAppearance;
   /** Must be referentially stable: an inline arrow rebuilds the reader every render. */
   createReader?: (host: HTMLElement) => EbookReader;
   bootTimeoutMs?: number;
@@ -59,6 +62,7 @@ export const useEbookReader = ({
   manifestUrl,
   enabled,
   holdPageTurns,
+  appearance,
   createReader = aReadiumReader,
   bootTimeoutMs = BOOT_TIMEOUT_MS,
 }: UseEbookReaderOptions): EbookReaderState => {
@@ -74,6 +78,12 @@ export const useEbookReader = ({
   useEffect(() => {
     holdRef.current = holdPageTurns;
   }, [holdPageTurns]);
+  // The same, so that changing the appearance never rebuilds the reader; a
+  // retry then opens on the current one rather than the one from mount.
+  const appearanceRef = useRef(appearance);
+  useEffect(() => {
+    appearanceRef.current = appearance;
+  }, [appearance]);
 
   useEffect(() => {
     const element = host.current;
@@ -115,7 +125,8 @@ export const useEbookReader = ({
     const abortedFirst = new Promise<never>((_, reject) => {
       signal.addEventListener('abort', () => reject(signal.reason as Error), { once: true });
     });
-    Promise.race([reader.open(manifestUrl, signal), abortedFirst]).then(onOpened, onFailed);
+    const opening = reader.open(manifestUrl, { appearance: appearanceRef.current, signal });
+    Promise.race([opening, abortedFirst]).then(onOpened, onFailed);
 
     return () => {
       cancel.abort();

--- a/frontend/src/components/reader/useReaderPreferences.ts
+++ b/frontend/src/components/reader/useReaderPreferences.ts
@@ -1,0 +1,24 @@
+import {
+  loadReaderPreferences,
+  saveReaderPreferences,
+} from '@/components/reader/readerPreferenceStorage.ts';
+import type { ReaderPreferences } from '@/components/reader/readerPreferences.ts';
+import { useEffect, useState, type Dispatch, type SetStateAction } from 'react';
+
+/** The reader's appearance, read during the first render and written down as it changes. */
+export const useReaderPreferences = (): [
+  ReaderPreferences,
+  Dispatch<SetStateAction<ReaderPreferences>>,
+] => {
+  // Lazily, so the navigator is built on the stored appearance rather than the
+  // book opening on the defaults and reflowing a tick later.
+  const [preferences, setPreferences] = useState(loadReaderPreferences);
+
+  // On every change rather than once a book is open: a reader who nudges the
+  // font size and closes the book has still expressed a preference.
+  useEffect(() => {
+    saveReaderPreferences(preferences);
+  }, [preferences]);
+
+  return [preferences, setPreferences];
+};

--- a/frontend/src/pages/ReaderPage/ReaderPage.test.tsx
+++ b/frontend/src/pages/ReaderPage/ReaderPage.test.tsx
@@ -452,6 +452,24 @@ test('an arrow key with the appearance open does not turn the page behind it', a
   await expect.element(screen.getByText('Page 1 of 2 · 0%')).toBeVisible();
 });
 
+test('a larger font size reaches the words on the page', async () => {
+  const screen = await aBookWithItsAppearanceOpen();
+
+  await screen.getByRole('button', { name: 'Larger text' }).click();
+
+  await expect.poll(() => userProperty('fontSize')).toBe('125%');
+});
+
+test('an arrow key typed into the font size does not turn the page', async () => {
+  const screen = await aBookWithItsAppearanceOpen();
+
+  await screen.getByRole('textbox', { name: 'Font size in percent' }).click();
+  await userEvent.keyboard('{ArrowRight}');
+
+  await new Promise((resolve) => setTimeout(resolve, 1_200));
+  await expect.element(screen.getByText('Page 1 of 2 · 0%')).toBeVisible();
+});
+
 test('pressing the setting already chosen leaves it chosen', async () => {
   const screen = await aBookWithItsAppearanceOpen();
   const justified = screen.getByRole('button', { name: 'Justified' });

--- a/frontend/src/pages/ReaderPage/ReaderPage.test.tsx
+++ b/frontend/src/pages/ReaderPage/ReaderPage.test.tsx
@@ -453,7 +453,7 @@ test('a looser spacing reaches the words on the page', async () => {
 
   await expect.poll(() => userProperty('lineHeight')).toBe('1.8');
   await expect.poll(() => userProperty('paraSpacing')).toBe('1rem');
-  await expect.poll(() => userProperty('paraIndent')).toBe('1.5rem');
+  await expect.poll(() => userProperty('paraIndent')).toBe('1rem');
 });
 
 test('a spacing set back to default gives the book its own again', async () => {

--- a/frontend/src/pages/ReaderPage/ReaderPage.test.tsx
+++ b/frontend/src/pages/ReaderPage/ReaderPage.test.tsx
@@ -1,4 +1,5 @@
 import type { WebPublicationManifest } from '@/api/generated/model';
+import { theme } from '@/theme/theme.ts';
 import { aBookDetails } from '@tests/fixtures/book';
 import { aManifest } from '@tests/fixtures/publication';
 import { renderApp } from '@tests/harness/renderApp';
@@ -364,4 +365,114 @@ test('an arrow key with the contents open does not turn the page behind them', a
   // two later, and an immediate assertion would pass while it was in flight.
   await new Promise((resolve) => setTimeout(resolve, 1_200));
   await expect.element(screen.getByText('Page 1 of 2 · 0%')).toBeVisible();
+});
+
+const openTheAppearance = async (screen: Screen) => {
+  await screen.getByRole('button', { name: 'Appearance' }).click();
+  await expect.element(screen.getByRole('heading', { name: 'Page colour' })).toBeVisible();
+  return screen.getByRole('dialog', { name: 'Appearance' });
+};
+
+const closeTheAppearance = async (screen: Screen) => {
+  await userEvent.keyboard('{Escape}');
+  await expect.element(screen.getByRole('dialog', { name: 'Appearance' })).not.toBeInTheDocument();
+};
+
+/** A book on screen at its first page, with the appearance popover open over it. */
+const aBookWithItsAppearanceOpen = async () => {
+  worker.use(...aReadableBook());
+  worker.use(...readiumApi());
+  const screen = await openTheBook();
+  await openTheAppearance(screen);
+  return screen;
+};
+
+/** The reader's own frame: the fixed overlay its chrome and the book sit in. */
+const readerFrame = (screen: Screen) => {
+  const button = screen.getByRole('button', { name: 'Close reader' }).element();
+  for (let node = button.parentElement; node; node = node.parentElement) {
+    if (getComputedStyle(node).position === 'fixed') return node;
+  }
+  throw new Error('The reader is not on screen.');
+};
+
+const asRgb = (hex: string, opacity?: number) => {
+  const channels = [1, 3, 5].map((at) => parseInt(hex.slice(at, at + 2), 16)).join(', ');
+  return opacity === undefined ? `rgb(${channels})` : `rgba(${channels}, ${opacity})`;
+};
+
+test('the dark page is painted into the book and into the chrome around it', async () => {
+  worker.use(...aReadableBook());
+  worker.use(...readiumApi());
+  const screen = await openTheBook();
+  // Both read before the popover covers them: a role query skips the modal's
+  // aria-hidden siblings.
+  const frame = readerFrame(screen);
+  const label = screen.getByText('Page 1 of 2 · 0%').element();
+  const { dark } = theme.customColors.readerPage;
+  await openTheAppearance(screen);
+
+  await screen.getByRole('button', { name: 'Dark' }).click();
+
+  await expect.poll(() => userProperty('backgroundColor')).toBe(dark.background);
+  await expect.poll(() => userProperty('textColor')).toBe(dark.text);
+  await expect.poll(() => getComputedStyle(frame).backgroundColor).toBe(asRgb(dark.background));
+  // The position label is drawn from the page rather than the theme: the
+  // theme's own secondary text is 3.7:1 here, under the 4.5:1 body-text floor.
+  expect(getComputedStyle(label).color).toBe(asRgb(dark.text, 0.7));
+});
+
+test('a justified alignment reaches the words on the page', async () => {
+  worker.use(...aReadableBook());
+  worker.use(...readiumApi());
+  const screen = await openTheBook();
+  // The default says nothing at all, which is what leaves the book in charge.
+  expect(userProperty('textAlign')).toBe('');
+  await openTheAppearance(screen);
+
+  await screen.getByRole('button', { name: 'Justified' }).click();
+
+  await expect.poll(() => userProperty('textAlign')).toBe('justify');
+});
+
+test('the automatic column count gives a wide page two columns', async () => {
+  const screen = await aBookWithItsAppearanceOpen();
+
+  await screen.getByRole('button', { name: 'Auto' }).click();
+
+  await expect.poll(() => userProperty('colCount')).toBe('2');
+});
+
+test('an arrow key with the appearance open does not turn the page behind it', async () => {
+  const screen = await aBookWithItsAppearanceOpen();
+
+  await userEvent.keyboard('{ArrowRight}');
+
+  await new Promise((resolve) => setTimeout(resolve, 1_200));
+  await expect.element(screen.getByText('Page 1 of 2 · 0%')).toBeVisible();
+});
+
+test('pressing the setting already chosen leaves it chosen', async () => {
+  const screen = await aBookWithItsAppearanceOpen();
+  const justified = screen.getByRole('button', { name: 'Justified' });
+  await justified.click();
+  await expect.poll(() => userProperty('textAlign')).toBe('justify');
+
+  await justified.click();
+
+  await expect.element(justified).toHaveAttribute('aria-pressed', 'true');
+  expect(userProperty('textAlign')).toBe('justify');
+});
+
+test('the appearance opens on what the reader has already chosen', async () => {
+  const screen = await aBookWithItsAppearanceOpen();
+  await screen.getByRole('button', { name: 'Justified' }).click();
+  await expect.poll(() => userProperty('textAlign')).toBe('justify');
+  await closeTheAppearance(screen);
+
+  const reopened = await openTheAppearance(screen);
+
+  await expect
+    .element(reopened.getByRole('button', { name: 'Justified' }))
+    .toHaveAttribute('aria-pressed', 'true');
 });

--- a/frontend/src/pages/ReaderPage/ReaderPage.test.tsx
+++ b/frontend/src/pages/ReaderPage/ReaderPage.test.tsx
@@ -387,9 +387,9 @@ const aBookWithItsAppearanceOpen = async () => {
   return screen;
 };
 
-/** One line-height option, scoped past the alignment section's own "Default". */
-const lineHeightOption = (screen: Screen, name: string) =>
-  screen.getByRole('group', { name: 'Line height' }).getByRole('button', { name });
+/** One spacing option, scoped past the alignment section's own "Default". */
+const spacingOption = (screen: Screen, name: string) =>
+  screen.getByRole('group', { name: 'Spacing' }).getByRole('button', { name });
 
 /** The reader's own frame: the fixed overlay its chrome and the book sit in. */
 const readerFrame = (screen: Screen) => {
@@ -439,27 +439,33 @@ test('a justified alignment reaches the words on the page', async () => {
   await expect.poll(() => userProperty('textAlign')).toBe('justify');
 });
 
-test('a line height the reader chooses reaches the words on the page', async () => {
+test('a looser spacing reaches the words on the page', async () => {
   worker.use(...aReadableBook());
   worker.use(...readiumApi());
   const screen = await openTheBook();
   // The default says nothing at all, which is what leaves the book's own spacing.
   expect(userProperty('lineHeight')).toBe('');
+  expect(userProperty('paraSpacing')).toBe('');
+  expect(userProperty('paraIndent')).toBe('');
   await openTheAppearance(screen);
 
-  await lineHeightOption(screen, 'Loose').click();
+  await spacingOption(screen, 'Loose').click();
 
   await expect.poll(() => userProperty('lineHeight')).toBe('1.8');
+  await expect.poll(() => userProperty('paraSpacing')).toBe('1rem');
+  await expect.poll(() => userProperty('paraIndent')).toBe('1.5rem');
 });
 
-test('a line height set back to default gives the book its own spacing again', async () => {
+test('a spacing set back to default gives the book its own again', async () => {
   const screen = await aBookWithItsAppearanceOpen();
-  await lineHeightOption(screen, 'Loose').click();
+  await spacingOption(screen, 'Loose').click();
   await expect.poll(() => userProperty('lineHeight')).toBe('1.8');
 
-  await lineHeightOption(screen, 'Default').click();
+  await spacingOption(screen, 'Default').click();
 
   await expect.poll(() => userProperty('lineHeight')).toBe('');
+  await expect.poll(() => userProperty('paraSpacing')).toBe('');
+  await expect.poll(() => userProperty('paraIndent')).toBe('');
 });
 
 test('the automatic column count gives a wide page two columns', async () => {

--- a/frontend/src/pages/ReaderPage/ReaderPage.test.tsx
+++ b/frontend/src/pages/ReaderPage/ReaderPage.test.tsx
@@ -387,6 +387,10 @@ const aBookWithItsAppearanceOpen = async () => {
   return screen;
 };
 
+/** One line-height option, scoped past the alignment section's own "Default". */
+const lineHeightOption = (screen: Screen, name: string) =>
+  screen.getByRole('group', { name: 'Line height' }).getByRole('button', { name });
+
 /** The reader's own frame: the fixed overlay its chrome and the book sit in. */
 const readerFrame = (screen: Screen) => {
   const button = screen.getByRole('button', { name: 'Close reader' }).element();
@@ -433,6 +437,29 @@ test('a justified alignment reaches the words on the page', async () => {
   await screen.getByRole('button', { name: 'Justified' }).click();
 
   await expect.poll(() => userProperty('textAlign')).toBe('justify');
+});
+
+test('a line height the reader chooses reaches the words on the page', async () => {
+  worker.use(...aReadableBook());
+  worker.use(...readiumApi());
+  const screen = await openTheBook();
+  // The default says nothing at all, which is what leaves the book's own spacing.
+  expect(userProperty('lineHeight')).toBe('');
+  await openTheAppearance(screen);
+
+  await lineHeightOption(screen, 'Loose').click();
+
+  await expect.poll(() => userProperty('lineHeight')).toBe('1.8');
+});
+
+test('a line height set back to default gives the book its own spacing again', async () => {
+  const screen = await aBookWithItsAppearanceOpen();
+  await lineHeightOption(screen, 'Loose').click();
+  await expect.poll(() => userProperty('lineHeight')).toBe('1.8');
+
+  await lineHeightOption(screen, 'Default').click();
+
+  await expect.poll(() => userProperty('lineHeight')).toBe('');
 });
 
 test('the automatic column count gives a wide page two columns', async () => {

--- a/frontend/src/pages/ReaderPage/ReaderPage.test.tsx
+++ b/frontend/src/pages/ReaderPage/ReaderPage.test.tsx
@@ -1,4 +1,5 @@
 import type { WebPublicationManifest } from '@/api/generated/model';
+import { READER_PREFERENCES_KEY } from '@/components/reader/readerPreferenceStorage.ts';
 import { theme } from '@/theme/theme.ts';
 import { aBookDetails } from '@tests/fixtures/book';
 import { aManifest } from '@tests/fixtures/publication';
@@ -515,15 +516,64 @@ test('pressing the setting already chosen leaves it chosen', async () => {
   expect(userProperty('textAlign')).toBe('justify');
 });
 
-test('the appearance opens on what the reader has already chosen', async () => {
+/** The book on screen, justified by the reader, with the popover dismissed again. */
+const aJustifiedBook = async () => {
   const screen = await aBookWithItsAppearanceOpen();
   await screen.getByRole('button', { name: 'Justified' }).click();
   await expect.poll(() => userProperty('textAlign')).toBe('justify');
   await closeTheAppearance(screen);
+  return screen;
+};
+
+test('the appearance opens on what the reader has already chosen', async () => {
+  const screen = await aJustifiedBook();
 
   const reopened = await openTheAppearance(screen);
 
   await expect
     .element(reopened.getByRole('button', { name: 'Justified' }))
     .toHaveAttribute('aria-pressed', 'true');
+});
+
+test('an appearance the reader set is still set when the book is opened again', async () => {
+  const screen = await aJustifiedBook();
+  await screen.getByRole('button', { name: 'Close reader' }).click();
+  await expect.element(screen.getByRole('heading', { name: 'Ada Lovelace' })).toBeVisible();
+
+  await screen.getByRole('link', { name: 'Read', exact: true }).click();
+
+  await expectTheReaderOpen(screen);
+  await expect.poll(() => userProperty('textAlign'), { timeout: 5_000 }).toBe('justify');
+});
+
+/** The book on screen, opened after this record was left in the browser's storage. */
+const aBookOpenedAfterStoring = async (record: string) => {
+  window.localStorage.setItem(READER_PREFERENCES_KEY, record);
+  worker.use(...aReadableBook());
+  worker.use(...readiumApi());
+  await openTheBook();
+};
+
+test('an appearance stored as nonsense opens the book on the defaults', async () => {
+  await aBookOpenedAfterStoring('{not json at all');
+
+  await expect.poll(() => userProperty('backgroundColor')).toBe(theme.palette.background.default);
+  expect(userProperty('textAlign')).toBe('');
+  expect(userProperty('colCount')).toBe('1');
+});
+
+test('an appearance of values we do not offer opens the book on the defaults', async () => {
+  await aBookOpenedAfterStoring(
+    JSON.stringify({
+      version: 1,
+      pageColor: 'chartreuse',
+      fontSize: 1,
+      spacing: 'enormous',
+      alignment: 'sideways',
+      columns: 'three',
+    })
+  );
+
+  await expect.poll(() => userProperty('backgroundColor')).toBe(theme.palette.background.default);
+  expect(userProperty('colCount')).toBe('1');
 });

--- a/frontend/src/pages/ReaderPage/ReaderPage.test.tsx
+++ b/frontend/src/pages/ReaderPage/ReaderPage.test.tsx
@@ -111,6 +111,22 @@ test('the book opens at its first page', async () => {
   await expect.element(screen.getByRole('button', { name: 'Next page' })).toBeEnabled();
 });
 
+/** What ReadiumCSS has written into the chapter on screen, of its user settings. */
+const userProperty = (name: string) => {
+  const frames = [...document.querySelectorAll<HTMLIFrameElement>('iframe')];
+  const shown = frames.find((frame) => frame.getBoundingClientRect().width > 0);
+  return shown?.contentDocument?.documentElement.style.getPropertyValue(`--USER__${name}`) ?? '';
+};
+
+test('a book opens in one column on a wide screen', async () => {
+  worker.use(...aReadableBook());
+  worker.use(...readiumApi());
+
+  await openTheBook();
+
+  await expect.poll(() => userProperty('colCount')).toBe('1');
+});
+
 test('the next button turns the page and the label follows', async () => {
   worker.use(...aReadableBook());
   worker.use(...readiumApi());

--- a/frontend/src/theme/Icons.tsx
+++ b/frontend/src/theme/Icons.tsx
@@ -54,6 +54,7 @@ export {
   ArrowDropDown as DropdownIcon,
   Edit as EditIcon,
   PlaylistAdd as EditTagsIcon,
+  TextIncrease as LargerTextIcon,
   Link as LinkIcon,
   LinkOff as LinkOffIcon,
   NoteAdd as NoteAddIcon,
@@ -62,6 +63,7 @@ export {
   Replay as RetryIcon,
   Check as SelectedIcon,
   Send as SendIcon,
+  TextDecrease as SmallerTextIcon,
   SwapVert as SortIcon,
 } from '@mui/icons-material';
 

--- a/frontend/src/theme/theme.ts
+++ b/frontend/src/theme/theme.ts
@@ -79,6 +79,13 @@ const customColors = {
     empty: colors.stone[100], // A day with no reading
     full: colors.amber[700], // The book's heaviest reading days, as primary.main
   },
+
+  // The only colours in the app that leave it: the reader hands them to the
+  // book's own stylesheet, which paints them inside the book's frame.
+  readerPage: {
+    light: { background: colors.stone[50], text: colors.stone[900] },
+    dark: { background: colors.stone[900], text: colors.stone[100] },
+  },
 };
 
 const COARSE_POINTER_QUERY = '@media (pointer: coarse)';

--- a/frontend/tests/fakes/FakeEbookReader.ts
+++ b/frontend/tests/fakes/FakeEbookReader.ts
@@ -43,7 +43,16 @@ export class FakeEbookReader implements EbookReader {
   }
 
   resolveOpen(opened: Partial<OpenedEbook> = {}): void {
-    this.settle?.({ pageCount: 2, toc: [], tocHref: null, location: aFakeLocation(1), ...opened });
+    this.settle?.({
+      pageCount: 2,
+      toc: [],
+      tocHref: null,
+      location: aFakeLocation(1),
+      // Deliberately not the engine's own [0.7, 4], so a test about the
+      // stepper's limits proves the range crossed the seam.
+      fontSizeRange: [0.6, 2],
+      ...opened,
+    });
   }
 
   requestPageTurn(direction: PageTurnDirection): void {

--- a/frontend/tests/fakes/FakeEbookReader.ts
+++ b/frontend/tests/fakes/FakeEbookReader.ts
@@ -17,6 +17,7 @@ export const aFakeLocation = (position: number): EbookLocation => ({
 /** An `EbookReader` whose open the test settles and whose events the test fires. */
 export class FakeEbookReader implements EbookReader {
   readonly openedWith: { manifestUrl: string; appearance: EbookAppearance }[] = [];
+  readonly appearances: EbookAppearance[] = [];
   readonly goToCalls: EbookLocation[] = [];
   nextCalls = 0;
   previousCalls = 0;
@@ -53,7 +54,8 @@ export class FakeEbookReader implements EbookReader {
     for (const listener of [...this.tocEntryListeners]) listener(href);
   }
 
-  setAppearance(): Promise<void> {
+  setAppearance(appearance: EbookAppearance): Promise<void> {
+    this.appearances.push(appearance);
     return Promise.resolve();
   }
 

--- a/frontend/tests/fakes/FakeEbookReader.ts
+++ b/frontend/tests/fakes/FakeEbookReader.ts
@@ -1,6 +1,8 @@
 import type {
+  EbookAppearance,
   EbookLocation,
   EbookReader,
+  OpenEbookOptions,
   OpenedEbook,
   PageTurnDirection,
 } from '@/components/reader/EbookReader.ts';
@@ -14,7 +16,7 @@ export const aFakeLocation = (position: number): EbookLocation => ({
 
 /** An `EbookReader` whose open the test settles and whose events the test fires. */
 export class FakeEbookReader implements EbookReader {
-  readonly openedWith: string[] = [];
+  readonly openedWith: { manifestUrl: string; appearance: EbookAppearance }[] = [];
   readonly goToCalls: EbookLocation[] = [];
   nextCalls = 0;
   previousCalls = 0;
@@ -26,11 +28,11 @@ export class FakeEbookReader implements EbookReader {
   private settle: ((opened: OpenedEbook) => void) | undefined;
   private isOpened = false;
 
-  async open(manifestUrl: string, signal?: AbortSignal): Promise<OpenedEbook> {
+  async open(manifestUrl: string, { appearance, signal }: OpenEbookOptions): Promise<OpenedEbook> {
     signal?.throwIfAborted();
     if (this.isOpened) throw new Error('A reader opens one book; build another one.');
     this.isOpened = true;
-    this.openedWith.push(manifestUrl);
+    this.openedWith.push({ manifestUrl, appearance });
     return await new Promise<OpenedEbook>((resolve, reject) => {
       this.settle = resolve;
       // The interface's contract, and the only way a boot watchdog can reach an
@@ -49,6 +51,10 @@ export class FakeEbookReader implements EbookReader {
 
   reportTocEntry(href: string | null): void {
     for (const listener of [...this.tocEntryListeners]) listener(href);
+  }
+
+  setAppearance(): Promise<void> {
+    return Promise.resolve();
   }
 
   next(): Promise<void> {

--- a/frontend/tests/setup.ts
+++ b/frontend/tests/setup.ts
@@ -61,6 +61,10 @@ async function waitForIdle(
 afterEach(async () => {
   cleanup();
 
+  // An appearance one test writes down would otherwise be what every test
+  // after it opens a book on, and the failure would look like anything but this.
+  window.localStorage.clear();
+
   // Unmounting stops any query's own refetch scheduling, but a request already
   // dispatched before unmount can still be in flight for a moment after. Give
   // every client this test created a bounded chance to finish before the


### PR DESCRIPTION
Closes #825. Part of #823 (R3 — Reader UI, second pass), after #822.

The reader gets an **Appearance** button in the header, opening a popover with
five settings that reach the book as they are chosen and are remembered the next
time a book is opened.

| Setting | Offers |
|---|---|
| Font size | − / + in quarters, plus a field for anything in between |
| Spacing | Tight · Default · Loose |
| Page colour | Light · Dark |
| Text alignment | Default · Left · Justified |
| Columns | 1 column · Auto |

Every book now opens in **one column** — including on a desktop viewport wide
enough for two — and on the app's own off-white page rather than publisher white.
The chrome follows the page colour, so the header is not the brightest thing
above a dark page.

## Read it commit by commit

Each one ends green and carries its reasoning in its message.

| | |
|---|---|
| `36f3c9e5` | The appearance crosses the `EbookReader` seam; books open on our defaults |
| `352f07a1` | The popover: page colour, alignment, columns |
| `2560a48b` | Font size: a stepper in quarters, and a field for the rest |
| `1f3e1a4c` | Line height: tight, the book's own, or loose |
| `805cbd80` | Loose opens up the paragraphs, not just the lines |
| `8d0b01b7` | Follows a tweaked indent in the test that pins it |
| `cd51648e` | The appearance is remembered between books |

## Decisions that differ from the ticket

- **A stepper with a field, not a slider.** The slider was hard to use in the
  spike. At the engine's own step of 0.05, doubling the text took 20 presses; at
  a quarter it takes 4, and the field reaches everything in between. The buttons
  step to the next quarter *above or below* the current size rather than adding
  one, because the engine's floor of 0.7 is not a whole number of quarters and
  adding would put 100% permanently out of reach.
- **No sepia**, and the light page is the app's own `stone[50]` rather than white.
- **Columns are a two-state choice defaulting to one column**, not a switch
  defaulting to off — so the ticket's `columnCount()` seam query and its rule for
  hiding the control are deliberately absent. Under a default-on single column
  that rule would only ever fire after a reader turned it off on a narrow screen,
  where its one effect is to trap them without the control.
- **Spacing, not line height.** A fifth setting beyond the ticket's four, added
  after reading on a real book: Loose sets a line height, a paragraph gap and a
  first-line indent together, so paragraphs stand out in books that separate them
  by a small indent alone. Tight is deliberately asymmetric — it squeezes the
  lines and leaves the paragraph breaks alone, because closing the gap to zero
  would run paragraphs together in any book that separates them by spacing.
- **Storage holds our shape, not `EpubPreferences.serialize`.** The ticket wanted
  Readium to validate the record on the way back in; under this shape that would
  validate one setting of five. Readium has never heard of `tight` or `auto`, and
  `spacing` maps to a triple of engine values that nothing could turn back into an
  option name without guessing. The record is checked field by field against the
  arrays that define those options, which are exhaustive by construction; one
  unreadable field costs only itself. Font size is the one genuinely-Readium
  value, and it is the one clamped to the range the library itself publishes.

## Two things that are load-bearing rather than cosmetic

**`role="dialog"` on the popover's paper is a page-turn defence.** Readium
registers its arrow keys with `suppressOnInteractiveElement`, and its check counts
an element as interactive only by role, tag name or a non-negative `tabIndex`.
MUI's `Popover` sets no role, and the paper that holds focus is a `div` with
`tabIndex: -1` — so without the role, an arrow key reaches the book and turns the
page under the open popover. `Drawer` sets it itself, which is why R3.1's contents
drawer was already safe.

**The appearance goes to the navigator's constructor, and changes are guarded by
identity.** Nothing in `submitPreferences` → `applyPreferences` → `updateCSS` →
`commitCSS` compares anything: submitting an appearance the book already shows
re-pushes ReadiumCSS into every frame and reflows a book that opened correctly.

## Accessibility

The position label, the header divider and the loading state are drawn from the
page's own colours rather than the theme: the theme's secondary text is 3.65:1 on
the dark page, under the 4.5:1 floor for body text. It is now 6.32:1 on the light
page and 8.35:1 on the dark, both measured. The popover is fully operable by
keyboard and returns focus to its trigger on Escape.

## Gates

`tsc`, eslint, prettier, `knip` clean. **296/296** browser tests across Chromium.
`duplication-check` at 0.8% against a 1.05 threshold, unchanged. `ReaderShell.tsx`
is 293 lines, under the epic's ~300 cap — the `ReaderMessage` extraction three
commits predicted would be needed turned out not to be.

Every commit's behaviour was mutation-checked: each rule broken in the smallest
way that should fail a test, with the survivors reported rather than hidden. Two
survive deliberately and are named in their commit messages — a font-size range
hard-coded to today's numbers (the consequence is covered instead, via the
library's own exported range), and an eagerly-evaluated storage read that is
correct but wasteful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DZ2vdUGgLAsfUzU1S46PVU