### PR TITLE
R3.3 The page-turn buttons stand aside on a phone (#826)

### DIFF
--- a/frontend/src/components/reader/ReaderShell.test.tsx
+++ b/frontend/src/components/reader/ReaderShell.test.tsx
@@ -8,13 +8,19 @@ import { FakeEbookReader, aFakeLocation } from '@tests/fakes/FakeEbookReader';
 import { readiumApi } from '@tests/msw/readiumApi';
 import { worker } from '@tests/msw/worker';
 import { HttpResponse, delay, http } from 'msw';
-import { beforeEach, expect, test } from 'vitest';
+import { afterEach, beforeEach, expect, test } from 'vitest';
 import { render } from 'vitest-browser-react';
-import { userEvent } from 'vitest/browser';
+import { page, userEvent } from 'vitest/browser';
 
 const SESSION_PATH = '/api/v1/readium/books/:bookId/session';
 const RESOURCE_PATH = '/api/v1/readium/books/:bookId/resources/*';
 const MANIFEST_URL = `${window.location.origin}/api/v1/readium/books/1/manifest.json`;
+
+/** Narrower than the `sm` breakpoint the reader lays itself out against. */
+const PHONE_VIEWPORT = { width: 390, height: 780 };
+
+/** `vitest.config.ts`'s own viewport, restored after a test has narrowed it. */
+const DEFAULT_VIEWPORT = { width: 1440, height: 900 };
 
 const readers: FakeEbookReader[] = [];
 
@@ -26,6 +32,10 @@ const createReader = () => {
 
 beforeEach(() => {
   readers.length = 0;
+});
+
+afterEach(async () => {
+  await page.viewport(DEFAULT_VIEWPORT.width, DEFAULT_VIEWPORT.height);
 });
 
 const aSlowSession = (ms: number) =>
@@ -474,4 +484,30 @@ test('closing the shell destroys the reader', async () => {
   screen.unmount();
 
   await expect.poll(() => readers[0].destroyed).toBe(true);
+});
+
+/**
+ * On a phone the two arrow gutters were most of the screen and the book was a
+ * strip down the middle, while the buttons themselves sat over the page they
+ * turn. Swiping is the gesture at hand there — Readium's own column snapper
+ * handles it inside the publication's frame — so the buttons go and the page
+ * takes the width back. The chrome above the page, which fits either way,
+ * stays exactly as it was.
+ */
+test('the page-turn buttons stand aside on a phone and come back on a wider screen', async () => {
+  worker.use(...readiumApi());
+  const screen = await anOpenBook();
+
+  await page.viewport(PHONE_VIEWPORT.width, PHONE_VIEWPORT.height);
+
+  // Out of the accessibility tree, not merely out of sight: a `display: none`
+  // button is one no pointer, screen reader or tab stop can reach.
+  await expect.poll(() => screen.getByRole('button', { name: 'Next page' }).query()).toBeNull();
+  expect(screen.getByRole('button', { name: 'Previous page' }).query()).toBeNull();
+  await expect.element(screen.getByRole('button', { name: 'Contents' })).toBeVisible();
+
+  await page.viewport(DEFAULT_VIEWPORT.width, DEFAULT_VIEWPORT.height);
+
+  await expect.element(screen.getByRole('button', { name: 'Next page' })).toBeVisible();
+  await expect.element(screen.getByRole('button', { name: 'Previous page' })).toBeVisible();
 });

--- a/frontend/src/components/reader/ReaderShell.tsx
+++ b/frontend/src/components/reader/ReaderShell.tsx
@@ -74,7 +74,16 @@ const PageTurnButton = ({ edge, onClick, disabled }: PageTurnButtonProps) => (
     disabled={disabled}
     color="inherit"
     aria-label={edge === 'left' ? 'Previous page' : 'Next page'}
-    sx={{ position: 'absolute', top: '50%', transform: 'translateY(-50%)', [edge]: 4, zIndex: 1 }}
+    sx={{
+      position: 'absolute',
+      top: '50%',
+      transform: 'translateY(-50%)',
+      [edge]: 4,
+      zIndex: 1,
+      // Gone on a phone, where they cover the page they turn and swiping is
+      // the gesture at hand; the gutter they need goes with them.
+      display: { xs: 'none', sm: 'inline-flex' },
+    }}
   >
     {edge === 'left' ? (
       <PreviousPageIcon sx={{ fontSize: ICON_SIZE.prominent }} />


### PR DESCRIPTION
Closes #826.

## What changed

The two arrow buttons sat over the page they turn, and the 48 px gutters they needed took most of a 390 px screen, leaving the book a strip down the middle. Below `sm` they go, and the gutter goes with them — that half was already written as `px: { xs: 0, sm: PAGE_TURN_GUTTER }`.

Two files, 48 lines.

## Why there are no tap zones

The ticket was written around tap zones ported from the spike: a gesture recogniser in the engine, a new `setTapZones` seam member, and an enabled flag mirrored across the breakpoint so a rotation mid-gesture neither invents a page turn nor swallows one.

None of that is needed, because swiping already works. Readium's `ColumnSnapper` binds touch handlers inside the publication's own frame — it drags the columns and snaps (`ColumnSnapper.ts:250-302`) — and at a chapter boundary sends `no_more`/`no_less`, which `EpubNavigator` turns into `changeResource` (`EpubNavigator.ts:585-590`). Swiping is the gesture on a phone, so the engine needs no new gesture code at all.

## Decisions worth a reviewer's eye

- **`sx` display, not `useMediaQuery`.** The gutter beside it is already expressed by breakpoint, so both halves of the rule now read alike, and nothing else in the shell needs the boolean — no JS media listener, no re-render on rotation. Precedent: `AppBar.tsx:65,126`, `BackToLibraryLink.tsx:22`.
- **The test asserts the buttons leave the accessibility tree**, not that they are invisible. `display: none` takes an element out of the tree, so `getByRole` finds nothing — `.query()` returning null is the true statement and the stronger one: no pointer, screen reader or tab stop can reach the button.
- **One test resizing across the breakpoint**, which proves the rule is responsive rather than decided at mount. Two fixed-viewport tests would not.

## Checked, not assumed

A swipe crossing a chapter boundary runs inside the navigator and never reaches `pageTurnRequested`, so the hook's hold-while-renewing gate does not apply to it. That looked like a hole a phone would now depend on, so I measured it: during a renewal the shell's "Reconnecting…" overlay spans the whole reading area (`0,49 → 390,780` at a 390 px viewport) with `pointerEvents: 'auto'`, and `elementFromPoint` at the centre of the page returns the overlay. A swipe cannot reach the frame while the cookie is being replaced. No gap, nothing to file.

## Verification

- `npx vitest run`: 33 files, 297 tests, all pass.
- Mutation check: replacing `display: { xs: 'none', sm: 'inline-flex' }` with a plain `display: 'inline-flex'` fails the new test.
- `tsc --noEmit`, `eslint`, `prettier --check`: clean.
- `npm run duplication-check`: 0.8 %, threshold 1.05, unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DZ2vdUGgLAsfUzU1S46PVU